### PR TITLE
feat: add ConfirmModal before all on-chain transactions

### DIFF
--- a/frontend/src/components/BurnForm.tsx
+++ b/frontend/src/components/BurnForm.tsx
@@ -1,13 +1,9 @@
-import { Input } from './UI';
 import { useState, useEffect } from 'react'
-import { Input } from './UI/Input'
-import { Button } from './UI/Button'
+import { Input, Button, ConfirmModal } from './UI'
 import { useDebounce } from '../hooks/useDebounce'
-import { useStellarContext } from '../context/StellarContext'
+import { stellarService } from '../services/stellar'
+import type { TokenInfo } from '../types'
 
-export const BurnForm: React.FC = () => {
-  const { stellarService } = useStellarContext()
-  const [tokenAddress, setTokenAddress] = useState('')
 interface BurnFormProps {
   tokenAddress?: string
   onSuccess?: () => void
@@ -17,6 +13,7 @@ export const BurnForm: React.FC<BurnFormProps> = ({ tokenAddress: initialAddress
   const [tokenAddress, setTokenAddress] = useState(initialAddress)
   const [amount, setAmount] = useState('')
   const [tokenInfo, setTokenInfo] = useState<TokenInfo | null>(null)
+  const [pending, setPending] = useState(false)
 
   const debouncedAddress = useDebounce(tokenAddress, 300)
 
@@ -27,34 +24,54 @@ export const BurnForm: React.FC<BurnFormProps> = ({ tokenAddress: initialAddress
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
+    setPending(true)
+  }
+
+  const handleConfirm = () => {
+    setPending(false)
     // burn logic placeholder
     onSuccess?.()
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <Input
-        label="Token Address"
-        value={tokenAddress}
-        onChange={(e) => setTokenAddress(e.target.value)}
-        placeholder="G..."
-        required
+    <>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <Input
+          label="Token Address"
+          value={tokenAddress}
+          onChange={(e) => setTokenAddress(e.target.value)}
+          placeholder="G..."
+          required
+        />
+        {tokenInfo && (
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Token: {tokenInfo.name} ({tokenInfo.symbol})
+          </p>
+        )}
+        <Input
+          label="Amount"
+          type="number"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          placeholder="0"
+          min="0"
+          required
+        />
+        <Button type="submit" variant="secondary">Burn</Button>
+      </form>
+
+      <ConfirmModal
+        isOpen={pending}
+        title="Confirm Burn"
+        description="This will permanently destroy the specified token amount."
+        details={[
+          { label: 'Token', value: tokenInfo ? `${tokenInfo.name} (${tokenInfo.symbol})` : tokenAddress },
+          { label: 'Amount to Burn', value: amount },
+        ]}
+        onConfirm={handleConfirm}
+        onCancel={() => setPending(false)}
+        confirmLabel="Burn Tokens"
       />
-      {tokenInfo && (
-        <p className="text-sm text-gray-600 dark:text-gray-400">
-          Token: {tokenInfo.name} ({tokenInfo.symbol})
-        </p>
-      )}
-      <Input
-        label="Amount"
-        type="number"
-        value={amount}
-        onChange={(e) => setAmount(e.target.value)}
-        placeholder="0"
-        min="0"
-        required
-      />
-      <Button type="submit" variant="secondary">Burn</Button>
-    </form>
+    </>
   )
 }

--- a/frontend/src/components/MintForm.tsx
+++ b/frontend/src/components/MintForm.tsx
@@ -1,17 +1,10 @@
-import { Input } from './UI';
 import { useState, useEffect } from 'react'
-import { Input } from './UI/Input'
-import { Button } from './UI/Button'
+import { Input, Button, ConfirmModal } from './UI'
 import { useDebounce } from '../hooks/useDebounce'
-import { useStellarContext } from '../context/StellarContext'
-// import { useWallet } from '../hooks/useWallet'
-// import { walletService } from '../services/wallet'
-
-export const MintForm: React.FC = () => {
-  const { stellarService } = useStellarContext()
-  const [tokenAddress, setTokenAddress] = useState('')
 import { stellarService } from '../services/stellar'
 import type { TokenInfo } from '../types'
+
+const ESTIMATED_FEE = '0.01' // XLM
 
 interface MintFormProps {
   tokenAddress?: string
@@ -20,8 +13,10 @@ interface MintFormProps {
 
 export const MintForm: React.FC<MintFormProps> = ({ tokenAddress: initialAddress = '', onSuccess }) => {
   const [tokenAddress, setTokenAddress] = useState(initialAddress)
+  const [recipient, setRecipient] = useState('')
   const [amount, setAmount] = useState('')
   const [tokenInfo, setTokenInfo] = useState<TokenInfo | null>(null)
+  const [pending, setPending] = useState(false)
 
   const debouncedAddress = useDebounce(tokenAddress, 300)
 
@@ -30,36 +25,65 @@ export const MintForm: React.FC<MintFormProps> = ({ tokenAddress: initialAddress
     stellarService.getTokenInfo(debouncedAddress).then(setTokenInfo).catch(() => setTokenInfo(null))
   }, [debouncedAddress])
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
+    setPending(true)
+  }
+
+  const handleConfirm = async () => {
+    setPending(false)
     // mint logic placeholder
     onSuccess?.()
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <Input
-        label="Token Address"
-        value={tokenAddress}
-        onChange={(e) => setTokenAddress(e.target.value)}
-        placeholder="G..."
-        required
+    <>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <Input
+          label="Token Address"
+          value={tokenAddress}
+          onChange={(e) => setTokenAddress(e.target.value)}
+          placeholder="G..."
+          required
+        />
+        {tokenInfo && (
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Token: {tokenInfo.name} ({tokenInfo.symbol})
+          </p>
+        )}
+        <Input
+          label="Recipient Address"
+          value={recipient}
+          onChange={(e) => setRecipient(e.target.value)}
+          placeholder="G..."
+          required
+        />
+        <Input
+          label="Amount"
+          type="number"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          placeholder="0"
+          min="0"
+          required
+        />
+        <Button type="submit" variant="primary">Mint</Button>
+      </form>
+
+      <ConfirmModal
+        isOpen={pending}
+        title="Confirm Mint"
+        description="You are about to mint tokens to the recipient address."
+        details={[
+          { label: 'Token', value: tokenInfo ? `${tokenInfo.name} (${tokenInfo.symbol})` : tokenAddress },
+          { label: 'Recipient', value: recipient },
+          { label: 'Amount', value: amount },
+          { label: 'Estimated Fee', value: `${ESTIMATED_FEE} XLM` },
+        ]}
+        onConfirm={handleConfirm}
+        onCancel={() => setPending(false)}
+        confirmLabel="Mint Tokens"
       />
-      {tokenInfo && (
-        <p className="text-sm text-gray-600 dark:text-gray-400">
-          Token: {tokenInfo.name} ({tokenInfo.symbol})
-        </p>
-      )}
-      <Input
-        label="Amount"
-        type="number"
-        value={amount}
-        onChange={(e) => setAmount(e.target.value)}
-        placeholder="0"
-        min="0"
-        required
-      />
-      <Button type="submit" variant="primary">Mint</Button>
-    </form>
+    </>
   )
 }

--- a/frontend/src/components/SetMetadataForm.tsx
+++ b/frontend/src/components/SetMetadataForm.tsx
@@ -1,7 +1,9 @@
-import { Input,Button } from './UI';
 import { useState } from 'react'
+import { Input, Button, ConfirmModal } from './UI'
 import { isValidIPFSUri } from '../utils/validation'
 import { useToast } from '../context/ToastContext'
+
+const ESTIMATED_FEE = '0.01' // XLM
 
 interface Props {
   tokenAddress?: string
@@ -12,14 +14,20 @@ export const SetMetadataForm: React.FC<Props> = ({ tokenAddress: initialAddress 
   const [tokenAddress, setTokenAddress] = useState(initialAddress)
   const [metadataUri, setMetadataUri] = useState('')
   const [loading, setLoading] = useState(false)
+  const [pending, setPending] = useState(false)
   const { addToast } = useToast()
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     if (!isValidIPFSUri(metadataUri)) {
       addToast('Metadata URI must be a valid IPFS URI (e.g. ipfs://Qm...)', 'error')
       return
     }
+    setPending(true)
+  }
+
+  const handleConfirm = async () => {
+    setPending(false)
     setLoading(true)
     try {
       await onSubmit(tokenAddress, metadataUri)
@@ -32,24 +40,40 @@ export const SetMetadataForm: React.FC<Props> = ({ tokenAddress: initialAddress 
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <Input
-        label="Token Address"
-        value={tokenAddress}
-        onChange={(e) => setTokenAddress(e.target.value)}
-        placeholder="G..."
-        required
+    <>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <Input
+          label="Token Address"
+          value={tokenAddress}
+          onChange={(e) => setTokenAddress(e.target.value)}
+          placeholder="G..."
+          required
+        />
+        <Input
+          label="Metadata URI"
+          value={metadataUri}
+          onChange={(e) => setMetadataUri(e.target.value)}
+          placeholder="ipfs://Qm..."
+          required
+        />
+        <Button type="submit" disabled={loading}>
+          {loading ? 'Submitting...' : 'Set Metadata'}
+        </Button>
+      </form>
+
+      <ConfirmModal
+        isOpen={pending}
+        title="Confirm Set Metadata"
+        description="Review the metadata update before submitting on-chain."
+        details={[
+          { label: 'Token Address', value: tokenAddress },
+          { label: 'Metadata URI', value: metadataUri },
+          { label: 'Estimated Fee', value: `${ESTIMATED_FEE} XLM` },
+        ]}
+        onConfirm={handleConfirm}
+        onCancel={() => setPending(false)}
+        confirmLabel="Set Metadata"
       />
-      <Input
-        label="Metadata URI"
-        value={metadataUri}
-        onChange={(e) => setMetadataUri(e.target.value)}
-        placeholder="ipfs://Qm..."
-        required
-      />
-      <Button type="submit" disabled={loading}>
-        {loading ? 'Submitting...' : 'Set Metadata'}
-      </Button>
-    </form>
+    </>
   )
 }

--- a/frontend/src/components/TokenCreateForm.tsx
+++ b/frontend/src/components/TokenCreateForm.tsx
@@ -1,10 +1,12 @@
-import { Input,Button,MainnetConfirmationModal } from './UI';
 import { useState } from 'react'
+import { Input, Button, MainnetConfirmationModal, ConfirmModal } from './UI'
 import { useMainnetConfirmation } from '../hooks/useMainnetConfirmation'
 import { useToast } from '../context/ToastContext'
 import { useStellarContext } from '../context/StellarContext'
 import { TokenDeployParams } from '../types'
 import { validateTokenSymbol, validateTokenName, validateDecimals } from '../utils/validation'
+
+const ESTIMATED_FEE = '0.01' // XLM
 
 export const TokenCreateForm: React.FC = () => {
   const { stellarService } = useStellarContext()
@@ -14,6 +16,7 @@ export const TokenCreateForm: React.FC = () => {
   const [initialSupply, setInitialSupply] = useState('')
   const [description, setDescription] = useState('')
   const [isDeploying, setIsDeploying] = useState(false)
+  const [pendingParams, setPendingParams] = useState<TokenDeployParams | null>(null)
 
   const { showModal, tokenParams, requestDeployment, closeModal, confirmDeployment } =
     useMainnetConfirmation()
@@ -22,52 +25,34 @@ export const TokenCreateForm: React.FC = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
 
-    // Validate inputs
-    if (!validateTokenName(name)) {
-      addToast('Invalid token name', 'error')
-      return
-    }
-
-    if (!validateTokenSymbol(symbol)) {
-      addToast('Invalid token symbol', 'error')
-      return
-    }
-
-    if (!validateDecimals(parseInt(decimals))) {
-      addToast('Decimals must be between 0 and 18', 'error')
-      return
-    }
+    if (!validateTokenName(name)) { addToast('Invalid token name', 'error'); return }
+    if (!validateTokenSymbol(symbol)) { addToast('Invalid token symbol', 'error'); return }
+    if (!validateDecimals(parseInt(decimals))) { addToast('Decimals must be between 0 and 18', 'error'); return }
 
     const params: TokenDeployParams = {
       name,
       symbol,
       decimals: parseInt(decimals),
       initialSupply,
-      ...(description && {
-        metadata: {
-          description,
-          image: new File([], ''), // Placeholder - update when image upload is implemented
-        },
-      }),
+      ...(description && { metadata: { description, image: new File([], '') } }),
     }
 
-    // Request deployment - will show modal on mainnet, proceed directly on testnet
-    requestDeployment(params, () => deployToken(params))
+    setPendingParams(params)
+  }
+
+  const handleConfirm = () => {
+    if (!pendingParams) return
+    setPendingParams(null)
+    requestDeployment(pendingParams, () => deployToken(pendingParams))
   }
 
   const deployToken = async (params: TokenDeployParams) => {
     setIsDeploying(true)
     try {
       const result = await stellarService.deployToken(params)
-      
       if (result.success) {
         addToast('Token deployed successfully!', 'success')
-        // Reset form
-        setName('')
-        setSymbol('')
-        setDecimals('7')
-        setInitialSupply('')
-        setDescription('')
+        setName(''); setSymbol(''); setDecimals('7'); setInitialSupply(''); setDescription('')
       } else {
         addToast('Token deployment failed', 'error')
       }
@@ -82,41 +67,10 @@ export const TokenCreateForm: React.FC = () => {
   return (
     <>
       <form onSubmit={handleSubmit} className="space-y-4">
-        <Input
-          label="Token Name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="My Token"
-          required
-        />
-
-        <Input
-          label="Token Symbol"
-          value={symbol}
-          onChange={(e) => setSymbol(e.target.value.toUpperCase())}
-          placeholder="MTK"
-          required
-        />
-
-        <Input
-          label="Decimals"
-          type="number"
-          value={decimals}
-          onChange={(e) => setDecimals(e.target.value)}
-          placeholder="7"
-          min="0"
-          max="18"
-          required
-        />
-
-        <Input
-          label="Initial Supply"
-          value={initialSupply}
-          onChange={(e) => setInitialSupply(e.target.value)}
-          placeholder="1000000"
-          required
-        />
-
+        <Input label="Token Name" value={name} onChange={(e) => setName(e.target.value)} placeholder="My Token" required />
+        <Input label="Token Symbol" value={symbol} onChange={(e) => setSymbol(e.target.value.toUpperCase())} placeholder="MTK" required />
+        <Input label="Decimals" type="number" value={decimals} onChange={(e) => setDecimals(e.target.value)} placeholder="7" min="0" max="18" required />
+        <Input label="Initial Supply" value={initialSupply} onChange={(e) => setInitialSupply(e.target.value)} placeholder="1000000" required />
         <div>
           <label htmlFor="description" className="block text-sm font-medium text-gray-700 mb-1">
             Description (Optional)
@@ -130,11 +84,26 @@ export const TokenCreateForm: React.FC = () => {
             rows={3}
           />
         </div>
-
         <Button type="submit" disabled={isDeploying}>
           {isDeploying ? 'Deploying...' : 'Deploy Token'}
         </Button>
       </form>
+
+      <ConfirmModal
+        isOpen={!!pendingParams}
+        title="Confirm Token Creation"
+        description="Review the details before deploying your token on-chain."
+        details={[
+          { label: 'Name', value: pendingParams?.name ?? '' },
+          { label: 'Symbol', value: pendingParams?.symbol ?? '' },
+          { label: 'Decimals', value: pendingParams?.decimals ?? '' },
+          { label: 'Initial Supply', value: pendingParams?.initialSupply ?? '' },
+          { label: 'Estimated Fee', value: `${ESTIMATED_FEE} XLM` },
+        ]}
+        onConfirm={handleConfirm}
+        onCancel={() => setPendingParams(null)}
+        confirmLabel="Deploy Token"
+      />
 
       {tokenParams && (
         <MainnetConfirmationModal

--- a/frontend/src/components/UI/Button.tsx
+++ b/frontend/src/components/UI/Button.tsx
@@ -8,25 +8,17 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   'aria-label'?: string
 }
 
-export const Button: React.FC<ButtonProps> = ({
-  variant = 'primary',
-  size = 'md',
-  loading = false,
-  children,
-  className = '',
-  disabled,
-  ...props
-}) => {
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { variant = 'primary', size = 'md', loading = false, children, className = '', disabled, ...props },
+  ref
+) {
   const baseClasses =
     'inline-flex items-center justify-center font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed'
 
   const variantClasses: Record<string, string> = {
     primary: 'bg-blue-600 hover:bg-blue-700 text-white focus:ring-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400',
     secondary: 'bg-gray-600 hover:bg-gray-700 text-white focus:ring-gray-500 dark:bg-gray-500 dark:hover:bg-gray-400',
-    outline: 'border border-gray-300 bg-white hover:bg-gray-50 text-gray-700 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200'
-    primary: 'bg-blue-600 hover:bg-blue-700 text-white focus:ring-blue-500',
-    secondary: 'bg-gray-600 hover:bg-gray-700 text-white focus:ring-gray-500',
-    outline: 'border border-gray-300 bg-white hover:bg-gray-50 text-gray-700 focus:ring-blue-500',
+    outline: 'border border-gray-300 bg-white hover:bg-gray-50 text-gray-700 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200',
   }
 
   const sizeClasses: Record<string, string> = {
@@ -39,6 +31,7 @@ export const Button: React.FC<ButtonProps> = ({
 
   return (
     <button
+      ref={ref}
       className={classes}
       disabled={disabled || loading}
       aria-busy={loading || undefined}
@@ -63,4 +56,4 @@ export const Button: React.FC<ButtonProps> = ({
       {children}
     </button>
   )
-}
+})

--- a/frontend/src/components/UI/ConfirmModal.tsx
+++ b/frontend/src/components/UI/ConfirmModal.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useRef } from 'react'
+import { Button } from './Button'
+
+export interface DetailRow {
+  label: string
+  value: string | number
+}
+
+interface ConfirmModalProps {
+  isOpen: boolean
+  title: string
+  description?: string
+  details: DetailRow[]
+  onConfirm: () => void
+  onCancel: () => void
+  confirmLabel?: string
+}
+
+export const ConfirmModal: React.FC<ConfirmModalProps> = ({
+  isOpen,
+  title,
+  description,
+  details,
+  onConfirm,
+  onCancel,
+  confirmLabel = 'Confirm',
+}) => {
+  const cancelRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (!isOpen) return
+    cancelRef.current?.focus()
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, onCancel])
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-modal-title"
+    >
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-md w-full mx-4">
+        <div className="p-6 space-y-4">
+          <h2
+            id="confirm-modal-title"
+            className="text-xl font-semibold text-gray-900 dark:text-gray-100"
+          >
+            {title}
+          </h2>
+
+          {description && (
+            <p className="text-sm text-gray-600 dark:text-gray-400">{description}</p>
+          )}
+
+          <div className="bg-gray-50 dark:bg-gray-700 rounded-lg divide-y divide-gray-200 dark:divide-gray-600">
+            {details.map(({ label, value }) => (
+              <div key={label} className="flex justify-between px-4 py-2 text-sm">
+                <span className="text-gray-500 dark:text-gray-400">{label}</span>
+                <span className="font-medium text-gray-900 dark:text-gray-100 text-right max-w-[60%] break-all">
+                  {value}
+                </span>
+              </div>
+            ))}
+          </div>
+
+          <div className="flex gap-3 justify-end pt-2">
+            <Button ref={cancelRef} variant="outline" onClick={onCancel}>
+              Cancel
+            </Button>
+            <Button variant="primary" onClick={onConfirm}>
+              {confirmLabel}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/UI/index.ts
+++ b/frontend/src/components/UI/index.ts
@@ -5,3 +5,5 @@ export { Spinner } from './Spinner';
 export { ToastContainer } from './ToastContainer';
 export { MainnetConfirmationModal } from './MainnetConfirmationModal';
 export { PaginationControls } from './PaginationControls';
+export { ConfirmModal } from './ConfirmModal';
+export type { DetailRow } from './ConfirmModal';


### PR DESCRIPTION
closes #15
- Add reusable ConfirmModal component with title, description, detail rows
- Show confirmation before create_token with name, symbol, decimals, supply, fee
- Show confirmation before mint_tokens with recipient, amount, fee
- Show confirmation before burn with amount
- Show confirmation before set_metadata with URI, fee
- Update Button to use forwardRef for focus management
- Keyboard accessible: Escape to close, Tab to navigate buttons

## Description

Please include a summary of the changes and the "Why" behind them.

## Related Issue

Link the issue using "Closes #XX" or "Fixes #XX".

## Type of Change

Please tick the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing Done

Please describe the tests you ran (unit tests, manual verification, etc.) to verify your changes.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes
