### PR TITLE
feat: add useTokens pagination and useTokenInfo hook

### DIFF
--- a/frontend/src/hooks/useTokenInfo.ts
+++ b/frontend/src/hooks/useTokenInfo.ts
@@ -1,0 +1,92 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { stellarService } from '../services/stellar'
+import type { TokenInfo } from '../types'
+
+// ── Module-level cache keyed by token address ─────────────────────────────────
+// Shared across all hook instances so multiple components showing the same
+// token don't each fire a separate RPC call within the TTL window.
+
+const CACHE_TTL_MS = 30_000
+
+interface CacheEntry {
+  info: TokenInfo
+  fetchedAt: number
+}
+
+const cache = new Map<string, CacheEntry>()
+
+/** Exposed for testing only */
+export function _clearTokenInfoCache() {
+  cache.clear()
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface UseTokenInfoResult {
+  token: TokenInfo | null
+  isLoading: boolean
+  error: Error | null
+  /** Bypass cache and re-fetch */
+  refresh: () => void
+}
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Fetches and caches the on-chain details for a single token by its contract address.
+ * Returns null while loading or when address is empty.
+ */
+export function useTokenInfo(address: string): UseTokenInfoResult {
+  const [token, setToken] = useState<TokenInfo | null>(
+    () => cache.get(address)?.info ?? null,
+  )
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+
+  // Guard against duplicate in-flight requests
+  const fetchingRef = useRef(false)
+
+  const load = useCallback(
+    async (bypassCache: boolean) => {
+      if (!address) {
+        setToken(null)
+        return
+      }
+
+      const now = Date.now()
+      const hit = cache.get(address)
+
+      if (!bypassCache && hit && now - hit.fetchedAt < CACHE_TTL_MS) {
+        setToken(hit.info)
+        return
+      }
+
+      if (fetchingRef.current) return
+      fetchingRef.current = true
+
+      setIsLoading(true)
+      setError(null)
+
+      try {
+        const info = await stellarService.getTokenInfo(address)
+        cache.set(address, { info, fetchedAt: Date.now() })
+        setToken(info)
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error(String(err)))
+      } finally {
+        setIsLoading(false)
+        fetchingRef.current = false
+      }
+    },
+    [address],
+  )
+
+  // Re-run whenever the address changes
+  useEffect(() => {
+    load(false)
+  }, [load])
+
+  const refresh = useCallback(() => load(true), [load])
+
+  return { token, isLoading, error, refresh }
+}

--- a/frontend/src/hooks/useTokens.test.tsx
+++ b/frontend/src/hooks/useTokens.test.tsx
@@ -75,16 +75,36 @@ describe('useTokens', () => {
     expect(result.current.tokens).toHaveLength(0)
   })
 
-  it('refetch triggers a fresh fetch', async () => {
+  it('refresh triggers a fresh fetch bypassing cache', async () => {
     vi.mocked(stellarService.getTokensByCreator).mockResolvedValue([TOKEN_A])
 
     const { result } = renderHook(() => useTokens('GABC'))
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     vi.mocked(stellarService.getTokensByCreator).mockResolvedValue([TOKEN_A, TOKEN_B])
-    await act(async () => { result.current.refetch() })
+    await act(async () => { result.current.refresh() })
 
     await waitFor(() => expect(result.current.tokens).toHaveLength(2))
     expect(stellarService.getTokensByCreator).toHaveBeenCalledTimes(2)
+  })
+
+  it('paginates tokens correctly', async () => {
+    const manyTokens = Array.from({ length: 15 }, (_, i) => ({
+      name: `Token${i}`, symbol: `TK${i}`, decimals: 7, creator: 'GABC', createdAt: i,
+    }))
+    vi.mocked(stellarService.getTokensByCreator).mockResolvedValue(manyTokens)
+
+    const { result } = renderHook(() => useTokens('GABC'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    // Default pageSize=10, page=1
+    expect(result.current.tokens).toHaveLength(10)
+    expect(result.current.totalCount).toBe(15)
+    expect(result.current.totalPages).toBe(2)
+
+    // Navigate to page 2
+    act(() => { result.current.setPage(2) })
+    expect(result.current.tokens).toHaveLength(5)
+    expect(result.current.page).toBe(2)
   })
 })

--- a/frontend/src/hooks/useTokens.ts
+++ b/frontend/src/hooks/useTokens.ts
@@ -1,9 +1,12 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { stellarService } from '../services/stellar'
 import { STELLAR_CONFIG } from '../config/stellar'
 import type { TokenInfo } from '../types'
 
 // ── Module-level cache keyed by creator address ('' = all tokens) ─────────────
+// Shared across all hook instances — any component mounting within the TTL
+// window reuses the same result without an extra network round-trip.
+
 const CACHE_TTL_MS = 30_000
 
 interface CacheEntry {
@@ -14,11 +17,13 @@ interface CacheEntry {
 const cache = new Map<string, CacheEntry>()
 
 /** Exposed for testing only */
-export function _clearCache() { cache.clear() }
+export function _clearCache() {
+  cache.clear()
+}
 
 // ── Parallel token fetcher ────────────────────────────────────────────────────
 
-async function fetchTokens(creator?: string): Promise<TokenInfo[]> {
+async function fetchAllTokens(creator?: string): Promise<TokenInfo[]> {
   const contractId = STELLAR_CONFIG.factoryContractId
   if (!contractId) throw new Error('VITE_FACTORY_CONTRACT_ID is not configured')
 
@@ -26,7 +31,8 @@ async function fetchTokens(creator?: string): Promise<TokenInfo[]> {
     return stellarService.getTokensByCreator(creator)
   }
 
-  // Fetch all: get event list then resolve each token address in parallel
+  // Fetch all: collect unique token addresses from token_created events,
+  // then resolve each in parallel (failed resolutions are silently dropped).
   const { events } = await stellarService.getContractEvents(contractId, 100)
   const addresses = [
     ...new Set(
@@ -46,56 +52,109 @@ async function fetchTokens(creator?: string): Promise<TokenInfo[]> {
     .map((r) => r.value)
 }
 
-// ── Hook ──────────────────────────────────────────────────────────────────────
+// ── Types ─────────────────────────────────────────────────────────────────────
 
-interface UseTokensResult {
+export interface UseTokensResult {
+  /** Tokens for the current page */
   tokens: TokenInfo[]
+  /** All fetched tokens (unsliced) */
+  allTokens: TokenInfo[]
   isLoading: boolean
   error: Error | null
-  refetch: () => void
+  /** Current 1-based page number */
+  page: number
+  pageSize: number
+  totalCount: number
+  totalPages: number
+  setPage: (page: number) => void
+  setPageSize: (size: number) => void
+  /** Bypass cache and re-fetch */
+  refresh: () => void
 }
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
 
 export function useTokens(creator?: string): UseTokensResult {
   const cacheKey = creator ?? ''
-  const cached = cache.get(cacheKey)
 
-  const [tokens, setTokens] = useState<TokenInfo[]>(cached?.tokens ?? [])
+  const [allTokens, setAllTokens] = useState<TokenInfo[]>(
+    () => cache.get(cacheKey)?.tokens ?? [],
+  )
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<Error | null>(null)
+  const [page, setPageRaw] = useState(1)
+  const [pageSize, setPageSizeRaw] = useState(10)
+
+  // Prevent duplicate in-flight requests when multiple components mount at once
   const fetchingRef = useRef(false)
 
-  const load = useCallback(async (bypassCache: boolean) => {
-    const now = Date.now()
-    const hit = cache.get(cacheKey)
+  const load = useCallback(
+    async (bypassCache: boolean) => {
+      const now = Date.now()
+      const hit = cache.get(cacheKey)
 
-    if (!bypassCache && hit && now - hit.fetchedAt < CACHE_TTL_MS) {
-      setTokens(hit.tokens)
-      return
-    }
+      if (!bypassCache && hit && now - hit.fetchedAt < CACHE_TTL_MS) {
+        setAllTokens(hit.tokens)
+        return
+      }
 
-    if (fetchingRef.current) return
-    fetchingRef.current = true
+      if (fetchingRef.current) return
+      fetchingRef.current = true
 
-    setIsLoading(true)
-    setError(null)
+      setIsLoading(true)
+      setError(null)
 
-    try {
-      const result = await fetchTokens(creator)
-      cache.set(cacheKey, { tokens: result, fetchedAt: Date.now() })
-      setTokens(result)
-    } catch (err) {
-      setError(err instanceof Error ? err : new Error(String(err)))
-    } finally {
-      setIsLoading(false)
-      fetchingRef.current = false
-    }
-  }, [cacheKey, creator])
+      try {
+        const result = await fetchAllTokens(creator)
+        cache.set(cacheKey, { tokens: result, fetchedAt: Date.now() })
+        setAllTokens(result)
+        // Reset to first page whenever data is refreshed
+        setPageRaw(1)
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error(String(err)))
+      } finally {
+        setIsLoading(false)
+        fetchingRef.current = false
+      }
+    },
+    [cacheKey, creator],
+  )
 
   useEffect(() => {
     load(false)
   }, [load])
 
-  const refetch = useCallback(() => load(true), [load])
+  const refresh = useCallback(() => load(true), [load])
 
-  return { tokens, isLoading, error, refetch }
+  const totalCount = allTokens.length
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize))
+
+  const setPage = useCallback(
+    (p: number) => setPageRaw(Math.min(Math.max(1, p), totalPages)),
+    [totalPages],
+  )
+
+  const setPageSize = useCallback((size: number) => {
+    setPageSizeRaw(Math.max(1, size))
+    setPageRaw(1)
+  }, [])
+
+  const tokens = useMemo(() => {
+    const start = (page - 1) * pageSize
+    return allTokens.slice(start, start + pageSize)
+  }, [allTokens, page, pageSize])
+
+  return {
+    tokens,
+    allTokens,
+    isLoading,
+    error,
+    page,
+    pageSize,
+    totalCount,
+    totalPages,
+    setPage,
+    setPageSize,
+    refresh,
+  }
 }


### PR DESCRIPTION
closed #488 

- useTokens: add page, pageSize, totalCount, totalPages, setPage, setPageSize state; expose allTokens (unsliced) alongside paginated tokens slice; rename refetch -> refresh for consistency
- useTokenInfo: new hook for single token details by contract address, with per-address module-level cache (30s TTL) and in-flight guard
- useTokens.test: update refetch -> refresh, add pagination test

## Description

Please include a summary of the changes and the "Why" behind them.

## Related Issue

Link the issue using "Closes #XX" or "Fixes #XX".

## Type of Change

Please tick the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing Done

Please describe the tests you ran (unit tests, manual verification, etc.) to verify your changes.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes
