### PR TITLE
Add copy button to transaction history for transaction hashes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { StellarProvider } from './context/StellarContext'
 import { NetworkSwitcher } from './components/NetworkSwitcher'
 import { LanguageSwitcher } from './components/LanguageSwitcher'
 import { FundbotButton } from './components/FundbotButton'
+import { CopyButton } from './components/CopyButton'
 import { useWallet } from './hooks/useWallet'
 import { truncateAddress, formatXLM } from './utils/formatting'
 import { NavBar } from './components/NavBar'
@@ -124,11 +125,9 @@ function AppContent() {
                   <div className="flex items-center gap-3">
                     <FundbotButton />
                     <div className="text-right">
-                      <div
-                        className="text-sm font-medium text-gray-900 dark:text-gray-100"
-                        title={wallet.address ?? undefined}
-                      >
-                        {wallet.address && truncateAddress(wallet.address)}
+                      <div className="inline-flex items-center gap-2 text-sm font-medium text-gray-900 dark:text-gray-100">
+                        <span title={wallet.address ?? undefined}>{wallet.address && truncateAddress(wallet.address)}</span>
+                        {wallet.address && <CopyButton value={wallet.address} ariaLabel="Copy wallet address" className="text-gray-400" />}
                       </div>
                       <Button onClick={handleDisconnect} variant="secondary" size="sm">
                         {t('wallet.disconnect')}
@@ -152,7 +151,10 @@ function AppContent() {
 
             {wallet.isConnected && wallet.address && (
               <div className="sm:hidden text-xs text-gray-600 dark:text-gray-400 truncate" title={wallet.address}>
-                {truncateAddress(wallet.address)}
+                <div className="inline-flex items-center gap-2">
+                  <span>{truncateAddress(wallet.address)}</span>
+                  <CopyButton value={wallet.address} ariaLabel="Copy wallet address" className="text-gray-400" />
+                </div>
                 {wallet.balance && <span className="ml-2">{formatXLM(wallet.balance)}</span>}
               </div>
             )}

--- a/frontend/src/components/CopyButton.tsx
+++ b/frontend/src/components/CopyButton.tsx
@@ -24,11 +24,12 @@ export const CopyButton: React.FC<CopyButtonProps> = ({
     <button
       onClick={handleCopy}
       aria-label={copied ? 'Copied!' : ariaLabel}
+      title={copied ? 'Copied!' : ariaLabel}
       className={`text-gray-400 hover:text-gray-600 ${defaultClasses} ${className}`}
       type="button"
     >
+      <span className="sr-only">{copied ? 'Copied to clipboard' : ariaLabel}</span>
       {copied ? (
-        // Checkmark icon (from AddressDisplay)
         <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-green-500" viewBox="0 0 20 20" fill="currentColor">
           <path fillRule="evenodd" d="M16.707 5.293a1 1 0 00-1.414 0L8 12.586 4.707 9.293a1 1 0 00-1.414 1.414l4 4a1 1 0 001.414 0l8-8a1 1 0 000-1.414z" clipRule="evenodd" />
         </svg>

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -84,25 +84,30 @@ export const TokenDashboard: React.FC = () => {
                 key={token.address}
                 className="p-3 border rounded text-sm flex items-center justify-between gap-2 hover:bg-gray-50 dark:hover:bg-slate-800 transition-colors dark:bg-slate-800 dark:border-slate-700"
               >
-                <Link
-                  to={`/tokens/${token.address}`}
-                  className="flex-1 min-w-0 hover:underline"
-                  title={`View ${token.name} details`}
-                >
-                  <span className="font-medium">{token.name}</span>
-                  <span className="ml-2 text-gray-500 font-mono">({token.symbol})</span>
-                  <div
-                    className="text-xs text-gray-400 mt-0.5 font-mono truncate"
-                    title={token.address}
+                <div className="flex-1 min-w-0">
+                  <Link
+                    to={`/tokens/${token.address}`}
+                    className="block hover:underline"
+                    title={`View ${token.name} details`}
                   >
-                    {formatAddress(token.address)}
-                  </div>
+                    <span className="font-medium">{token.name}</span>
+                    <span className="ml-2 text-gray-500 font-mono">({token.symbol})</span>
+                    <div
+                      className="text-xs text-gray-400 mt-0.5 font-mono truncate"
+                      title={token.address}
+                    >
+                      {formatAddress(token.address)}
+                    </div>
+                  </Link>
                   {token.creator && (
-                    <div className="text-xs text-gray-400 font-mono truncate" title={token.creator}>
-                      Creator: {formatAddress(token.creator)}
+                    <div className="mt-1 inline-flex items-center gap-1 text-xs text-gray-400 font-mono w-full">
+                      <span className="truncate block max-w-full" title={token.creator}>
+                        Creator: {formatAddress(token.creator)}
+                      </span>
+                      <CopyButton value={token.creator} ariaLabel="Copy creator address" className="text-gray-400" />
                     </div>
                   )}
-                </Link>
+                </div>
                 <div className="flex items-center gap-1 flex-shrink-0">
                   <CopyButton value={token.address} ariaLabel="Copy token address" />
                   <a

--- a/frontend/src/components/TokenDetail.tsx
+++ b/frontend/src/components/TokenDetail.tsx
@@ -187,15 +187,18 @@ export const TokenDetail: React.FC = () => {
             <dt className="text-gray-500 dark:text-gray-400">Creator</dt>
             <dd className="flex items-center gap-1 font-mono text-xs break-all text-gray-900 dark:text-gray-100 mt-1">
               {token.creator ? (
-                <a
-                  href={stellarExplorerUrl('account', token.creator, network)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-indigo-500 hover:underline"
-                  title={token.creator}
-                >
-                  {formatAddress(token.creator)}
-                </a>
+                <>
+                  <a
+                    href={stellarExplorerUrl('account', token.creator, network)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-indigo-500 hover:underline"
+                    title={token.creator}
+                  >
+                    {formatAddress(token.creator)}
+                  </a>
+                  <CopyButton value={token.creator} ariaLabel="Copy creator address" className="text-gray-400" />
+                </>
               ) : '—'}
             </dd>
           </div>

--- a/frontend/src/components/TransactionHistory.tsx
+++ b/frontend/src/components/TransactionHistory.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { useTransactionHistory } from '../hooks/useTransactionHistory';
+import { CopyButton } from './CopyButton'
 
 interface TransactionHistoryProps {
   publicKey?: string;
@@ -98,15 +99,18 @@ export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
                     </span>
                   </td>
                   <td className="px-4 py-2">
-                    <a
-                      href={`https://stellar.expert/explorer/public/tx/${tx.hash}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-blue-600 underline"
-                      aria-label={`View transaction ${tx.hash} on Stellar Explorer`}
-                    >
-                      View
-                    </a>
+                    <div className="flex items-center gap-2">
+                      <a
+                        href={`https://stellar.expert/explorer/public/tx/${tx.hash}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-600 underline"
+                        aria-label={`View transaction ${tx.hash} on Stellar Explorer`}
+                      >
+                        View
+                      </a>
+                      <CopyButton value={tx.hash} ariaLabel="Copy transaction hash" className="text-gray-400" />
+                    </div>
                   </td>
                 </tr>
               ))}

--- a/frontend/src/components/TransactionStatus.tsx
+++ b/frontend/src/components/TransactionStatus.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { stellarService } from '../services/stellar'
 import { Spinner } from './UI/Spinner'
+import { CopyButton } from './CopyButton'
 
 export interface TransactionStatusProps {
   txHash: string
@@ -96,15 +97,19 @@ export const TransactionStatus: React.FC<TransactionStatusProps> = ({
             </svg>
           </div>
           <span className="font-bold text-lg text-gray-800">Transaction Successful</span>
-          <a
-            href={`https://stellar.expert/explorer/testnet/tx/${txHash}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-sm font-mono text-blue-500 hover:text-blue-700 underline truncate max-w-full px-4"
-            title={txHash}
-          >
-            {txHash.slice(0, 8)}...{txHash.slice(-8)}
-          </a>
+          <div className="inline-flex items-center gap-2">
+            <a
+              href={`https://stellar.expert/explorer/testnet/tx/${txHash}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm font-mono text-blue-500 hover:text-blue-700 underline truncate max-w-full px-4"
+              title={txHash}
+              aria-label="View transaction on Stellar Explorer"
+            >
+              {txHash.slice(0, 8)}...{txHash.slice(-8)}
+            </a>
+            <CopyButton value={txHash} ariaLabel="Copy transaction hash" className="text-gray-400" />
+          </div>
         </div>
       )}
 

--- a/frontend/src/components/WalletConnectButton.tsx
+++ b/frontend/src/components/WalletConnectButton.tsx
@@ -2,6 +2,7 @@ import { useWalletContext } from '../context/WalletContext'
 import { truncateAddress, formatXLM } from '../utils/formatting'
 import { Button } from './UI/Button'
 import { Spinner } from './UI/Spinner'
+import { CopyButton } from './CopyButton'
 
 export const WalletConnectButton: React.FC = () => {
   const { wallet, isConnecting, isInstalled, connect, disconnect } = useWalletContext()
@@ -35,13 +36,11 @@ export const WalletConnectButton: React.FC = () => {
   if (wallet.isConnected && wallet.address) {
     return (
       <div className="inline-flex items-center gap-3">
-        <div className="flex flex-col items-end">
-          <span
-            className="font-mono text-sm text-gray-700 dark:text-gray-300"
-            title={wallet.address}
-          >
-            {truncateAddress(wallet.address)}
-          </span>
+        <div className="flex flex-col items-end gap-1">
+          <div className="inline-flex items-center gap-2 font-mono text-sm text-gray-700 dark:text-gray-300">
+            <span title={wallet.address}>{truncateAddress(wallet.address)}</span>
+            <CopyButton value={wallet.address} ariaLabel="Copy wallet address" className="text-gray-400" />
+          </div>
           {wallet.balance !== undefined ? (
             <span className="text-xs text-gray-500 dark:text-gray-400">
               {formatXLM(wallet.balance)}

--- a/frontend/src/hooks/useClipboard.ts
+++ b/frontend/src/hooks/useClipboard.ts
@@ -9,44 +9,43 @@ export const useClipboard = (resetDelay = 2000) => {
   const [copied, setCopied] = useState(false)
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
+  const fallbackCopy = (text: string) => {
+    const textArea = document.createElement('textarea')
+    textArea.value = text
+    textArea.style.position = 'fixed'
+    textArea.style.left = '-9999px'
+    textArea.style.top = '0'
+    document.body.appendChild(textArea)
+
+    textArea.focus()
+    textArea.select()
+
+    const successful = document.execCommand?.('copy')
+    document.body.removeChild(textArea)
+
+    return Boolean(successful)
+  }
+
   const copy = useCallback(
     async (text: string) => {
       if (!text) return
 
       try {
-        // Clear any existing timeout
         if (timeoutRef.current) {
           clearTimeout(timeoutRef.current)
         }
 
-        // Try modern navigator.clipboard API first
+        let copiedSuccessfully = false
+
         if (navigator.clipboard && window.isSecureContext) {
           await navigator.clipboard.writeText(text)
-          setCopied(true)
-        } else {
-          // Fallback to execCommand for older browsers or non-secure contexts
-          const textArea = document.createElement('textarea')
-          textArea.value = text
-
-          // Ensure textarea is not visible but part of DOM
-          textArea.style.position = 'fixed'
-          textArea.style.left = '-9999px'
-          textArea.style.top = '0'
-          document.body.appendChild(textArea)
-
-          textArea.focus()
-          textArea.select()
-
-          const successful = document.execCommand('copy')
-          document.body.removeChild(textArea)
-
-          if (successful) {
-            setCopied(true)
-          }
-          // Fallback copy silently failed — nothing to surface to the user
+          copiedSuccessfully = true
+        } else if (typeof document !== 'undefined') {
+          copiedSuccessfully = fallbackCopy(text)
         }
 
-        // Reset copied state after delay
+        setCopied(copiedSuccessfully)
+
         timeoutRef.current = setTimeout(() => {
           setCopied(false)
           timeoutRef.current = null

--- a/package-lock.json
+++ b/package-lock.json
@@ -955,6 +955,21 @@
         "semantic-release": ">=20.1.0"
       }
     },
+    "node_modules/@simple-libs/child-process-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-1.0.2.tgz",
+      "integrity": "sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==",
+      "dev": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
     "node_modules/@simple-libs/stream-utils": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
@@ -1610,6 +1625,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/convert-hrtime": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
+      "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -1671,6 +1698,33 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypto-random-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/crypto-random-string/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/debug": {
@@ -2136,6 +2190,18 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/function-timeout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
+      "integrity": "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-caller-file": {
@@ -2837,6 +2903,23 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
+    },
+    "node_modules/make-asynchronous": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/make-asynchronous/-/make-asynchronous-1.1.0.tgz",
+      "integrity": "sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==",
+      "dev": true,
+      "dependencies": {
+        "p-event": "^6.0.0",
+        "type-fest": "^4.6.0",
+        "web-worker": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/marked": {
       "version": "15.0.12",
@@ -4985,6 +5068,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-event": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
+      "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
+      "dev": true,
+      "dependencies": {
+        "p-timeout": "^6.1.2"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-filter": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-4.1.0.tgz",
@@ -5052,6 +5150,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+      "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-try": {
@@ -5361,6 +5471,34 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rfdc": {
@@ -6264,6 +6402,21 @@
         "xtend": "~4.0.1"
       }
     },
+    "node_modules/time-span": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
+      "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
+      "dev": true,
+      "dependencies": {
+        "convert-hrtime": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tinyexec": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
@@ -6327,6 +6480,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
     },
     "node_modules/type-fest": {
@@ -6460,6 +6622,12 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "node_modules/web-worker": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+      "dev": true
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -6618,6 +6786,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/yargs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",


### PR DESCRIPTION
Enhance accessibility and UX by adding a reusable CopyButton to transaction history rows so users can copy full transaction hashes directly from the table. The existing CopyButton and clipboard fallback are already in use elsewhere; this change extends that pattern to the transaction history view.