### PR TITLE
feat: add fee bump transaction support (#63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,31 @@ For users deploying tokens, we strongly recommend:
 - Review all parameters carefully using the mainnet deployment checklist
 - Verify contract addresses and transaction details before signing
 
+## Fee Bump Transactions
+
+If a user's XLM balance is too low to cover the network base fee, their transaction will fail. Stellar's [fee bump](https://developers.stellar.org/docs/learn/encyclopedia/transactions-specialized/fee-bump-transactions) mechanism lets a third-party account (the *fee source*) pay the base fee on behalf of the original sender.
+
+### When to use fee bumps
+
+- The inner transaction's source account has near-zero XLM.
+- You want to sponsor fees for users as part of your application UX.
+- Resubmitting a stuck transaction with a higher fee without re-signing the inner envelope.
+
+### How it works in StellarForge
+
+Two utilities are exported from `frontend/src/services/stellar.ts`:
+
+```ts
+// 1. Wrap a signed inner transaction in a fee bump envelope.
+//    The fee-source account (connected via Freighter) signs the bump.
+const signedFeeBumpXdr = await buildFeeBumpTransaction(innerTxXdr, feeSourceAddress)
+
+// 2. Submit the fee bump and wait for confirmation.
+const txHash = await submitFeeBumpTransaction(signedFeeBumpXdr)
+```
+
+The fee source must have enough XLM to cover the base fee. The inner transaction is not re-signed — only the fee bump envelope requires the fee source's signature.
+
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for local development setup and contribution guidelines.

--- a/frontend/src/services/stellar.ts
+++ b/frontend/src/services/stellar.ts
@@ -9,6 +9,8 @@ import {
   scValToNative,
   rpc,
   xdr,
+  FeeBumpTransaction,
+  Transaction,
 } from 'stellar-sdk'
 import { STELLAR_CONFIG } from '../config/stellar'
 import { walletService } from './wallet'
@@ -146,6 +148,79 @@ async function pollTransaction(
     await new Promise((r) => setTimeout(r, intervalMs))
   }
   throw new Error(`Transaction ${hash} timed out after ${maxAttempts} attempts`)
+}
+
+// ── Fee Bump Transactions ─────────────────────────────────────────────────────
+
+/**
+ * Wraps an inner (signed) transaction in a fee bump transaction.
+ *
+ * Use this when the inner transaction's source account has insufficient XLM to
+ * cover the base fee. The `feeSource` account pays the network fee instead,
+ * allowing the inner transaction to succeed even with a near-empty balance.
+ *
+ * Flow:
+ *  1. Build and sign the inner transaction normally (e.g. via simulateAndSubmit).
+ *  2. Pass the signed inner XDR and a fee-source address to this function.
+ *  3. The fee-source account signs the resulting fee bump envelope.
+ *  4. Submit the fee bump transaction to the network.
+ *
+ * @param innerTxXdr  - Base64 XDR of the signed inner transaction.
+ * @param feeSource   - Stellar address that will pay the base fee.
+ * @param baseFee     - Fee per operation in stroops (defaults to 10× BASE_FEE
+ *                      to ensure the bump is accepted by the network).
+ * @returns The signed fee bump transaction XDR ready for submission.
+ */
+export async function buildFeeBumpTransaction(
+  innerTxXdr: string,
+  feeSource: string,
+  baseFee: string = String(Number(BASE_FEE) * 10),
+): Promise<string> {
+  const networkPassphrase = getNetworkPassphrase()
+
+  // Reconstruct the inner transaction from XDR
+  const innerTx = TransactionBuilder.fromXDR(innerTxXdr, networkPassphrase) as Transaction
+
+  // Build the fee bump envelope
+  const feeBumpTx = TransactionBuilder.buildFeeBumpTransaction(
+    feeSource,
+    baseFee,
+    innerTx,
+    networkPassphrase,
+  )
+
+  // The fee-source account must sign the fee bump envelope
+  const signedFeeBumpXdr = await walletService.signTransaction(feeBumpTx.toXDR())
+
+  return signedFeeBumpXdr
+}
+
+/**
+ * Submit a signed fee bump transaction and wait for confirmation.
+ *
+ * @param signedFeeBumpXdr - Base64 XDR of the signed fee bump transaction.
+ * @returns The transaction hash on success.
+ */
+export async function submitFeeBumpTransaction(signedFeeBumpXdr: string): Promise<string> {
+  const server = getRpcServer()
+  const networkPassphrase = getNetworkPassphrase()
+
+  const feeBumpTx = TransactionBuilder.fromXDR(
+    signedFeeBumpXdr,
+    networkPassphrase,
+  ) as FeeBumpTransaction
+
+  const submitResult = await server.sendTransaction(feeBumpTx)
+
+  if (submitResult.status === 'ERROR') {
+    throw parseContractError(
+      new Error(submitResult.errorResult?.toXDR('base64') ?? 'Fee bump submission failed'),
+    )
+  }
+
+  await pollTransaction(server, submitResult.hash)
+
+  return submitResult.hash
 }
 
 /**


### PR DESCRIPTION
Closes #63

---

## Summary

This PR adds fee bump transaction support to StellarForge, allowing a third-party account (fee source) to cover the base fee when a user's XLM balance is too low to pay it themselves.

## Changes

### `frontend/src/services/stellar.ts`
- Added `buildFeeBumpTransaction(innerTxXdr, feeSource, baseFee?)` — wraps a signed inner transaction in a fee bump envelope and signs it via Freighter using the fee source account
- Added `submitFeeBumpTransaction(signedFeeBumpXdr)` — submits the fee bump to the network and polls for confirmation
- Imported `FeeBumpTransaction` and `Transaction` types from `stellar-sdk`

### `README.md`
- Added a **Fee Bump Transactions** section documenting when to use fee bumps, how the flow works, and a usage code example

## How it works

1. Build and sign the inner transaction normally (e.g. via `simulateAndSubmit`)
2. Call `buildFeeBumpTransaction(innerTxXdr, feeSourceAddress)` — the fee source signs the bump envelope via Freighter
3. Call `submitFeeBumpTransaction(signedFeeBumpXdr)` to submit and await confirmation

The inner transaction is not re-signed. Only the fee bump envelope requires the fee source's signature.

## Acceptance Criteria

- [x] `buildFeeBumpTransaction` correctly wraps an inner transaction using `TransactionBuilder.buildFeeBumpTransaction`
- [x] The fee bump transaction is signed by the fee source account via Freighter
- [x] Documentation explains the fee bump flow in both JSDoc and README

closes#63
