### PR TITLE
update on factory state

### DIFF
--- a/frontend/src/hooks/useFactoryState.ts
+++ b/frontend/src/hooks/useFactoryState.ts
@@ -1,0 +1,175 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { STELLAR_CONFIG } from '../config/stellar'
+import type { FactoryState } from '../types'
+
+// ── Module-level cache ────────────────────────────────────────────────────────
+// Shared across all hook instances so any component mounting after the first
+// fetch within the TTL window reuses the same result without a network call.
+
+const CACHE_TTL_MS = 30_000
+
+interface CacheEntry {
+  state: FactoryState
+  fetchedAt: number // Date.now()
+}
+
+let cache: CacheEntry | null = null
+
+// ── RPC helpers ───────────────────────────────────────────────────────────────
+
+function getRpcUrl(): string {
+  const network = STELLAR_CONFIG.network as 'testnet' | 'mainnet'
+  return STELLAR_CONFIG[network].sorobanRpcUrl
+}
+
+async function rpcSimulate(contractId: string, method: string): Promise<unknown> {
+  const { xdr, Contract } = await import('stellar-sdk')
+
+  const contract = new Contract(contractId)
+  const tx = contract.call(method)
+
+  const res = await fetch(getRpcUrl(), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'simulateTransaction',
+      params: { transaction: tx.toXDR() },
+    }),
+  })
+
+  if (!res.ok) throw new Error(`RPC HTTP error ${res.status}`)
+  const json = await res.json()
+  if (json.error) throw new Error(json.error.message ?? 'RPC error')
+
+  // simulateTransaction returns results[0].xdr — a base64 ScVal
+  const resultXdr: string = json.result?.results?.[0]?.xdr
+  if (!resultXdr) throw new Error('No result returned from simulateTransaction')
+
+  return xdr.ScVal.fromXDR(resultXdr, 'base64')
+}
+
+// ── XDR → FactoryState decoder ────────────────────────────────────────────────
+
+async function decodeFactoryState(scVal: unknown): Promise<FactoryState> {
+  const { xdr } = await import('stellar-sdk')
+
+  // get_state() returns a contracttype struct encoded as ScvMap
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const val = scVal as any
+  if (val.switch() !== xdr.ScValType.scvMap()) {
+    throw new Error('Unexpected ScVal type for FactoryState')
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const map: Map<string, any> = new Map(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (val.map() as any[]).map((entry: any) => [
+      entry.key().sym().toString() as string,
+      entry.val(),
+    ]),
+  )
+
+  function getAddress(key: string): string {
+    const v = map.get(key)
+    if (!v) throw new Error(`Missing field: ${key}`)
+    const addr = v.address()
+    if (addr.switch() === xdr.ScAddressType.scAddressTypeAccount()) {
+      return addr.accountId().publicKey().toString()
+    }
+    return [...new Uint8Array(addr.contractId() as ArrayBuffer)]
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('')
+  }
+
+  function getI128(key: string): bigint {
+    const v = map.get(key)
+    if (!v) throw new Error(`Missing field: ${key}`)
+    const hi = BigInt(v.i128().hi().toString())
+    const lo = BigInt(v.i128().lo().toString())
+    return (hi << 64n) | lo
+  }
+
+  function getU32(key: string): number {
+    const v = map.get(key)
+    if (!v) throw new Error(`Missing field: ${key}`)
+    return v.u32() as number
+  }
+
+  function getBool(key: string): boolean {
+    const v = map.get(key)
+    if (!v) throw new Error(`Missing field: ${key}`)
+    return v.b() as boolean
+  }
+
+  return {
+    admin: getAddress('admin'),
+    treasury: getAddress('treasury'),
+    base_fee: getI128('base_fee'),
+    metadata_fee: getI128('metadata_fee'),
+    token_count: getU32('token_count'),
+    paused: getBool('paused'),
+  }
+}
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+interface UseFactoryStateResult {
+  state: FactoryState | null
+  isLoading: boolean
+  error: Error | null
+  refetch: () => void
+}
+
+export function useFactoryState(): UseFactoryStateResult {
+  const [state, setState] = useState<FactoryState | null>(cache?.state ?? null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+
+  // Tracks whether a fetch is already in-flight to avoid duplicate requests
+  // when multiple components mount simultaneously.
+  const fetchingRef = useRef(false)
+
+  const fetchState = useCallback(async (bypassCache: boolean) => {
+    const now = Date.now()
+
+    if (!bypassCache && cache && now - cache.fetchedAt < CACHE_TTL_MS) {
+      setState(cache.state)
+      return
+    }
+
+    if (fetchingRef.current) return
+    fetchingRef.current = true
+
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const contractId = STELLAR_CONFIG.factoryContractId
+      if (!contractId) throw new Error('VITE_FACTORY_CONTRACT_ID is not configured')
+
+      const scVal = await rpcSimulate(contractId, 'get_state')
+      const decoded = await decodeFactoryState(scVal)
+
+      cache = { state: decoded, fetchedAt: Date.now() }
+      setState(decoded)
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)))
+    } finally {
+      setIsLoading(false)
+      fetchingRef.current = false
+    }
+  }, [])
+
+  // Initial fetch on mount
+  useEffect(() => {
+    fetchState(false)
+  }, [fetchState])
+
+  const refetch = useCallback(() => {
+    fetchState(true)
+  }, [fetchState])
+
+  return { state, isLoading, error, refetch }
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -50,3 +50,12 @@ export interface GetEventsResult {
   events: ContractEvent[]
   cursor: string | null // opaque cursor for pagination
 }
+
+export interface FactoryState {
+  admin: string       // Stellar account address (G...)
+  treasury: string    // Stellar account address (G...)
+  base_fee: bigint    // i128 — fee in stroops for token creation / minting
+  metadata_fee: bigint // i128 — fee in stroops for set_metadata
+  token_count: number // u32 — total tokens deployed via the factory
+  paused: boolean     // whether the contract is paused
+}


### PR DESCRIPTION
Added FactoryState type to 
index.ts
 matching the contract struct (admin, treasury, base_fee, metadata_fee, token_count, paused)
Implemented useFactoryState hook in 
useFactoryState.ts
 — calls simulateTransaction via JSON-RPC, decodes the XDR response, and returns { state, isLoading, error, refetch }
Cache is module-level (shared across all hook instances) with a 30s TTL; refetch() bypasses it and resets the window
No external data-fetching libraries — plain useState/useEffect/useCallback/useRef

closes #79 