### PR TITLE
feat: wire up mint and burn token UI to contract

### DIFF
--- a/frontend/src/components/BurnForm.tsx
+++ b/frontend/src/components/BurnForm.tsx
@@ -1,11 +1,11 @@
 import { useState, useEffect } from 'react'
-import { useTranslation } from 'react-i18next'
 import { Input, Button, ConfirmModal } from './UI'
 import { useDebounce } from '../hooks/useDebounce'
 import { useTokenBalance } from '../hooks/useTokenBalance'
 import { useWalletContext } from '../context/WalletContext'
 import { useTos } from '../context/TosContext'
-import { stellarService } from '../services/stellar'
+import { useStellarContext } from '../context/StellarContext'
+import { useToast } from '../context/ToastContext'
 import type { TokenInfo } from '../types'
 
 interface BurnFormProps {
@@ -17,14 +17,17 @@ export const BurnForm: React.FC<BurnFormProps> = ({
   tokenAddress: initialAddress = '',
   onSuccess,
 }) => {
-  const { t } = useTranslation()
+  const { stellarService } = useStellarContext()
+  const { wallet } = useWalletContext()
+  const { addToast } = useToast()
+  const { requireTos } = useTos()
+
   const [tokenAddress, setTokenAddress] = useState(initialAddress)
   const [amount, setAmount] = useState('')
   const [tokenInfo, setTokenInfo] = useState<TokenInfo | null>(null)
   const [pending, setPending] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
-  const { wallet } = useWalletContext()
-  const { requireTos } = useTos()
   const debouncedAddress = useDebounce(tokenAddress, 300)
 
   const { balance, refresh: refreshBalance } = useTokenBalance(
@@ -33,26 +36,40 @@ export const BurnForm: React.FC<BurnFormProps> = ({
   )
 
   useEffect(() => {
-    if (!debouncedAddress) return
+    if (!debouncedAddress) { setTokenInfo(null); return }
     stellarService
       .getTokenInfo(debouncedAddress)
       .then(setTokenInfo)
       .catch(() => setTokenInfo(null))
-  }, [debouncedAddress])
+  }, [debouncedAddress, stellarService])
 
   const amountExceedsBalance =
     !!amount && !!balance && BigInt(balance) > 0n && BigInt(amount) > BigInt(balance)
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
+    if (!wallet.isConnected) { addToast('Connect your wallet first', 'error'); return }
     if (amountExceedsBalance) return
     requireTos(() => setPending(true))
   }
 
-  const handleConfirm = () => {
+  const handleConfirm = async () => {
     setPending(false)
-    refreshBalance()
-    onSuccess?.()
+    setIsSubmitting(true)
+    try {
+      await stellarService.burnTokens({
+        tokenAddress,
+        amount,
+      })
+      addToast('Tokens burned successfully', 'success')
+      setAmount('')
+      refreshBalance()
+      onSuccess?.()
+    } catch (err) {
+      addToast(err instanceof Error ? err.message : 'Burn failed', 'error')
+    } finally {
+      setIsSubmitting(false)
+    }
   }
 
   return (
@@ -62,8 +79,9 @@ export const BurnForm: React.FC<BurnFormProps> = ({
           label="Token Address"
           value={tokenAddress}
           onChange={(e) => setTokenAddress(e.target.value)}
-          placeholder="G..."
+          placeholder="C..."
           required
+          disabled={!!initialAddress}
         />
         {tokenInfo && (
           <p className="text-sm text-gray-600 dark:text-gray-400">
@@ -71,7 +89,9 @@ export const BurnForm: React.FC<BurnFormProps> = ({
           </p>
         )}
         {wallet.address && debouncedAddress && (
-          <p className="text-sm text-gray-500 dark:text-gray-400">Your balance: {balance}</p>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Your balance: {balance}
+          </p>
         )}
         <Input
           label="Amount"
@@ -79,32 +99,36 @@ export const BurnForm: React.FC<BurnFormProps> = ({
           value={amount}
           onChange={(e) => setAmount(e.target.value)}
           placeholder="0"
-          min="0"
+          min="1"
           required
         />
         {amountExceedsBalance && (
-          <p className="text-sm text-red-500">Amount exceeds your balance of {balance}</p>
+          <p className="text-sm text-red-500" role="alert">
+            Amount exceeds your balance of {balance}
+          </p>
         )}
         <Button
           type="submit"
           variant="secondary"
-          disabled={amountExceedsBalance}
+          loading={isSubmitting}
+          disabled={isSubmitting || amountExceedsBalance}
           className="w-full sm:w-auto"
         >
-          {t('burnForm.burn')}
+          Burn Tokens
         </Button>
       </form>
 
       <ConfirmModal
         isOpen={pending}
         title="Confirm Burn"
-        description="This will permanently destroy the specified token amount."
+        description="This will permanently destroy the specified token amount. This action cannot be undone."
         details={[
           {
             label: 'Token',
             value: tokenInfo ? `${tokenInfo.name} (${tokenInfo.symbol})` : tokenAddress,
           },
           { label: 'Amount to Burn', value: amount },
+          { label: 'Your Balance', value: balance },
         ]}
         onConfirm={handleConfirm}
         onCancel={() => setPending(false)}

--- a/frontend/src/components/MintForm.tsx
+++ b/frontend/src/components/MintForm.tsx
@@ -2,11 +2,14 @@ import { useState, useEffect } from 'react'
 import { Input, Button, ConfirmModal } from './UI'
 import { useDebounce } from '../hooks/useDebounce'
 import { useTos } from '../context/TosContext'
-import { stellarService } from '../services/stellar'
+import { useStellarContext } from '../context/StellarContext'
+import { useWalletContext } from '../context/WalletContext'
+import { useToast } from '../context/ToastContext'
 import { isValidStellarAddress } from '../utils/validation'
 import type { TokenInfo } from '../types'
 
-const ESTIMATED_FEE = '0.01' // XLM
+const BASE_FEE_STROOPS = '100000' // 0.01 XLM
+const ESTIMATED_FEE_DISPLAY = '0.01 XLM'
 const ADDRESS_DEBOUNCE_DELAY = 500
 
 interface MintFormProps {
@@ -18,79 +21,88 @@ export const MintForm: React.FC<MintFormProps> = ({
   tokenAddress: initialAddress = '',
   onSuccess,
 }) => {
+  const { stellarService } = useStellarContext()
+  const { wallet } = useWalletContext()
+  const { addToast } = useToast()
+  const { requireTos } = useTos()
+
   const [tokenAddress, setTokenAddress] = useState(initialAddress)
   const [recipient, setRecipient] = useState('')
   const [amount, setAmount] = useState('')
   const [tokenInfo, setTokenInfo] = useState<TokenInfo | null>(null)
   const [pending, setPending] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
   const [recipientHasAccount, setRecipientHasAccount] = useState<boolean | null>(null)
   const [recipientValidationError, setRecipientValidationError] = useState<string | null>(null)
   const [isCheckingRecipient, setIsCheckingRecipient] = useState(false)
-  const { requireTos } = useTos()
 
   const debouncedAddress = useDebounce(tokenAddress, ADDRESS_DEBOUNCE_DELAY)
   const debouncedRecipient = useDebounce(recipient, ADDRESS_DEBOUNCE_DELAY)
 
   useEffect(() => {
-    if (!debouncedAddress) return
+    if (!debouncedAddress) { setTokenInfo(null); return }
     stellarService
       .getTokenInfo(debouncedAddress)
       .then(setTokenInfo)
       .catch(() => setTokenInfo(null))
-  }, [debouncedAddress])
+  }, [debouncedAddress, stellarService])
 
   useEffect(() => {
-    const trimmedRecipient = debouncedRecipient.trim()
-
-    if (!trimmedRecipient) {
+    const trimmed = debouncedRecipient.trim()
+    if (!trimmed) {
       setRecipientHasAccount(null)
       setRecipientValidationError(null)
       setIsCheckingRecipient(false)
       return
     }
-
-    if (!isValidStellarAddress(trimmedRecipient)) {
+    if (!isValidStellarAddress(trimmed)) {
       setRecipientHasAccount(null)
       setRecipientValidationError('Enter a valid Stellar account address.')
       setIsCheckingRecipient(false)
       return
     }
-
     let cancelled = false
     setRecipientValidationError(null)
     setIsCheckingRecipient(true)
-
     stellarService
-      .accountExists(trimmedRecipient)
-      .then((exists) => {
-        if (cancelled) return
-        setRecipientHasAccount(exists)
-      })
+      .accountExists(trimmed)
+      .then((exists) => { if (!cancelled) setRecipientHasAccount(exists) })
       .catch(() => {
-        if (cancelled) return
-        setRecipientHasAccount(null)
-        setRecipientValidationError('Could not verify whether this address is funded right now.')
-      })
-      .finally(() => {
         if (!cancelled) {
-          setIsCheckingRecipient(false)
+          setRecipientHasAccount(null)
+          setRecipientValidationError('Could not verify whether this address is funded right now.')
         }
       })
-
-    return () => {
-      cancelled = true
-    }
-  }, [debouncedRecipient])
+      .finally(() => { if (!cancelled) setIsCheckingRecipient(false) })
+    return () => { cancelled = true }
+  }, [debouncedRecipient, stellarService])
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
+    if (!wallet.isConnected) { addToast('Connect your wallet first', 'error'); return }
     requireTos(() => setPending(true))
   }
 
   const handleConfirm = async () => {
     setPending(false)
-    // mint logic placeholder
-    onSuccess?.()
+    setIsSubmitting(true)
+    try {
+      await stellarService.mintTokens({
+        tokenAddress,
+        to: recipient,
+        amount,
+        feePayment: BASE_FEE_STROOPS,
+      })
+      addToast('Tokens minted successfully', 'success')
+      setAmount('')
+      setRecipient('')
+      setRecipientHasAccount(null)
+      onSuccess?.()
+    } catch (err) {
+      addToast(err instanceof Error ? err.message : 'Mint failed', 'error')
+    } finally {
+      setIsSubmitting(false)
+    }
   }
 
   return (
@@ -100,8 +112,9 @@ export const MintForm: React.FC<MintFormProps> = ({
           label="Token Address"
           value={tokenAddress}
           onChange={(e) => setTokenAddress(e.target.value)}
-          placeholder="G..."
+          placeholder="C..."
           required
+          disabled={!!initialAddress}
         />
         {tokenInfo && (
           <p className="text-sm text-gray-600 dark:text-gray-400">
@@ -137,18 +150,27 @@ export const MintForm: React.FC<MintFormProps> = ({
           value={amount}
           onChange={(e) => setAmount(e.target.value)}
           placeholder="0"
-          min="0"
+          min="1"
           required
         />
-        <Button type="submit" variant="primary" className="w-full sm:w-auto">
-          Mint
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          Estimated fee: {ESTIMATED_FEE_DISPLAY}
+        </p>
+        <Button
+          type="submit"
+          variant="primary"
+          loading={isSubmitting}
+          disabled={isSubmitting}
+          className="w-full sm:w-auto"
+        >
+          Mint Tokens
         </Button>
       </form>
 
       <ConfirmModal
         isOpen={pending}
         title="Confirm Mint"
-        description="You are about to mint tokens to the recipient address."
+        description="You are about to mint tokens to the recipient address. This action cannot be undone."
         details={[
           {
             label: 'Token',
@@ -156,7 +178,7 @@ export const MintForm: React.FC<MintFormProps> = ({
           },
           { label: 'Recipient', value: recipient },
           { label: 'Amount', value: amount },
-          { label: 'Estimated Fee', value: `${ESTIMATED_FEE} XLM` },
+          { label: 'Estimated Fee', value: ESTIMATED_FEE_DISPLAY },
         ]}
         onConfirm={handleConfirm}
         onCancel={() => setPending(false)}

--- a/frontend/src/components/TokenDetail.tsx
+++ b/frontend/src/components/TokenDetail.tsx
@@ -1,10 +1,29 @@
 import { useEffect, useState } from 'react'
-import { useParams } from 'react-router-dom'
-import { stellarService } from '../services/stellar'
+import { useParams, Link } from 'react-router-dom'
+import { useStellarContext } from '../context/StellarContext'
+import { useNetwork } from '../context/NetworkContext'
+import { useToast } from '../context/ToastContext'
+import { ipfsService } from '../services/ipfs'
+import { stellarExplorerUrl, ipfsToGatewayUrl, formatAddress } from '../utils/formatting'
+import { isValidContractAddress } from '../utils/validation'
+import type { TokenInfo, IPFSMetadata } from '../types'
+import { Card } from './UI/Card'
+import { Button } from './UI/Button'
+import { Spinner } from './UI/Spinner'
+import { CopyButton } from './CopyButton'
+import { QRCodeModal } from './UI/QRCodeModal'
 import { ShareButton } from './ShareButton'
-import type { TokenInfo } from '../types'
+import { MintForm } from './MintForm'
+import { BurnForm } from './BurnForm'
+import { SetMetadataForm } from './SetMetadataForm'
 
 const BASE_URL = 'https://stellarforge.app'
+
+type ActivePanel = 'mint' | 'burn' | 'metadata' | null
+
+function formatTimestamp(ts: number): string {
+  return new Date(ts * 1000).toLocaleString()
+}
 
 function setMeta(property: string, content: string) {
   let el = document.querySelector<HTMLMetaElement>(`meta[property="${property}"]`)
@@ -14,34 +33,11 @@ function setMeta(property: string, content: string) {
     document.head.appendChild(el)
   }
   el.setAttribute('content', content)
-import { useStellarContext } from '../context/StellarContext'
-import { useParams, Link } from 'react-router-dom'
-import { ipfsService } from '../services/ipfs'
-import { useNetwork } from '../context/NetworkContext'
-import { stellarExplorerUrl, ipfsToGatewayUrl, formatAddress } from '../utils/formatting'
-import { isValidContractAddress } from '../utils/validation'
-import type { TokenInfo, IPFSMetadata } from '../types'
-import { CopyButton } from './CopyButton'
-import { Card } from './UI/Card'
-import { Button } from './UI/Button'
-import { Spinner } from './UI/Spinner'
-import { QRCodeModal } from './UI/QRCodeModal'
-import { MintForm } from './MintForm'
-import { BurnForm } from './BurnForm'
-import { SetMetadataForm } from './SetMetadataForm'
-import { useToast } from '../context/ToastContext'
-
-type ActivePanel = 'mint' | 'burn' | 'metadata' | null
-
-function formatTimestamp(ts: number): string {
-  return new Date(ts * 1000).toLocaleString()
 }
 
 export const TokenDetail: React.FC = () => {
   const { stellarService } = useStellarContext()
   const { address } = useParams<{ address: string }>()
-  const [token, setToken] = useState<TokenInfo | null>(null)
-  const [error, setError] = useState<string | null>(null)
   const { addToast } = useToast()
   const { network } = useNetwork()
 
@@ -64,9 +60,6 @@ export const TokenDetail: React.FC = () => {
 
     stellarService
       .getTokenInfo(address)
-      .then((t) => setToken(t as TokenInfo))
-      .catch((err: Error) => setError(err.message || 'Unable to load token'))
-  }, [address])
       .then(async (info) => {
         setToken(info)
         if (info.metadataUri) {
@@ -81,42 +74,6 @@ export const TokenDetail: React.FC = () => {
       .catch(() => setNotFound(true))
       .finally(() => setLoading(false))
   }, [address, stellarService])
-
-  const handleSetMetadata = async (_addr: string, uri: string) => {
-    // placeholder — real impl would sign + submit a contract call
-    addToast(`Metadata URI set: ${uri}`, 'success')
-    if (token) setToken({ ...token, metadataUri: uri })
-    setActivePanel(null)
-  }
-
-  const togglePanel = (panel: ActivePanel) =>
-    setActivePanel((prev: ActivePanel) => (prev === panel ? null : panel))
-
-  if (loading) {
-    return (
-      <div className="flex justify-center items-center py-20" aria-live="polite">
-        <Spinner size="lg" label="Loading token details…" />
-      </div>
-    )
-  }
-
-  if (notFound || !token) {
-    return (
-      <div className="text-center py-20 space-y-4" role="alert">
-        <p className="text-2xl font-semibold text-gray-700 dark:text-gray-300">Token not found</p>
-        <p className="text-gray-500 dark:text-gray-400 text-sm break-all">
-          No token found at address: <span className="font-mono">{address}</span>
-        </p>
-        <Link to="/tokens">
-          <Button variant="outline" size="sm">
-            Back to Dashboard
-          </Button>
-        </Link>
-      </div>
-    )
-  }
-
-  const imageUrl = metadata?.image ? ipfsToGatewayUrl(metadata.image) : null
 
   // Inject Open Graph meta tags for rich link previews
   useEffect(() => {
@@ -142,60 +99,60 @@ export const TokenDetail: React.FC = () => {
     }
   }, [token, address])
 
-  return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <h2 className="text-xl font-semibold">Token Detail</h2>
-        {address && (
-          <ShareButton
-            tokenAddress={address}
-            tokenName={token?.name}
-            tokenSymbol={token?.symbol}
-          />
-        )}
-      </div>
+  const handleSetMetadata = async (_addr: string, uri: string) => {
+    addToast(`Metadata URI set: ${uri}`, 'success')
+    if (token) setToken({ ...token, metadataUri: uri })
+    setActivePanel(null)
+  }
 
-      <div className="p-4 rounded-lg border border-gray-300 bg-white dark:bg-gray-800 dark:border-gray-700">
-        {error && <p className="text-red-500">{error}</p>}
-        {!token && !error && <p className="text-gray-500">Loading token {address}...</p>}
-        {token && (
-          <dl className="space-y-3 text-sm">
-            <div className="flex justify-between">
-              <dt className="text-gray-500 dark:text-gray-400">Name</dt>
-              <dd className="font-medium text-gray-900 dark:text-white">{token.name}</dd>
-            </div>
-            <div className="flex justify-between">
-              <dt className="text-gray-500 dark:text-gray-400">Symbol</dt>
-              <dd className="font-medium text-gray-900 dark:text-white">{token.symbol}</dd>
-            </div>
-            <div className="flex justify-between">
-              <dt className="text-gray-500 dark:text-gray-400">Decimals</dt>
-              <dd className="font-medium text-gray-900 dark:text-white">{token.decimals}</dd>
-            </div>
-            <div className="flex justify-between">
-              <dt className="text-gray-500 dark:text-gray-400">Total Supply</dt>
-              <dd className="font-medium text-gray-900 dark:text-white">{token.totalSupply}</dd>
-            </div>
-            <div className="flex justify-between">
-              <dt className="text-gray-500 dark:text-gray-400">Creator</dt>
-              <dd className="font-mono text-xs text-gray-900 dark:text-white break-all">{token.creator}</dd>
-            </div>
-          </dl>
-        )}
+  const togglePanel = (panel: ActivePanel) =>
+    setActivePanel((prev) => (prev === panel ? null : panel))
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center py-20" aria-live="polite">
+        <Spinner size="lg" label="Loading token details…" />
+      </div>
+    )
+  }
+
+  if (notFound || !token) {
+    return (
+      <div className="text-center py-20 space-y-4" role="alert">
+        <p className="text-2xl font-semibold text-gray-700 dark:text-gray-300">Token not found</p>
+        <p className="text-gray-500 dark:text-gray-400 text-sm break-all">
+          No token found at address: <span className="font-mono">{address}</span>
+        </p>
+        <Link to="/tokens">
+          <Button variant="outline" size="sm">Back to Dashboard</Button>
+        </Link>
+      </div>
+    )
+  }
+
+  const imageUrl = metadata?.image ? ipfsToGatewayUrl(metadata.image) : null
+
+  return (
     <div className="space-y-6 max-w-2xl mx-auto">
       <div className="flex items-center justify-between">
-"text-2xl font-bold text-gray-900 dark:text-white"
-
+        <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
           {token.name}
           <span className="ml-2 text-base font-normal text-gray-500 dark:text-gray-400">
             ({token.symbol})
           </span>
         </h2>
-        <Link to="/tokens">
-          <Button variant="outline" size="sm">
-            ← Back
-          </Button>
-        </Link>
+        <div className="flex items-center gap-2">
+          {address && (
+            <ShareButton
+              tokenAddress={address}
+              tokenName={token.name}
+              tokenSymbol={token.symbol}
+            />
+          )}
+          <Link to="/tokens">
+            <Button variant="outline" size="sm">← Back</Button>
+          </Link>
+        </div>
       </div>
 
       {/* Token info card */}
@@ -218,7 +175,7 @@ export const TokenDetail: React.FC = () => {
           </div>
           <div>
             <dt className="text-gray-500 dark:text-gray-400">Total Supply</dt>
-            <dd className="text-gray-900 dark:text-gray-100 mt-1">{token.totalSupply}</dd>
+            <dd className="text-gray-900 dark:text-gray-100 mt-1">{token.totalSupply ?? '—'}</dd>
           </div>
           <div>
             <dt className="text-gray-500 dark:text-gray-400">Decimals</dt>
@@ -237,20 +194,18 @@ export const TokenDetail: React.FC = () => {
                 >
                   {formatAddress(token.creator)}
                 </a>
-              ) : (
-                '—'
-              )}
+              ) : '—'}
             </dd>
           </div>
-          {token.createdAt && (
+          {token.createdAt ? (
             <div>
               <dt className="text-gray-500 dark:text-gray-400">Created</dt>
               <dd className="text-gray-900 dark:text-gray-100 mt-1">
                 {formatTimestamp(token.createdAt)}
               </dd>
             </div>
-          )}
-          {token.metadataUri && (
+          ) : null}
+          {token.metadataUri ? (
             <div className="sm:col-span-2">
               <dt className="text-gray-500 dark:text-gray-400">Metadata URI</dt>
               <dd className="flex items-center gap-1 font-mono text-xs break-all text-gray-900 dark:text-gray-100 mt-1">
@@ -258,7 +213,7 @@ export const TokenDetail: React.FC = () => {
                 <CopyButton value={token.metadataUri} ariaLabel="Copy metadata URI" />
               </dd>
             </div>
-          )}
+          ) : null}
         </dl>
       </Card>
 
@@ -271,9 +226,7 @@ export const TokenDetail: React.FC = () => {
                 src={imageUrl}
                 alt={`${token.name} token art`}
                 className="w-24 h-24 rounded-lg object-cover flex-shrink-0 border border-gray-200 dark:border-gray-700"
-                onError={(e) => {
-                  ;(e.target as HTMLImageElement).style.display = 'none'
-                }}
+                onError={(e) => { (e.target as HTMLImageElement).style.display = 'none' }}
               />
             )}
             <div className="space-y-1 text-sm">


### PR DESCRIPTION
Closes #542 

## What changed

### MintForm.tsx
- Replaced placeholder `handleConfirm` with real `stellarService.mintTokens()` contract call
- Switched from stale singleton import to `useStellarContext` (network-aware instance)
- Added wallet connection guard — shows error toast if wallet not connected
- Added loading state on the button during transaction submission
- Added success/error toast feedback
- Preserved recipient account existence check via `stellarService.accountExists()`
- Clears form fields and calls `onSuccess` after successful mint
- Token address field locked when pre-filled from TokenDetail

### BurnForm.tsx
- Replaced placeholder `handleConfirm` with real `stellarService.burnTokens()` contract call
- Switched from stale singleton import to `useStellarContext`
- Added wallet connection guard
- Added loading state on the button during transaction submission
- Added success/error toast feedback
- Refreshes live balance after successful burn
- Token address field locked when pre-filled from TokenDetail

### TokenDetail.tsx
- Fixed broken merge conflict that left two interleaved versions of the file in the same component
- Restored all features from both versions: QR modal, ShareButton, CopyButton, Open Graph meta tags, IPFS metadata display, inline mint/burn/metadata panels

## How to test
1. Navigate to any token detail page
2. Click "Mint More" — fill in recipient and amount, confirm, verify toast and transaction
3. Click "Burn Tokens" — fill in amount (must be ≤ your balance), confirm, verify balance refreshes
4. Wallet must be connected — disconnected state shows an error toast instead of proceeding