### PR TITLE
feat: implement Token Dashboard page (#673)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,7 +20,7 @@ import { Home } from './components/Home'
 import { CreateToken } from './components/CreateToken'
 import { MintForm } from './components/MintForm'
 import { BurnForm } from './components/BurnForm'
-import { Dashboard } from './components/Dashboard'
+import { TokenDashboard } from './components/TokenDashboard'
 import { TokenDetail } from './components/TokenDetail'
 import { TokenExplorer } from './components/TokenExplorer'
 import { FAQ } from './components/FAQ'
@@ -252,7 +252,7 @@ function AppContent() {
                   element={
                     <ProtectedRoute>
                       <ErrorBoundary>
-                        <Dashboard />
+                        <TokenDashboard />
                       </ErrorBoundary>
                     </ProtectedRoute>
                   }

--- a/frontend/src/components/TokenDashboard.tsx
+++ b/frontend/src/components/TokenDashboard.tsx
@@ -1,0 +1,119 @@
+import { useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useTokenDashboard } from '../hooks/useTokenDashboard'
+import { useWalletContext } from '../context/WalletContext'
+import { TokenCard } from './TokenCard'
+import { Button } from './UI/Button'
+import { SkeletonTokenCard } from './UI/Skeleton'
+import { PaginationControls } from './UI/PaginationControls'
+
+// ── Skeleton grid shown while loading ─────────────────────────────────────────
+
+const LoadingSkeleton: React.FC = () => (
+  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4" aria-busy="true" aria-label="Loading tokens">
+    {Array.from({ length: 6 }).map((_, i) => (
+      <SkeletonTokenCard key={i} />
+    ))}
+  </div>
+)
+
+// ── Empty state ───────────────────────────────────────────────────────────────
+
+const EmptyState: React.FC<{ onCreateToken: () => void }> = ({ onCreateToken }) => (
+  <div className="flex flex-col items-center justify-center py-16 text-center gap-4">
+    <div className="text-5xl" aria-hidden="true">🪙</div>
+    <h2 className="text-xl font-semibold text-gray-800 dark:text-gray-100">No tokens yet</h2>
+    <p className="text-sm text-gray-500 dark:text-gray-400 max-w-xs">
+      You haven't deployed any tokens from this wallet. Create your first token to get started.
+    </p>
+    <Button onClick={onCreateToken}>Create Token</Button>
+  </div>
+)
+
+// ── Error state ───────────────────────────────────────────────────────────────
+
+const ErrorState: React.FC<{ message: string; onRetry: () => void }> = ({ message, onRetry }) => (
+  <div className="flex flex-col items-center justify-center py-16 text-center gap-4">
+    <div className="text-5xl" aria-hidden="true">⚠️</div>
+    <h2 className="text-xl font-semibold text-gray-800 dark:text-gray-100">Failed to load tokens</h2>
+    <p className="text-sm text-red-500 dark:text-red-400 max-w-sm break-words">{message}</p>
+    <Button variant="outline" onClick={onRetry}>Retry</Button>
+  </div>
+)
+
+// ── Not connected state ───────────────────────────────────────────────────────
+
+const NotConnected: React.FC = () => (
+  <div className="flex flex-col items-center justify-center py-16 text-center gap-3">
+    <div className="text-5xl" aria-hidden="true">🔌</div>
+    <h2 className="text-xl font-semibold text-gray-800 dark:text-gray-100">Wallet not connected</h2>
+    <p className="text-sm text-gray-500 dark:text-gray-400">Connect your Freighter wallet to view your tokens.</p>
+  </div>
+)
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export const TokenDashboard: React.FC = () => {
+  const { wallet } = useWalletContext()
+  const navigate = useNavigate()
+  const { rows, isLoading, error, page, totalPages, totalCount, setPage, refresh } =
+    useTokenDashboard()
+
+  const handleCreateToken = useCallback(() => navigate('/create'), [navigate])
+
+  if (!wallet.isConnected) return <NotConnected />
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">My Tokens</h1>
+          {!isLoading && !error && (
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+              {totalCount === 0
+                ? 'No tokens deployed'
+                : `${totalCount} token${totalCount !== 1 ? 's' : ''} deployed`}
+            </p>
+          )}
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" onClick={refresh} disabled={isLoading} aria-label="Refresh token list">
+            Refresh
+          </Button>
+          <Button size="sm" onClick={handleCreateToken}>
+            + Create Token
+          </Button>
+        </div>
+      </div>
+
+      {/* Content */}
+      {isLoading ? (
+        <LoadingSkeleton />
+      ) : error ? (
+        <ErrorState message={error.message} onRetry={refresh} />
+      ) : rows.length === 0 ? (
+        <EmptyState onCreateToken={handleCreateToken} />
+      ) : (
+        <>
+          <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 list-none p-0">
+            {rows.map((token) => (
+              <TokenCard key={token.address} token={token} />
+            ))}
+          </ul>
+
+          {totalPages > 1 && (
+            <PaginationControls
+              page={page}
+              totalPages={totalPages}
+              totalCount={totalCount}
+              pageSize={10}
+              onPrev={() => setPage(page - 1)}
+              onNext={() => setPage(page + 1)}
+            />
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/hooks/useTokenDashboard.ts
+++ b/frontend/src/hooks/useTokenDashboard.ts
@@ -28,12 +28,16 @@ export function useTokenDashboard(): UseTokenDashboardResult {
   const { wallet } = useWalletContext()
 
   const [allRows, setAllRows] = useState<TokenRow[]>([])
-  const [totalCount, setTotalCount] = useState(0)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<Error | null>(null)
   const [page, setPageRaw] = useState(1)
   const fetchingRef = useRef(false)
 
+  // Filter to only the connected wallet's tokens
+  const myRows = allRows.filter(
+    (r) => wallet.address && r.creator.toLowerCase() === wallet.address.toLowerCase(),
+  )
+  const totalCount = myRows.length
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE))
 
   const setPage = useCallback(
@@ -52,42 +56,38 @@ export function useTokenDashboard(): UseTokenDashboardResult {
         const contractId = STELLAR_CONFIG.factoryContractId
         if (!contractId) throw new Error('VITE_FACTORY_CONTRACT_ID is not configured')
 
-        // 1. Get total token count via get_state()
+        // Step 1: get total token count via get_state()
         const state = await stellarService.getFactoryState()
         const count = state.tokenCount
-        setTotalCount(count)
 
         if (count === 0) {
           setAllRows([])
           return
         }
 
-        // 2. Build index→address map from token_created events
-        //    The contract emits: (token_address, creator, index)
+        // Step 2: build index→address map from token_created events
         const { events } = await stellarService.getContractEvents(contractId, 200)
         const indexToAddress = new Map<number, string>()
         for (const e of events) {
           if (e.type === 'token_created' && e.data.tokenAddress) {
-            // index is stored in data — fall back to position if missing
             const idx = e.data.index !== undefined ? Number(e.data.index) : -1
             if (idx >= 0) indexToAddress.set(idx, e.data.tokenAddress)
           }
         }
 
-        // 3. Fetch token info by index for all tokens (Promise.all for parallelism)
-        //    Indices are 1-based in the contract (incremented before storing)
+        // Step 3: fetch token info for all indices in parallel (1-based)
         const indices = Array.from({ length: count }, (_, i) => i + 1)
         const results = await Promise.allSettled(
           indices.map((i) => stellarService.getTokenInfo(i)),
         )
 
+        // Step 4: assemble rows — client-side filter by creator happens in render
         const rows: TokenRow[] = results
           .map((r, i) => {
             if (r.status !== 'fulfilled') return null
-            const info = r.value
             const address = indexToAddress.get(indices[i]) ?? ''
             if (!address) return null
-            return { ...info, address } as TokenRow
+            return { ...r.value, address } as TokenRow
           })
           .filter((r): r is TokenRow => r !== null)
 
@@ -103,14 +103,21 @@ export function useTokenDashboard(): UseTokenDashboardResult {
     [stellarService],
   )
 
+  // Re-fetch when wallet connects; clear data when wallet disconnects or switches
   useEffect(() => {
-    if (wallet.isConnected) load()
-  }, [load, wallet.isConnected])
+    if (wallet.isConnected) {
+      load()
+    } else {
+      setAllRows([])
+      setError(null)
+      setPageRaw(1)
+    }
+  }, [load, wallet.isConnected, wallet.address])
 
   const refresh = useCallback(() => load(true), [load])
 
   const start = (page - 1) * PAGE_SIZE
-  const rows = allRows.slice(start, start + PAGE_SIZE)
+  const rows = myRows.slice(start, start + PAGE_SIZE)
 
   return {
     rows,


### PR DESCRIPTION

## Summary

Implements the "My Tokens" dashboard page that fetches and displays all tokens deployed by the currently connected wallet.

## Changes

### `frontend/src/components/TokenDashboard.tsx` (new)
Main page container wired to the `/tokens` route. Handles all UI states:
- **Loading** — 6-card skeleton grid matching the `TokenCard` layout
- **Empty** — clean empty state with a "Create Token" CTA button
- **Error** — error message with a "Retry" button
- **Loaded** — responsive token grid + pagination

### `frontend/src/hooks/useTokenDashboard.ts` (updated)
- Filters fetched tokens client-side: `creator === connectedAddress`
- Clears token list and resets pagination when the wallet disconnects or switches accounts (reactive to `wallet.address`)

### `frontend/src/App.tsx` (updated)
- Swaps the generic `Dashboard` component for `TokenDashboard` on the `/tokens` route

## Architecture


TokenDashboard (page container)
├── useTokenDashboard (data fetching + wallet-filtered state)
├── TokenCard (existing, reused per token)
├── SkeletonTokenCard (loading state grid)
├── EmptyState (no tokens + CTA)
├── ErrorState (error + retry)
└── PaginationControls (existing, reused)

## Data Flow

1. `get_state()` → total `token_count`
2. `getContractEvents()` → build `index → address` map
3. `getTokenInfo(index)` × N in parallel via `Promise.allSettled`
4. Client-side filter: `creator === wallet.address`

## UX

- Responsive grid: 1 col (mobile) → 2 col (sm) → 3 col (lg)
- List clears immediately on wallet disconnect/switch — no stale data shown
- Retry re-fetches from scratch (bypasses any in-flight guard)

## Testing

- No pre-existing type errors introduced (confirmed via `tsc --noEmit`)
- Reuses battle-tested primitives: `TokenCard`, `CopyButton`, `SkeletonTokenCard`, `PaginationControls`, `Button`

Closes #673