### PR TITLE
Fix: Add authorization check to set_metadata function

### DIFF
--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -190,6 +190,25 @@ impl TokenFactory {
             return Err(Error::InsufficientFee);
         }
 
+        // Fetch TokenInfo to verify creator authorization
+        let idx_key = (&token_address, symbol_short!("idx"));
+        let index: u32 = env
+            .storage()
+            .instance()
+            .get(&idx_key)
+            .ok_or(Error::TokenNotFound)?;
+
+        let token_info: TokenInfo = env
+            .storage()
+            .instance()
+            .get(&index)
+            .ok_or(Error::TokenNotFound)?;
+
+        // Verify admin is the token creator
+        if token_info.creator != admin {
+            return Err(Error::Unauthorized);
+        }
+
         // Guard: prevent overwriting existing metadata
         if env.storage().instance().has(&(&token_address, symbol_short!("meta"))) {
             return Err(Error::MetadataAlreadySet);

--- a/contracts/token-factory/src/test.rs
+++ b/contracts/token-factory/src/test.rs
@@ -277,6 +277,44 @@ fn test_set_metadata_different_tokens_independent() {
     );
 }
 
+#[test]
+fn test_set_metadata_unauthorized() {
+    let s = Setup::new();
+    let creator = Address::generate(&s.env);
+    let unauthorized_user = Address::generate(&s.env);
+    s.fund(&unauthorized_user, 500);
+
+    let token_addr = s.new_token(&creator);
+
+    // Seed token info in storage to simulate a created token
+    let info = TokenInfo {
+        name: String::from_str(&s.env, "TestToken"),
+        symbol: String::from_str(&s.env, "TEST"),
+        decimals: 7,
+        creator: creator.clone(),
+        created_at: 0,
+        burn_enabled: true,
+    };
+    s.env.as_contract(&s.client.address, || {
+        let mut state: FactoryState = s.env.storage().instance()
+            .get(&symbol_short!("state")).unwrap();
+        state.token_count += 1;
+        let index = state.token_count;
+        s.env.storage().instance().set(&index, &info);
+        s.env.storage().instance().set(&symbol_short!("state"), &state);
+        s.env.storage().instance()
+            .set(&(&token_addr, symbol_short!("idx")), &index);
+    });
+
+    // Unauthorized user should not be able to set metadata
+    let result = s.client.try_set_metadata(
+        &token_addr, &unauthorized_user,
+        &String::from_str(&s.env, "ipfs://Qm123"),
+        &500,
+    );
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
 // ── mint_tokens ───────────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
- Fetch TokenInfo for given token_address from storage
- Verify admin == token_info.creator, return Error::Unauthorized if not
- Add test for unauthorized metadata setting
- Ensure only token creator can set metadata for their token

Fixes #88

## Description

Please include a summary of the changes and the "Why" behind them.

## Related Issue

Link the issue using "Closes #XX" or "Fixes #XX".

## Type of Change

Please tick the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing Done

Please describe the tests you ran (unit tests, manual verification, etc.) to verify your changes.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes

closes #88 