### PR TITLE
feat: pause/unpause factory implemented, add burn-while-paused test 

### DIFF
--- a/contracts/token-factory/src/test.rs
+++ b/contracts/token-factory/src/test.rs
@@ -502,6 +502,23 @@ fn test_non_admin_cannot_pause() {
     assert_eq!(s.client.try_pause(&stranger), Err(Ok(Error::Unauthorized)));
 }
 
+#[test]
+fn test_burn_allowed_when_paused() {
+    let s = Setup::new();
+    let creator = Address::generate(&s.env);
+    let token_addr = seed_token_with_burn(&s, &creator, true);
+
+    let burner = Address::generate(&s.env);
+    StellarAssetClient::new(&s.env, &token_addr).mint(&burner, &500);
+
+    s.client.pause(&s.admin);
+    assert!(s.client.get_state().paused);
+
+    // burn must succeed even while the factory is paused
+    s.client.burn(&token_addr, &burner, &200);
+    assert_eq!(TokenClient::new(&s.env, &token_addr).balance(&burner), 300);
+}
+
 // ── transfer_admin ────────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Audit confirms all tasks and acceptance criteria for #480 are already satisfied by existing contract code:

Existing implementation (no changes needed):
- FactoryState.paused: bool field (lib.rs:34)
- Error::ContractPaused = 10 variant (lib.rs:57)
- require_not_paused() guard helper (lib.rs:137-140)
- pause(admin) / unpause(admin) functions with admin check (lib.rs)
- require_not_paused called at the top of create_token (lib.rs:157), set_metadata (lib.rs:272), and mint_tokens (lib.rs:331)
- burn() has no pause guard — intentional, users can always exit
- test_admin_can_pause_and_unpause: verifies state toggle
- test_non_admin_cannot_pause: verifies Unauthorized for strangers
- test_create_token_blocked_when_paused: verifies ContractPaused error

Gap closed by this commit:
- test_burn_allowed_when_paused: pauses the factory, then calls burn and asserts it succeeds and the balance is reduced correctly — directly covers the acceptance criterion 'burn is still allowed when paused (users should be able to exit)'

resolves #480 