### PR TITLE
feat(contract): emit events for all state-changing functions (#482)

### DIFF
--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -233,6 +233,8 @@ impl TokenFactory {
         state.token_count = new_count;
         let index = state.token_count;
 
+        let token_name = name.clone();
+        let token_symbol = symbol.clone();
         env.storage().instance().set(&index, &TokenInfo {
             name,
             symbol,
@@ -258,7 +260,7 @@ impl TokenFactory {
         Self::extend_token_ttl(env, &token_address, index);
 
         env.events()
-            .publish((symbol_short!("created"),), (token_address.clone(), creator, index));
+            .publish((symbol_short!("created"),), (token_address.clone(), creator, token_name, token_symbol));
         Ok(token_address)
     }
 


### PR DESCRIPTION
Closes #482

## Summary
All state-changing contract functions now emit structured on-chain events, enabling indexers, explorers, and the frontend to react in real time.

## Events added / updated

- token_created (create_token) Previously emitted (token_address, creator, index); updated payload to (token_address, creator, name, symbol) as required by the issue. The index field was dropped in favour of the human-readable name/symbol pair that consumers actually need for display and filtering.

- tokens_minted (mint_tokens) Already emitted (token_address, to, amount) — no change needed.

- tokens_burned (burn) Already emitted (token_address, from, amount) — no change needed.

- metadata_set (set_metadata) Already emitted (token_address, metadata_uri) — no change needed.

- fees_updated (update_fees) Already emitted (base_fee, metadata_fee) — no change needed.