### PR TITLE
feat: add client-side routing with react-router-dom (fixes #471)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,8 @@ import { TokenDetail } from './components/TokenDetail'
 import { TokenExplorer } from './components/TokenExplorer'
 import { AdminPanel } from './components/AdminPanel'
 import { MetadataForm } from './components/MetadataForm'
+import { Manage } from './components/Manage'
+import { NotFound } from './components/NotFound'
 import { useFactoryState } from './hooks/useFactoryState'
 import { isFactoryConfigured } from './config/env'
 import ErrorBoundary from './components/ErrorBoundary'
@@ -237,7 +239,37 @@ function AppContent() {
                     </ProtectedRoute>
                   }
                 />
-                <Route path="*" element={<Navigate to="/" replace />} />
+                <Route
+                  path="/dashboard"
+                  element={
+                    <ProtectedRoute>
+                      <ErrorBoundary>
+                        <TokenDashboard />
+                      </ErrorBoundary>
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/token/:address"
+                  element={
+                    <ProtectedRoute>
+                      <ErrorBoundary>
+                        <TokenDetail />
+                      </ErrorBoundary>
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/manage"
+                  element={
+                    <ProtectedRoute>
+                      <ErrorBoundary>
+                        <Manage />
+                      </ErrorBoundary>
+                    </ProtectedRoute>
+                  }
+                />
+                <Route path="*" element={<NotFound />} />
               </Routes>
             </div>
         </div>

--- a/frontend/src/components/Manage.tsx
+++ b/frontend/src/components/Manage.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export const Manage: React.FC = () => {
+  return <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Manage Tokens</h2>
+}

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -36,6 +36,12 @@ export const NavBar: React.FC<NavBarProps> = ({ onHelpClick, isAdmin = false }) 
         <NavLink to="/tokens" className={getLinkClass}>
           {t('nav.tokens')}
         </NavLink>
+        <NavLink to="/dashboard" className={getLinkClass}>
+          {t('nav.dashboard', 'Dashboard')}
+        </NavLink>
+        <NavLink to="/manage" className={getLinkClass}>
+          {t('nav.manage', 'Manage')}
+        </NavLink>
         <NavLink to="/explorer" className={getLinkClass}>
           {t('nav.explorer', 'Explorer')}
         </NavLink>


### PR DESCRIPTION
PR Description:
  
  ## Summary
  
  Implements client-side routing with `react-router-dom` to resolve #471.
  
  ## Changes
  
  - **App.tsx** — Added `/dashboard`, `/token/:address`, and `/manage` routes. Fixed wildcard `*` to render the `NotFound` component instead of silently
  redirecting to `/`
  - **NavBar.tsx** — Added `Dashboard` and `Manage` nav links
  - **Manage.tsx** — New stub component for the `/manage` route
  
  ## Notes
  
  `react-router-dom` was already installed and `BrowserRouter` was already wrapping the app with all context providers (including `WalletProvider`) above
  the route layer, so wallet state is preserved across navigation.
  
  The existing routes (`/tokens`, `/tokens/:address`, etc.) are kept intact — the new routes are additive.
  
  ## Testing
  
  - Navigate to `/dashboard` → renders TokenDashboard
  - Navigate to `/token/:address` → renders TokenDetail
  - Navigate to `/manage` → renders Manage stub
  - Navigate to any unknown path → renders NotFound (404)
  - Browser back/forward navigation works
  - Wallet connection persists across route changes
  closes #471 