### PR TITLE
Add GitHub issue templates and disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Report a bug with reproduction steps and environment details
+labels: bug
+---
+
+## Description
+
+<!-- Provide a clear and concise description of the bug. -->
+
+## Steps to reproduce
+
+1. 
+2. 
+3. 
+
+## Expected behavior
+
+<!-- What did you expect to happen? -->
+
+## Actual behavior
+
+<!-- What actually happened? -->
+
+## Environment
+
+- OS: 
+- Browser / client: 
+- Version: 
+- Any relevant configuration: 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,3 @@
+blank_issues_enabled: false
+
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+labels: enhancement
+---
+
+## Problem statement
+
+<!-- Describe the problem you are trying to solve. -->
+
+## Proposed solution
+
+<!-- Describe the solution you propose. -->
+
+## Alternatives considered
+
+<!-- List alternative options you considered. -->


### PR DESCRIPTION
Created issue templates in ISSUE_TEMPLATE:
bug_report.md with:
Description
Steps to reproduce
Expected behavior
Actual behavior
Environment
feature_request.md with:
Problem statement
Proposed solution
Alternatives consired
Created config.yml to disable blank issue creation:
blank_issues_enabled: false
Committed and pushed changes to the repository (main branch).

closes #45 