### PR TITLE
docs: add Vercel deployment guide (#505)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # StellarForge - Stellar Token Deployer
 
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/Ejirowebfi/Stellar-forge&root=frontend&env=VITE_FACTORY_CONTRACT_ID,VITE_TOKEN_WASM_HASH,VITE_IPFS_API_KEY,VITE_IPFS_API_SECRET&envDescription=Required%20environment%20variables%20for%20StellarForge&envLink=https://github.com/Ejirowebfi/Stellar-forge/blob/main/docs/deployment-vercel.md)
+
 StellarForge is a user-friendly decentralized application (dApp) that enables creators, entrepreneurs, and businesses in emerging markets to deploy custom tokens on the Stellar blockchain without writing a single line of code.
 
 ## Features
@@ -196,6 +198,8 @@ cd frontend
 npm run build
 # Deploy the dist/ folder to your hosting service (Vercel, Netlify, etc.)
 ```
+
+For a full step-by-step Vercel deployment guide see [docs/deployment-vercel.md](./docs/deployment-vercel.md).
 
 ## Project Structure
 

--- a/docs/deployment-vercel.md
+++ b/docs/deployment-vercel.md
@@ -1,0 +1,120 @@
+# Deploying StellarForge to Vercel
+
+This guide walks you through deploying the StellarForge frontend to [Vercel](https://vercel.com) from scratch.
+
+## Prerequisites
+
+- A [Vercel account](https://vercel.com/signup) (free tier is sufficient)
+- The StellarForge repo forked or pushed to your GitHub account
+- A deployed Soroban token-factory contract (see the main [README](../README.md))
+- Pinata API credentials for IPFS metadata uploads
+
+---
+
+## 1. Import the Repository
+
+1. Go to [vercel.com/new](https://vercel.com/new) and click **Add New → Project**.
+2. Select **Import Git Repository** and authorise Vercel to access your GitHub account.
+3. Find and select your `Stellar-forge` fork, then click **Import**.
+
+---
+
+## 2. Configure the Build
+
+Vercel auto-detects Vite projects. Confirm or set the following in the **Configure Project** screen:
+
+| Setting | Value |
+|---|---|
+| Framework Preset | **Vite** |
+| Root Directory | `frontend` |
+| Build Command | `npm run build` |
+| Output Directory | `dist` |
+| Install Command | `npm install` |
+
+> **Root Directory** is the most important setting. Click **Edit** next to it and type `frontend` so Vercel runs all commands inside the `frontend/` folder.
+
+---
+
+## 3. Set Environment Variables
+
+In the **Environment Variables** section of the same screen (or later under **Project → Settings → Environment Variables**), add the following:
+
+| Variable | Required | Description |
+|---|---|---|
+| `VITE_NETWORK` | No | `testnet` or `mainnet`. Defaults to `testnet`. |
+| `VITE_FACTORY_CONTRACT_ID` | **Yes** | The deployed Soroban factory contract address (`C...`). |
+| `VITE_TOKEN_WASM_HASH` | **Yes** | WASM hash of the token contract used for token creation. |
+| `VITE_IPFS_API_KEY` | **Yes** | Pinata API key — get one at [app.pinata.cloud/keys](https://app.pinata.cloud/keys). |
+| `VITE_IPFS_API_SECRET` | **Yes** | Pinata API secret. |
+
+Set each variable for the **Production**, **Preview**, and **Development** environments as appropriate. For preview deployments you may want `VITE_NETWORK=testnet` regardless of the production value.
+
+> The app will display a misconfiguration screen instead of failing silently if any required variable is missing.
+
+---
+
+## 4. Deploy
+
+Click **Deploy**. Vercel will install dependencies, run `npm run build`, and publish the `dist/` folder. The first deploy takes ~2 minutes.
+
+Once complete, Vercel assigns a URL like `https://stellar-forge-<hash>.vercel.app`.
+
+---
+
+## 5. Custom Domain
+
+1. Open your project on Vercel and go to **Settings → Domains**.
+2. Click **Add**, enter your domain (e.g. `app.stellarforge.xyz`), and click **Add**.
+3. Vercel shows the DNS records to add. In your DNS provider, add:
+   - An **A record** pointing to `76.76.21.21`, **or**
+   - A **CNAME record** pointing to `cname.vercel-dns.com` (for subdomains).
+4. Wait for DNS propagation (usually under 5 minutes with Vercel's nameservers). Vercel provisions a TLS certificate automatically.
+
+---
+
+## 6. Content Security Policy Header
+
+The repo ships a CSP `<meta>` tag in `frontend/index.html`. For stronger enforcement, add an HTTP response header via `vercel.json` in the **repo root**:
+
+```json
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; connect-src 'self' https://*.stellar.org https://api.pinata.cloud; img-src 'self' data: https://gateway.pinata.cloud; script-src 'self'"
+        }
+      ]
+    }
+  ]
+}
+```
+
+A `vercel.json` with this configuration is included at the repo root.
+
+---
+
+## 7. Preview Deployments for Pull Requests
+
+Vercel automatically creates a unique preview URL for every pull request — no extra configuration needed. Each preview is isolated and uses the environment variables you set for the **Preview** environment.
+
+**Recommended setup:**
+
+- Set `VITE_NETWORK=testnet` for the **Preview** environment so PRs always deploy against testnet.
+- Set `VITE_NETWORK=mainnet` (and production contract IDs) only for the **Production** environment.
+
+You can manage per-environment variable values under **Project → Settings → Environment Variables** by toggling the environment checkboxes next to each variable.
+
+---
+
+## 8. Redeploying After a Contract Upgrade
+
+When you deploy a new contract version and the contract ID or WASM hash changes:
+
+1. Go to **Project → Settings → Environment Variables**.
+2. Update `VITE_FACTORY_CONTRACT_ID` and/or `VITE_TOKEN_WASM_HASH`.
+3. Go to **Deployments**, find the latest production deployment, click **⋯ → Redeploy**.
+
+No code change is needed — Vercel rebuilds with the new variable values.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,13 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; connect-src 'self' https://*.stellar.org https://api.pinata.cloud; img-src 'self' data: https://gateway.pinata.cloud; script-src 'self'"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Closes #505.

## New files
docs/deployment-vercel.md
  Step-by-step guide covering:
  1. Importing the repo into Vercel
  2. Build configuration (root dir: frontend, output: dist)
  3. All required environment variables with descriptions
  4. One-click Deploy button
  5. Custom domain setup with DNS record instructions
  6. CSP HTTP header via vercel.json
  7. Preview deployments for PRs — recommended per-environment variable strategy (testnet for Preview, mainnet for Production)
  8. Redeploying after a contract upgrade without a code change

vercel.json (repo root)
  Configures the Content-Security-Policy response header for all
  routes, matching the CSP already defined as a <meta> tag in
  frontend/index.html. HTTP headers take precedence and support
  frame-ancestors and other directives the meta tag cannot.

## README changes

- Add 'Deploy with Vercel' one-click badge at the top of the README (pre-fills env var names and links to the guide for descriptions)
- Add guide link below the Frontend Deployment code block

## Acceptance criteria

- A developer with no prior Vercel experience can deploy by following the guide ✓
- All required environment variables are documented ✓
- The guide is linked from the main README ✓

