### PR TITLE
feat: add contract event history with pagination

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect } from 'react'
 import { Input } from './UI/Input'
+import { TransactionHistory } from './TransactionHistory'
 import { useDebounce } from '../hooks/useDebounce'
 import { stellarService } from '../services/stellar'
+import { STELLAR_CONFIG } from '../config/stellar'
 
 export const Dashboard: React.FC = () => {
   const [search, setSearch] = useState('')
@@ -14,19 +16,30 @@ export const Dashboard: React.FC = () => {
     stellarService.getTokenInfo(debouncedSearch).then((info) => setResults([info]))
   }, [debouncedSearch])
 
+  const factoryContractId = STELLAR_CONFIG.factoryContractId
+
   return (
-    <div className="space-y-4">
-      <Input
-        label="Search tokens"
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-        placeholder="Search by address or name..."
-      />
-      <ul className="space-y-2">
-        {results.map((r, i) => (
-          <li key={i} className="p-2 border rounded text-sm">{JSON.stringify(r)}</li>
-        ))}
-      </ul>
+    <div className="space-y-6">
+      <div className="space-y-4">
+        <Input
+          label="Search tokens"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search by address or name..."
+        />
+        <ul className="space-y-2">
+          {results.map((r, i) => (
+            <li key={i} className="p-2 border rounded text-sm">{JSON.stringify(r)}</li>
+          ))}
+        </ul>
+      </div>
+
+      {factoryContractId && (
+        <div className="space-y-2">
+          <h2 className="text-base font-semibold text-gray-800">Recent Activity</h2>
+          <TransactionHistory contractId={factoryContractId} />
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/TransactionHistory.tsx
+++ b/frontend/src/components/TransactionHistory.tsx
@@ -1,0 +1,222 @@
+import { useState, useEffect, useCallback } from 'react'
+import { stellarService } from '../services/stellar'
+import { Button } from './UI/Button'
+import { Spinner } from './UI/Spinner'
+import { STELLAR_CONFIG } from '../config/stellar'
+import type { ContractEvent, ContractEventType } from '../types'
+
+interface Props {
+  contractId: string
+  /** Optional: filter to events for a specific token address */
+  tokenAddress?: string
+  pageSize?: number
+}
+
+const EVENT_LABELS: Record<ContractEventType, string> = {
+  token_created: 'Token Created',
+  tokens_minted: 'Tokens Minted',
+  tokens_burned: 'Tokens Burned',
+  metadata_set: 'Metadata Set',
+  fees_updated: 'Fees Updated',
+}
+
+const EVENT_COLORS: Record<ContractEventType, string> = {
+  token_created: 'bg-green-100 text-green-800',
+  tokens_minted: 'bg-blue-100 text-blue-800',
+  tokens_burned: 'bg-red-100 text-red-800',
+  metadata_set: 'bg-purple-100 text-purple-800',
+  fees_updated: 'bg-yellow-100 text-yellow-800',
+}
+
+function formatTimestamp(unix: number): string {
+  if (!unix) return '—'
+  return new Date(unix * 1000).toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  })
+}
+
+function truncate(str: string, len = 12): string {
+  if (!str || str.length <= len) return str
+  return `${str.slice(0, 6)}…${str.slice(-4)}`
+}
+
+function EventDataRow({ label, value }: { label: string; value: string }) {
+  return (
+    <span className="inline-flex gap-1 text-xs text-gray-600">
+      <span className="font-medium">{label}:</span>
+      <span title={value} className="font-mono">{truncate(value, 20)}</span>
+    </span>
+  )
+}
+
+function renderEventData(event: ContractEvent) {
+  const d = event.data
+  switch (event.type) {
+    case 'token_created':
+      return (
+        <div className="flex flex-wrap gap-3">
+          <EventDataRow label="Token" value={d.tokenAddress} />
+          <EventDataRow label="Creator" value={d.creator} />
+        </div>
+      )
+    case 'tokens_minted':
+      return (
+        <div className="flex flex-wrap gap-3">
+          <EventDataRow label="Token" value={d.tokenAddress} />
+          <EventDataRow label="To" value={d.to} />
+          <EventDataRow label="Amount" value={d.amount} />
+        </div>
+      )
+    case 'tokens_burned':
+      return (
+        <div className="flex flex-wrap gap-3">
+          <EventDataRow label="Token" value={d.tokenAddress} />
+          <EventDataRow label="From" value={d.from} />
+          <EventDataRow label="Amount" value={d.amount} />
+        </div>
+      )
+    case 'metadata_set':
+      return (
+        <div className="flex flex-wrap gap-3">
+          <EventDataRow label="Token" value={d.tokenAddress} />
+          <EventDataRow label="URI" value={d.metadataUri} />
+        </div>
+      )
+    case 'fees_updated':
+      return (
+        <div className="flex flex-wrap gap-3">
+          <EventDataRow label="Base fee" value={d.baseFee} />
+          <EventDataRow label="Metadata fee" value={d.metadataFee} />
+        </div>
+      )
+  }
+}
+
+export const TransactionHistory: React.FC<Props> = ({
+  contractId,
+  tokenAddress,
+  pageSize = 20,
+}) => {
+  const [events, setEvents] = useState<ContractEvent[]>([])
+  const [cursor, setCursor] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [hasMore, setHasMore] = useState(true)
+
+  const filterEvents = useCallback(
+    (evts: ContractEvent[]) =>
+      tokenAddress
+        ? evts.filter(
+            (e) =>
+              e.data.tokenAddress === tokenAddress ||
+              e.data.creator === tokenAddress,
+          )
+        : evts,
+    [tokenAddress],
+  )
+
+  const fetchInitial = useCallback(async () => {
+    if (!contractId) return
+    setLoading(true)
+    setError(null)
+    try {
+      const result = await stellarService.getContractEvents(contractId, pageSize)
+      setEvents(filterEvents(result.events))
+      setCursor(result.cursor)
+      setHasMore(result.events.length === pageSize)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load events')
+    } finally {
+      setLoading(false)
+    }
+  }, [contractId, pageSize, filterEvents])
+
+  useEffect(() => {
+    fetchInitial()
+  }, [fetchInitial])
+
+  const loadMore = async () => {
+    if (!cursor || loadingMore) return
+    setLoadingMore(true)
+    try {
+      const result = await stellarService.getContractEvents(contractId, pageSize, cursor)
+      const filtered = filterEvents(result.events)
+      setEvents((prev) => [...prev, ...filtered])
+      setCursor(result.cursor)
+      setHasMore(result.events.length === pageSize)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load more events')
+    } finally {
+      setLoadingMore(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Spinner />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+        {error}
+        <button
+          onClick={fetchInitial}
+          className="ml-2 underline hover:no-underline"
+        >
+          Retry
+        </button>
+      </div>
+    )
+  }
+
+  if (events.length === 0) {
+    return (
+      <p className="py-6 text-center text-sm text-gray-500">No events found.</p>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <ul className="divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white">
+        {events.map((event) => (
+          <li key={event.id} className="flex flex-col gap-1 px-4 py-3">
+            <div className="flex items-center justify-between gap-2">
+              <span
+                className={`rounded-full px-2 py-0.5 text-xs font-semibold ${EVENT_COLORS[event.type]}`}
+              >
+                {EVENT_LABELS[event.type]}
+              </span>
+              <span className="text-xs text-gray-400">
+                {formatTimestamp(event.timestamp)}
+              </span>
+            </div>
+            {renderEventData(event)}
+            <a
+              href={`https://stellar.expert/explorer/${STELLAR_CONFIG.network}/tx/${event.txHash}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-0.5 text-xs text-indigo-500 hover:underline font-mono"
+              title={event.txHash}
+            >
+              tx: {truncate(event.txHash, 24)}
+            </a>
+          </li>
+        ))}
+      </ul>
+
+      {hasMore && (
+        <div className="flex justify-center">
+          <Button onClick={loadMore} loading={loadingMore} variant="secondary">
+            Load more
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/services/stellar.ts
+++ b/frontend/src/services/stellar.ts
@@ -1,23 +1,219 @@
 // Stellar SDK integration service
+import { STELLAR_CONFIG } from '../config/stellar'
+import type { ContractEvent, ContractEventType, GetEventsResult } from '../types'
+
+const EVENT_TOPICS: ContractEventType[] = [
+  'token_created',
+  'tokens_minted',
+  'tokens_burned',
+  'metadata_set',
+  'fees_updated',
+]
+
+function getRpcUrl(): string {
+  const network = STELLAR_CONFIG.network as 'testnet' | 'mainnet'
+  return STELLAR_CONFIG[network].sorobanRpcUrl
+}
+
+// ── Raw RPC types ────────────────────────────────────────────────────────────
+
+interface RpcEventResponse {
+  id: string
+  type: string
+  ledger: number
+  ledgerClosedAt: string
+  contractId: string
+  pagingToken: string
+  inSuccessfulContractCall: boolean
+  txHash: string
+  topic: string[]   // base64-encoded XDR ScVal[]
+  value: string     // base64-encoded XDR ScVal
+}
+
+interface RpcGetEventsResult {
+  events: RpcEventResponse[]
+  latestLedger: number
+}
+
+// ── XDR decode helpers (no SDK dependency) ───────────────────────────────────
+
+/**
+ * Decode a base64 XDR ScVal to a human-readable string.
+ * We use the stellar-sdk xdr module dynamically so the service still compiles
+ * even if types aren't resolved at edit time.
+ */
+async function scValB64ToString(b64: string): Promise<string> {
+  try {
+    // Dynamic import keeps the bundle tree-shakeable and avoids top-level type issues
+    const { xdr } = await import('stellar-sdk')
+    const val = xdr.ScVal.fromXDR(b64, 'base64')
+    return scValToString(val, xdr)
+  } catch {
+    return b64
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function scValToString(val: any, xdr: any): string {
+  try {
+    const type = val.switch()
+    if (type === xdr.ScValType.scvAddress()) {
+      const addr = val.address()
+      if (addr.switch() === xdr.ScAddressType.scAddressTypeAccount()) {
+        return addr.accountId().publicKey().toString()
+      }
+      return Buffer.from(addr.contractId()).toString('hex')
+    }
+    if (type === xdr.ScValType.scvI128()) {
+      const hi = BigInt(val.i128().hi().toString())
+      const lo = BigInt(val.i128().lo().toString())
+      return ((hi << 64n) | lo).toString()
+    }
+    if (type === xdr.ScValType.scvU64()) return val.u64().toString()
+    if (type === xdr.ScValType.scvString()) return val.str().toString()
+    if (type === xdr.ScValType.scvSymbol()) return val.sym().toString()
+    if (type === xdr.ScValType.scvVoid()) return 'none'
+    if (type === xdr.ScValType.scvVec()) {
+      const items: string[] = (val.vec() ?? []).map((v: any) => scValToString(v, xdr))
+      return items.join(', ')
+    }
+    return b64ToString(val.toXDR('base64'))
+  } catch {
+    return ''
+  }
+}
+
+function b64ToString(b64: string): string {
+  try {
+    return atob(b64)
+  } catch {
+    return b64
+  }
+}
+
+// ── Event parsing ─────────────────────────────────────────────────────────────
+
+async function parseRpcEvent(raw: RpcEventResponse): Promise<ContractEvent | null> {
+  try {
+    if (!raw.topic?.length) return null
+
+    // topic[0] is the event name symbol
+    const eventType = (await scValB64ToString(raw.topic[0])) as ContractEventType
+    if (!EVENT_TOPICS.includes(eventType)) return null
+
+    const { xdr } = await import('stellar-sdk')
+    const valueVal = xdr.ScVal.fromXDR(raw.value, 'base64')
+    const items: any[] = valueVal.vec() ?? []
+
+    const data: Record<string, string> = {}
+
+    switch (eventType) {
+      case 'token_created':
+        data.tokenAddress = scValToString(items[0], xdr)
+        data.creator = scValToString(items[1], xdr)
+        break
+      case 'tokens_minted':
+        data.tokenAddress = scValToString(items[0], xdr)
+        data.to = scValToString(items[1], xdr)
+        data.amount = scValToString(items[2], xdr)
+        break
+      case 'tokens_burned':
+        data.tokenAddress = scValToString(items[0], xdr)
+        data.from = scValToString(items[1], xdr)
+        data.amount = scValToString(items[2], xdr)
+        break
+      case 'metadata_set':
+        data.tokenAddress = scValToString(items[0], xdr)
+        data.metadataUri = scValToString(items[1], xdr)
+        break
+      case 'fees_updated':
+        data.baseFee = scValToString(items[0], xdr)
+        data.metadataFee = scValToString(items[1], xdr)
+        break
+    }
+
+    return {
+      id: raw.id,
+      type: eventType,
+      ledger: raw.ledger,
+      timestamp: raw.ledgerClosedAt
+        ? Math.floor(new Date(raw.ledgerClosedAt).getTime() / 1000)
+        : 0,
+      txHash: raw.txHash,
+      data,
+    }
+  } catch {
+    return null
+  }
+}
+
+// ── JSON-RPC helper ───────────────────────────────────────────────────────────
+
+async function rpcCall<T>(method: string, params: unknown): Promise<T> {
+  const res = await fetch(getRpcUrl(), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+  })
+  if (!res.ok) throw new Error(`RPC HTTP error ${res.status}`)
+  const json = await res.json()
+  if (json.error) throw new Error(json.error.message ?? 'RPC error')
+  return json.result as T
+}
+
+// ── StellarService ────────────────────────────────────────────────────────────
 
 export class StellarService {
-  // Placeholder for Stellar SDK methods
-  async deployToken(params: any): Promise<any> {
-    // Implementation for token deployment
+  async deployToken(params: unknown): Promise<unknown> {
     console.log('Deploying token:', params)
     return { success: true }
   }
 
-  async getTokenInfo(tokenAddress: string): Promise<any> {
-    // Implementation for getting token info
+  async getTokenInfo(tokenAddress: string): Promise<unknown> {
     console.log('Getting token info for:', tokenAddress)
     return {}
   }
 
-  async getTransaction(hash: string): Promise<any> {
-    // Implementation for getting transaction details
+  async getTransaction(hash: string): Promise<unknown> {
     console.log('Getting transaction:', hash)
     return {}
+  }
+
+  /**
+   * Fetch contract events for the factory contract, newest-first.
+   * @param contractId  Soroban contract address (C...)
+   * @param limit       Max events per page (default 20)
+   * @param cursor      Opaque pagination cursor from a previous call
+   */
+  async getContractEvents(
+    contractId: string,
+    limit = 20,
+    cursor?: string,
+  ): Promise<GetEventsResult> {
+    const params: Record<string, unknown> = {
+      filters: [
+        {
+          type: 'contract',
+          contractIds: [contractId],
+        },
+      ],
+      pagination: {
+        limit,
+        ...(cursor ? { cursor } : {}),
+      },
+    }
+
+    const result = await rpcCall<RpcGetEventsResult>('getEvents', params)
+
+    const parsed = await Promise.all(result.events.map(parseRpcEvent))
+    const events = parsed
+      .filter((e): e is ContractEvent => e !== null)
+      .sort((a, b) => b.ledger - a.ledger) // newest-first
+
+    const lastEvent = result.events[result.events.length - 1]
+    const nextCursor = lastEvent?.pagingToken ?? null
+
+    return { events, cursor: nextCursor }
   }
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -29,3 +29,24 @@ export interface AppError {
   code: string
   message: string
 }
+
+export type ContractEventType =
+  | 'token_created'
+  | 'tokens_minted'
+  | 'tokens_burned'
+  | 'metadata_set'
+  | 'fees_updated'
+
+export interface ContractEvent {
+  id: string
+  type: ContractEventType
+  ledger: number
+  timestamp: number // unix seconds
+  txHash: string
+  data: Record<string, string>
+}
+
+export interface GetEventsResult {
+  events: ContractEvent[]
+  cursor: string | null // opaque cursor for pagination
+}


### PR DESCRIPTION
this pr closes #34 

## Summary
Adds transaction history UI for factory contract events.

## Changes
- types/index.ts — ContractEventType, ContractEvent, GetEventsResult
- services/stellar.ts — getContractEvents() via Soroban RPC getEvents with XDR decoding
- components/TransactionHistory.tsx — color-coded badges, timestamps, decoded data, stellar.expert tx links, load-more pagination
- components/Dashboard.tsx — wires in TransactionHistory under Recent Activity

## Acceptance Criteria
- [x] Recent contract events listed with type, timestamp, and key data
- [x] Events sorted newest-first
- [x] Load more fetches older events via pagingToken cursor
