### PR TITLE
feat: implement TokenDetail page (#470)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -207,6 +207,16 @@ function AppContent() {
                   }
                 />
                 <Route
+                  path="/token/:address"
+                  element={
+                    <ProtectedRoute>
+                      <ErrorBoundary>
+                        <TokenDetail />
+                      </ErrorBoundary>
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
                   path="/explorer"
                   element={
                     <ErrorBoundary>

--- a/frontend/src/components/TokenDetail.tsx
+++ b/frontend/src/components/TokenDetail.tsx
@@ -215,6 +215,24 @@ export const TokenDetail: React.FC = () => {
               ) : '—'}
             </dd>
           </div>
+          {/* TODO: fetch per-token admin via direct token contract call once a
+              getTokenAdmin(tokenAddress) RPC method is available. For now the
+              token creator and the Soroban token admin are the same at deploy time. */}
+          <div>
+            <dt className="text-gray-500 dark:text-gray-400">Admin</dt>
+            <dd className="flex items-center gap-1 font-mono text-xs break-all text-gray-900 dark:text-gray-100 mt-1">
+              {token.creator ? (
+                <ExplorerLink
+                  type="account"
+                  value={token.creator}
+                  network={network}
+                  label={formatAddress(token.creator)}
+                  ariaLabel={`View admin account ${token.creator} on Stellar Expert`}
+                  className="text-indigo-500 hover:underline"
+                />
+              ) : '—'}
+            </dd>
+          </div>
           {token.createdAt ? (
             <div>
               <dt className="text-gray-500 dark:text-gray-400">Created</dt>

--- a/frontend/src/components/TokenHistory.tsx
+++ b/frontend/src/components/TokenHistory.tsx
@@ -58,16 +58,20 @@ export const TokenHistory: React.FC<TokenHistoryProps> = ({ tokenAddress }) => {
 
   const getEventIcon = (type: string) => {
     switch (type) {
-      case 'token_created':
+      case 'created':
         return '🎉'
-      case 'tokens_minted':
+      case 'mint':
         return '➕'
-      case 'tokens_burned':
+      case 'burn':
         return '🔥'
-      case 'metadata_set':
+      case 'meta':
         return '📝'
-      case 'fees_updated':
+      case 'fees':
         return '💰'
+      case 'pause':
+        return '⏸️'
+      case 'unpause':
+        return '▶️'
       default:
         return '📋'
     }
@@ -75,16 +79,20 @@ export const TokenHistory: React.FC<TokenHistoryProps> = ({ tokenAddress }) => {
 
   const getEventLabel = (type: string) => {
     switch (type) {
-      case 'token_created':
+      case 'created':
         return 'Token Created'
-      case 'tokens_minted':
+      case 'mint':
         return 'Tokens Minted'
-      case 'tokens_burned':
+      case 'burn':
         return 'Tokens Burned'
-      case 'metadata_set':
+      case 'meta':
         return 'Metadata Set'
-      case 'fees_updated':
+      case 'fees':
         return 'Fees Updated'
+      case 'pause':
+        return 'Contract Paused'
+      case 'unpause':
+        return 'Contract Unpaused'
       default:
         return type
     }
@@ -94,7 +102,7 @@ export const TokenHistory: React.FC<TokenHistoryProps> = ({ tokenAddress }) => {
     const { type, data } = event
 
     switch (type) {
-      case 'token_created':
+      case 'created':
         return (
           <div className="space-y-1">
             <div className="flex items-center gap-2">
@@ -110,7 +118,7 @@ export const TokenHistory: React.FC<TokenHistoryProps> = ({ tokenAddress }) => {
           </div>
         )
 
-      case 'tokens_minted':
+      case 'mint':
         return (
           <div className="space-y-1">
             <div className="flex items-center gap-2">
@@ -132,7 +140,7 @@ export const TokenHistory: React.FC<TokenHistoryProps> = ({ tokenAddress }) => {
           </div>
         )
 
-      case 'tokens_burned':
+      case 'burn':
         return (
           <div className="space-y-1">
             <div className="flex items-center gap-2">
@@ -154,7 +162,7 @@ export const TokenHistory: React.FC<TokenHistoryProps> = ({ tokenAddress }) => {
           </div>
         )
 
-      case 'metadata_set':
+      case 'meta':
         return (
           <div className="space-y-1">
             <div className="flex items-center gap-2">
@@ -166,7 +174,7 @@ export const TokenHistory: React.FC<TokenHistoryProps> = ({ tokenAddress }) => {
           </div>
         )
 
-      case 'fees_updated':
+      case 'fees':
         return (
           <div className="space-y-1">
             <div className="flex items-center gap-2">

--- a/frontend/src/services/stellar.ts
+++ b/frontend/src/services/stellar.ts
@@ -788,6 +788,10 @@ export class StellarService {
     const createdEvent = events.find(
       (e) => e.type === 'created' && e.data.tokenAddress === tokenAddress,
     )
+    // Most-recent metadata event for this token
+    const metaEvent = events
+      .filter((e) => e.type === 'meta' && e.data.tokenAddress === tokenAddress)
+      .sort((a, b) => b.ledger - a.ledger)[0]
 
     return {
       name: createdEvent?.data.name ?? tokenAddress,
@@ -795,6 +799,7 @@ export class StellarService {
       decimals: 7,
       creator: createdEvent?.data.creator ?? '',
       createdAt: createdEvent?.timestamp ?? 0,
+      metadataUri: metaEvent?.data.metadataUri,
     }
   }
 


### PR DESCRIPTION
 PR Description:
  
  ## Summary
  
  Implements the TokenDetail page for issue #470.
  
  ## Changes
  
  - **Routing** (`App.tsx`): Added `/token/:address` route alias alongside the existing `/tokens/:address` route. Both render `TokenDetail` wrapped in
  `ProtectedRoute` and `ErrorBoundary`.
  
  - **Token info** (`services/stellar.ts`): `getTokenInfoByAddress` now extracts `metadataUri` from the most-recent `meta` event for the token, so the
  detail page can display IPFS image and description without a separate call.
  
  - **Admin display** (`components/TokenDetail.tsx`): Added an "Admin" row to the token info card. Stubbed to the creator address with a `TODO` comment —
  a direct token contract query is needed once a `getTokenAdmin(tokenAddress)` RPC method is available.
  
  - **Event type fix** (`components/TokenHistory.tsx`): Fixed a mismatch between the event type strings the component expected (`token_created`,
  `tokens_minted`, `tokens_burned`, `metadata_set`, `fees_updated`) and what the service actually emits (`created`, `mint`, `burn`, `meta`, `fees`).
  Events were silently falling through to the default case, showing wrong icons and labels.
  
  ## Acceptance criteria
  
  - [x] `/token/:address` renders name, symbol, decimals, total supply, admin, metadata URI
  - [x] IPFS image and description render when metadata URI is present
  - [x] Recent mint/burn transactions display with amount and timestamp
  - [x] Copy button copies the token address to clipboard
  
  ## Notes
  
  - No new libraries added
  - `package-lock.json` excluded from this PR (unchanged by feature code)
  closes #470 