### PR TITLE
feat: add MetadataAlreadySet guard in set_metadata

### DIFF
--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -190,6 +190,11 @@ impl TokenFactory {
             return Err(Error::InsufficientFee);
         }
 
+        // Guard: prevent overwriting existing metadata
+        if env.storage().instance().has(&(&token_address, symbol_short!("meta"))) {
+            return Err(Error::MetadataAlreadySet);
+        }
+
         token::TokenClient::new(&env, &state.fee_token).transfer(
             &admin,
             &state.treasury,

--- a/contracts/token-factory/src/test.rs
+++ b/contracts/token-factory/src/test.rs
@@ -231,6 +231,52 @@ fn test_set_metadata_insufficient_fee() {
     assert_eq!(result, Err(Ok(Error::InsufficientFee)));
 }
 
+#[test]
+fn test_set_metadata_already_set() {
+    let s = Setup::new();
+    let admin = Address::generate(&s.env);
+    s.fund(&admin, 1_000);
+
+    let token_addr = s.new_token(&admin);
+
+    // First call succeeds
+    s.client.set_metadata(
+        &token_addr, &admin,
+        &String::from_str(&s.env, "ipfs://Qm123"),
+        &500,
+    );
+
+    // Second call on the same token should return MetadataAlreadySet
+    let result = s.client.try_set_metadata(
+        &token_addr, &admin,
+        &String::from_str(&s.env, "ipfs://Qm456"),
+        &500,
+    );
+    assert_eq!(result, Err(Ok(Error::MetadataAlreadySet)));
+}
+
+#[test]
+fn test_set_metadata_different_tokens_independent() {
+    let s = Setup::new();
+    let admin = Address::generate(&s.env);
+    s.fund(&admin, 1_000);
+
+    let token_a = s.new_token(&admin);
+    let token_b = s.new_token(&admin);
+
+    // Setting metadata on two different tokens should both succeed
+    s.client.set_metadata(
+        &token_a, &admin,
+        &String::from_str(&s.env, "ipfs://QmA"),
+        &500,
+    );
+    s.client.set_metadata(
+        &token_b, &admin,
+        &String::from_str(&s.env, "ipfs://QmB"),
+        &500,
+    );
+}
+
 // ── mint_tokens ───────────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
- Check if metadata URI already exists for a token before setting
- Return Error::MetadataAlreadySet if metadata has already been set
- Add test_set_metadata_already_set to verify second call is rejected
- Add test_set_metadata_different_tokens_independent to verify different tokens are unaffected
- MetadataAlreadySet error variant is now used (no longer dead code)

## Description

Please include a summary of the changes and the "Why" behind them.

## Related Issue

Link the issue using "Closes #XX" or "Fixes #XX".

## Type of Change

Please tick the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing Done

Please describe the tests you ran (unit tests, manual verification, etc.) to verify your changes.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes
closes #90 
