### PR TITLE
feat: add wasm-opt post-processing for contract binary

### DIFF
--- a/.github/workflows/wasm-build.yml
+++ b/.github/workflows/wasm-build.yml
@@ -20,5 +20,18 @@ jobs:
           target: wasm32-unknown-unknown
           override: true
 
-      - name: Build wasm
-        run: cargo build --locked --target wasm32-unknown-unknown --release --manifest-path contracts/token-factory/Cargo.toml
+      - name: Install wasm-opt
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y binaryen
+
+      - name: Build and optimize wasm
+        working-directory: contracts/token-factory
+        run: bash build.sh
+
+      - name: Upload optimized wasm
+        uses: actions/upload-artifact@v4
+        with:
+          name: token-factory-optimized
+          path: target/wasm32-unknown-unknown/release/token_factory.optimized.wasm
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ cd contracts
 cargo build --target wasm32-unknown-unknown --release
 ```
 
+For an optimized binary (requires `binaryen` — install via `apt install binaryen` or `brew install binaryen`):
+```bash
+cd contracts/token-factory
+bash build.sh
+```
+This produces `target/wasm32-unknown-unknown/release/token_factory.optimized.wasm`, which is significantly smaller and lowers on-chain deployment costs.
+
 ### Run Contract Tests
 ```bash
 cd contracts/token-factory

--- a/contracts/token-factory/build.sh
+++ b/contracts/token-factory/build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WASM_DIR="../../target/wasm32-unknown-unknown/release"
+WASM_FILE="$WASM_DIR/token_factory.wasm"
+OPTIMIZED_FILE="$WASM_DIR/token_factory.optimized.wasm"
+
+echo "Building contract..."
+cargo build --target wasm32-unknown-unknown --release
+
+echo "Optimizing with wasm-opt..."
+wasm-opt -Oz "$WASM_FILE" -o "$OPTIMIZED_FILE"
+
+ORIGINAL=$(wc -c < "$WASM_FILE")
+OPTIMIZED=$(wc -c < "$OPTIMIZED_FILE")
+echo "Original:  $ORIGINAL bytes"
+echo "Optimized: $OPTIMIZED bytes"
+echo "Reduction: $(( (ORIGINAL - OPTIMIZED) * 100 / ORIGINAL ))%"


### PR DESCRIPTION
- Add contracts/token-factory/build.sh that runs cargo build then wasm-opt -Oz
- Update CI (wasm-build.yml) to install binaryen and run build.sh
- Document optimized build step in README

Closes #95