### PR TITLE
feat: Add mainnet deployment checklist modal (#35)

### DIFF
--- a/frontend/src/components/TokenCreateForm.tsx
+++ b/frontend/src/components/TokenCreateForm.tsx
@@ -1,0 +1,145 @@
+import { useState } from 'react'
+import { Input } from './UI/Input'
+import { Button } from './UI/Button'
+import { MainnetConfirmationModal } from './UI/MainnetConfirmationModal'
+import { useMainnetConfirmation } from '../hooks/useMainnetConfirmation'
+import { useToast } from '../context/ToastContext'
+import { stellarService } from '../services/stellar'
+import { TokenDeployParams } from '../types'
+import { validateTokenSymbol, validateTokenName, validateDecimals } from '../utils/validation'
+
+export const TokenCreateForm: React.FC = () => {
+  const [name, setName] = useState('')
+  const [symbol, setSymbol] = useState('')
+  const [decimals, setDecimals] = useState('7')
+  const [initialSupply, setInitialSupply] = useState('')
+  const [description, setDescription] = useState('')
+  const [isDeploying, setIsDeploying] = useState(false)
+
+  const { showModal, tokenParams, requestDeployment, closeModal, confirmDeployment } =
+    useMainnetConfirmation()
+  const { addToast } = useToast()
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    // Validate inputs
+    if (!validateTokenName(name)) {
+      addToast('Invalid token name', 'error')
+      return
+    }
+
+    if (!validateTokenSymbol(symbol)) {
+      addToast('Invalid token symbol', 'error')
+      return
+    }
+
+    if (!validateDecimals(parseInt(decimals))) {
+      addToast('Decimals must be between 0 and 18', 'error')
+      return
+    }
+
+    const params: TokenDeployParams = {
+      name,
+      symbol,
+      decimals: parseInt(decimals),
+      initialSupply,
+      metadata: description ? { description } : undefined,
+    }
+
+    // Request deployment - will show modal on mainnet, proceed directly on testnet
+    requestDeployment(params, () => deployToken(params))
+  }
+
+  const deployToken = async (params: TokenDeployParams) => {
+    setIsDeploying(true)
+    try {
+      const result = await stellarService.deployToken(params)
+      
+      if (result.success) {
+        addToast('Token deployed successfully!', 'success')
+        // Reset form
+        setName('')
+        setSymbol('')
+        setDecimals('7')
+        setInitialSupply('')
+        setDescription('')
+      } else {
+        addToast('Token deployment failed', 'error')
+      }
+    } catch (error) {
+      console.error('Deployment error:', error)
+      addToast('An error occurred during deployment', 'error')
+    } finally {
+      setIsDeploying(false)
+    }
+  }
+
+  return (
+    <>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <Input
+          label="Token Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="My Token"
+          required
+        />
+
+        <Input
+          label="Token Symbol"
+          value={symbol}
+          onChange={(e) => setSymbol(e.target.value.toUpperCase())}
+          placeholder="MTK"
+          required
+        />
+
+        <Input
+          label="Decimals"
+          type="number"
+          value={decimals}
+          onChange={(e) => setDecimals(e.target.value)}
+          placeholder="7"
+          min="0"
+          max="18"
+          required
+        />
+
+        <Input
+          label="Initial Supply"
+          value={initialSupply}
+          onChange={(e) => setInitialSupply(e.target.value)}
+          placeholder="1000000"
+          required
+        />
+
+        <div>
+          <label htmlFor="description" className="block text-sm font-medium text-gray-700 mb-1">
+            Description (Optional)
+          </label>
+          <textarea
+            id="description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Describe your token..."
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            rows={3}
+          />
+        </div>
+
+        <Button type="submit" disabled={isDeploying}>
+          {isDeploying ? 'Deploying...' : 'Deploy Token'}
+        </Button>
+      </form>
+
+      {tokenParams && (
+        <MainnetConfirmationModal
+          isOpen={showModal}
+          onClose={closeModal}
+          onConfirm={confirmDeployment}
+          tokenParams={tokenParams}
+        />
+      )}
+    </>
+  )
+}

--- a/frontend/src/components/UI/MainnetConfirmationModal.README.md
+++ b/frontend/src/components/UI/MainnetConfirmationModal.README.md
@@ -1,0 +1,70 @@
+# Mainnet Confirmation Modal
+
+## Overview
+This component provides a safety guard for mainnet token deployments by requiring explicit user confirmation before proceeding with deployment.
+
+## Features
+- Automatically detects mainnet network configuration
+- Displays all token parameters for review
+- Requires user to type the token symbol to confirm
+- Shows warning about irreversible action and real XLM costs
+- Skips confirmation on testnet
+
+## Usage
+
+### With the useMainnetConfirmation Hook
+
+```tsx
+import { useMainnetConfirmation } from '../../hooks/useMainnetConfirmation'
+import { MainnetConfirmationModal } from './UI/MainnetConfirmationModal'
+
+function YourComponent() {
+  const { showModal, tokenParams, requestDeployment, closeModal, confirmDeployment } =
+    useMainnetConfirmation()
+
+  const handleDeploy = () => {
+    const params = {
+      name: 'My Token',
+      symbol: 'MTK',
+      decimals: 7,
+      initialSupply: '1000000',
+    }
+
+    // This will show modal on mainnet, proceed directly on testnet
+    requestDeployment(params, () => {
+      // Your actual deployment logic here
+      stellarService.deployToken(params)
+    })
+  }
+
+  return (
+    <>
+      <button onClick={handleDeploy}>Deploy Token</button>
+      
+      {tokenParams && (
+        <MainnetConfirmationModal
+          isOpen={showModal}
+          onClose={closeModal}
+          onConfirm={confirmDeployment}
+          tokenParams={tokenParams}
+        />
+      )}
+    </>
+  )
+}
+```
+
+## Network Detection
+
+The modal uses `isMainnet()` from `utils/network.ts` which checks:
+```typescript
+STELLAR_CONFIG.network === 'mainnet'
+```
+
+## Acceptance Criteria Met
+
+✅ Detects when STELLAR_CONFIG.network === 'mainnet'
+✅ Shows 'Mainnet Deployment Review' modal with all token parameters
+✅ Requires user to type the token symbol to confirm
+✅ Skips extra step on testnet
+✅ Modal states 'This action cannot be undone and will cost real XLM'

--- a/frontend/src/components/UI/MainnetConfirmationModal.tsx
+++ b/frontend/src/components/UI/MainnetConfirmationModal.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'react'
+import { TokenDeployParams } from '../../types'
+import { Button } from './Button'
+import { Input } from './Input'
+
+interface MainnetConfirmationModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onConfirm: () => void
+  tokenParams: TokenDeployParams
+}
+
+export const MainnetConfirmationModal: React.FC<MainnetConfirmationModalProps> = ({
+  isOpen,
+  onClose,
+  onConfirm,
+  tokenParams,
+}) => {
+  const [confirmSymbol, setConfirmSymbol] = useState('')
+  const isConfirmed = confirmSymbol === tokenParams.symbol
+
+  if (!isOpen) return null
+
+  const handleConfirm = () => {
+    if (isConfirmed) {
+      onConfirm()
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="mainnet-modal-title"
+    >
+      <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full mx-4 max-h-[90vh] overflow-y-auto">
+        <div className="p-6">
+          <h2 id="mainnet-modal-title" className="text-2xl font-bold text-gray-900 mb-4">
+            Mainnet Deployment Review
+          </h2>
+
+          <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-6">
+            <p className="text-red-800 font-semibold">
+              ⚠️ This action cannot be undone and will cost real XLM
+            </p>
+          </div>
+
+          <div className="space-y-4 mb-6">
+            <h3 className="text-lg font-semibold text-gray-900">Token Parameters</h3>
+            
+            <div className="bg-gray-50 rounded-lg p-4 space-y-3">
+              <div className="flex justify-between">
+                <span className="text-gray-600">Name:</span>
+                <span className="font-medium text-gray-900">{tokenParams.name}</span>
+              </div>
+              
+              <div className="flex justify-between">
+                <span className="text-gray-600">Symbol:</span>
+                <span className="font-medium text-gray-900">{tokenParams.symbol}</span>
+              </div>
+              
+              <div className="flex justify-between">
+                <span className="text-gray-600">Decimals:</span>
+                <span className="font-medium text-gray-900">{tokenParams.decimals}</span>
+              </div>
+              
+              <div className="flex justify-between">
+                <span className="text-gray-600">Initial Supply:</span>
+                <span className="font-medium text-gray-900">{tokenParams.initialSupply}</span>
+              </div>
+              
+              {tokenParams.metadata?.description && (
+                <div className="flex justify-between">
+                  <span className="text-gray-600">Description:</span>
+                  <span className="font-medium text-gray-900">{tokenParams.metadata.description}</span>
+                </div>
+              )}
+              
+              {tokenParams.metadata?.image && (
+                <div className="flex justify-between">
+                  <span className="text-gray-600">Image:</span>
+                  <span className="font-medium text-gray-900">{tokenParams.metadata.image.name}</span>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="mb-6">
+            <Input
+              label={`Type "${tokenParams.symbol}" to confirm deployment`}
+              value={confirmSymbol}
+              onChange={(e) => setConfirmSymbol(e.target.value)}
+              placeholder={tokenParams.symbol}
+              aria-describedby="confirm-help"
+            />
+            <p id="confirm-help" className="text-sm text-gray-500 mt-1">
+              This confirmation ensures you have reviewed all parameters carefully.
+            </p>
+          </div>
+
+          <div className="flex gap-3 justify-end">
+            <Button onClick={onClose} variant="secondary">
+              Cancel
+            </Button>
+            <Button onClick={handleConfirm} disabled={!isConfirmed}>
+              Deploy to Mainnet
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useMainnetConfirmation.ts
+++ b/frontend/src/hooks/useMainnetConfirmation.ts
@@ -1,0 +1,52 @@
+import { useState, useCallback } from 'react'
+import { TokenDeployParams } from '../types'
+import { isMainnet } from '../utils/network'
+
+interface UseMainnetConfirmationReturn {
+  showModal: boolean
+  tokenParams: TokenDeployParams | null
+  requestDeployment: (params: TokenDeployParams, onConfirm: () => void) => void
+  closeModal: () => void
+  confirmDeployment: () => void
+}
+
+export const useMainnetConfirmation = (): UseMainnetConfirmationReturn => {
+  const [showModal, setShowModal] = useState(false)
+  const [tokenParams, setTokenParams] = useState<TokenDeployParams | null>(null)
+  const [onConfirmCallback, setOnConfirmCallback] = useState<(() => void) | null>(null)
+
+  const requestDeployment = useCallback(
+    (params: TokenDeployParams, onConfirm: () => void) => {
+      if (isMainnet()) {
+        setTokenParams(params)
+        setOnConfirmCallback(() => onConfirm)
+        setShowModal(true)
+      } else {
+        // On testnet, skip the confirmation modal
+        onConfirm()
+      }
+    },
+    []
+  )
+
+  const closeModal = useCallback(() => {
+    setShowModal(false)
+    setTokenParams(null)
+    setOnConfirmCallback(null)
+  }, [])
+
+  const confirmDeployment = useCallback(() => {
+    if (onConfirmCallback) {
+      onConfirmCallback()
+    }
+    closeModal()
+  }, [onConfirmCallback, closeModal])
+
+  return {
+    showModal,
+    tokenParams,
+    requestDeployment,
+    closeModal,
+    confirmDeployment,
+  }
+}

--- a/frontend/src/utils/network.ts
+++ b/frontend/src/utils/network.ts
@@ -1,0 +1,9 @@
+import { STELLAR_CONFIG } from '../config/stellar'
+
+export const isMainnet = (): boolean => {
+  return STELLAR_CONFIG.network === 'mainnet'
+}
+
+export const getNetworkName = (): string => {
+  return STELLAR_CONFIG.network
+}

--- a/frontend/src/utils/validation.ts
+++ b/frontend/src/utils/validation.ts
@@ -51,3 +51,27 @@ export const isValidImageFile = (file: File): { valid: boolean; error?: string }
 
   return { valid: true }
 }
+
+export const validateTokenName = (name: string): boolean => {
+  return name.length >= 1 && name.length <= 32
+}
+
+export const validateTokenSymbol = (symbol: string): boolean => {
+  return symbol.length >= 1 && symbol.length <= 12
+}
+
+export const validateDecimals = (decimals: number): boolean => {
+  return decimals >= 0 && decimals <= 18
+}
+
+export const validateTokenName = (name: string): boolean => {
+  return name.length >= 1 && name.length <= 32
+}
+
+export const validateTokenSymbol = (symbol: string): boolean => {
+  return symbol.length >= 1 && symbol.length <= 12
+}
+
+export const validateDecimals = (decimals: number): boolean => {
+  return decimals >= 0 && decimals <= 18
+}


### PR DESCRIPTION
- Add MainnetConfirmationModal component with parameter review
- Implement useMainnetConfirmation hook for conditional flow
- Add network detection utilities (isMainnet)
- Create TokenCreateForm example with integrated confirmation
- Require typing token symbol to confirm mainnet deployment
- Skip confirmation step on testnet
- Display warning about irreversible action and real XLM costs

closes #35