### PR TITLE
feat: add update_admin function to token factory contract (#479)

### DIFF
--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -515,6 +515,22 @@ impl TokenFactory {
         Ok(())
     }
 
+    pub fn update_admin(env: Env, current_admin: Address, new_admin: Address) -> Result<(), Error> {
+        current_admin.require_auth();
+        let mut state = Self::load_state(&env)?;
+        if state.admin != current_admin {
+            return Err(Error::Unauthorized);
+        }
+        if current_admin == new_admin {
+            return Err(Error::InvalidParameters);
+        }
+        state.admin = new_admin.clone();
+        Self::save_state(&env, &state);
+        env.events()
+            .publish((symbol_short!("adm_upd"),), (current_admin, new_admin));
+        Ok(())
+    }
+
     pub fn get_state(env: Env) -> Result<FactoryState, Error> {
         Self::load_state(&env)
     }

--- a/contracts/token-factory/src/test.rs
+++ b/contracts/token-factory/src/test.rs
@@ -532,6 +532,53 @@ fn test_transfer_admin_same_address_fails() {
     );
 }
 
+// ── update_admin ──────────────────────────────────────────────────────────────
+
+#[test]
+fn test_update_admin() {
+    let s = Setup::new();
+    let new_admin = Address::generate(&s.env);
+    s.client.update_admin(&s.admin, &new_admin);
+    assert_eq!(s.client.get_state().admin, new_admin);
+}
+
+#[test]
+fn test_update_admin_unauthorized() {
+    let s = Setup::new();
+    let stranger = Address::generate(&s.env);
+    let new_admin = Address::generate(&s.env);
+    assert_eq!(
+        s.client.try_update_admin(&stranger, &new_admin),
+        Err(Ok(Error::Unauthorized))
+    );
+}
+
+#[test]
+fn test_update_admin_same_address_fails() {
+    let s = Setup::new();
+    assert_eq!(
+        s.client.try_update_admin(&s.admin, &s.admin),
+        Err(Ok(Error::InvalidParameters))
+    );
+}
+
+#[test]
+fn test_update_admin_old_admin_loses_access() {
+    let s = Setup::new();
+    let new_admin = Address::generate(&s.env);
+    s.client.update_admin(&s.admin, &new_admin);
+
+    // Old admin can no longer pause (admin-only operation)
+    assert_eq!(
+        s.client.try_pause(&s.admin),
+        Err(Ok(Error::Unauthorized))
+    );
+
+    // New admin can perform admin-only operations
+    s.client.pause(&new_admin);
+    assert!(s.client.get_state().paused);
+}
+
 // ── reentrancy guard ──────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Add update_admin(current_admin, new_admin) as the canonical admin ownership transfer function, alongside the existing transfer_admin.

Changes to lib.rs:
- update_admin requires current_admin.require_auth() so only the key-holder of the current admin address can call it
- Validates current_admin matches state.admin, returns Unauthorized otherwise
- Rejects same-address transfers with InvalidParameters
- Writes new_admin into FactoryState and persists via save_state (which also extends instance TTL)
- Emits an ("adm_upd",) event with (current_admin, new_admin) payload so off-chain indexers can track ownership history

Changes to test.rs:
- test_update_admin: happy path — new admin is stored in state
- test_update_admin_unauthorized: stranger cannot call update_admin
- test_update_admin_same_address_fails: self-transfer returns InvalidParameters
- test_update_admin_old_admin_loses_access: after transfer, old admin is rejected by pause (admin-only op) while new admin succeeds — directly satisfies the acceptance criteria that old admin loses access and new admin gains it

resolves #479 
