### PR TITLE
feat: implement responsive mobile layout (issue #616)

### DIFF
--- a/frontend/src/components/FAQ.tsx
+++ b/frontend/src/components/FAQ.tsx
@@ -36,11 +36,11 @@ export const FAQ: React.FC = () => {
 
   return (
     <div className="max-w-4xl mx-auto">
-      <div className="text-center mb-12">
-        <h2 className="text-4xl font-bold text-gray-900 dark:text-white mb-6">
+      <div className="text-center mb-6 sm:mb-12">
+        <h2 className="text-2xl sm:text-4xl font-bold text-gray-900 dark:text-white mb-4 sm:mb-6">
           {t('faq.title', 'Frequently Asked Questions')}
         </h2>
-        <p className="text-xl text-gray-600 mb-8">
+        <p className="text-base sm:text-xl text-gray-600 mb-4 sm:mb-8">
           {t('faq.subtitle', 'Find answers to common questions about token creation, fees, and Stellar network.')}
         </p>
         <div className="max-w-md mx-auto">

--- a/frontend/src/components/LanguageSwitcher.tsx
+++ b/frontend/src/components/LanguageSwitcher.tsx
@@ -23,7 +23,7 @@ export const LanguageSwitcher: React.FC = () => {
         value={lang}
         onChange={handleChange}
         aria-label={t('language.label')}
-        className="rounded border border-gray-300 bg-white px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        className="rounded border border-gray-300 bg-white px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 min-h-[44px] dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
       >
         {LANGUAGES.map(({ code, label }) => (
           <option key={code} value={code}>

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { NavLink } from 'react-router-dom'
 
@@ -9,39 +9,69 @@ interface NavBarProps {
 
 export const NavBar: React.FC<NavBarProps> = ({ onHelpClick, isAdmin = false }) => {
   const { t } = useTranslation()
+  const [menuOpen, setMenuOpen] = useState(false)
 
   const getLinkClass = ({ isActive }: { isActive: boolean }) =>
     `block px-3 sm:px-4 py-2 sm:py-3 rounded-md text-xs sm:text-sm font-medium min-h-[44px] flex items-center justify-center dark:text-gray-300 ${
       isActive ? 'bg-blue-600 text-white dark:bg-blue-500' : 'text-gray-700 hover:bg-gray-200 dark:text-white dark:hover:bg-slate-700'
     }`
 
+  const closeMenu = () => setMenuOpen(false)
+
   return (
     <nav aria-label={t('nav.ariaLabel')} className="mt-3 sm:mt-4 mb-3 sm:mb-4 bg-white/50 dark:bg-slate-800/50 backdrop-blur-sm rounded-xl p-3 sm:p-4">
-      <div className="flex flex-wrap gap-2 items-center justify-center sm:justify-start">
-        <NavLink to="/" className={getLinkClass} end>
+      {/* Mobile: hamburger toggle */}
+      <div className="flex items-center justify-between sm:hidden">
+        <span className="text-xs font-medium text-gray-500 dark:text-gray-400">Navigation</span>
+        <button
+          onClick={() => setMenuOpen((o) => !o)}
+          aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+          aria-expanded={menuOpen}
+          aria-controls="nav-links"
+          className="p-2 rounded-md text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-slate-700 min-h-[44px] min-w-[44px] flex items-center justify-center"
+        >
+          {menuOpen ? (
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          ) : (
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+          )}
+        </button>
+      </div>
+
+      {/* Links: hidden on mobile unless open, always shown on sm+ */}
+      <div
+        id="nav-links"
+        className={`${menuOpen ? 'flex' : 'hidden'} sm:flex flex-col sm:flex-row flex-wrap gap-2 items-stretch sm:items-center sm:justify-start mt-2 sm:mt-0`}
+      >
+        <NavLink to="/" className={getLinkClass} end onClick={closeMenu}>
           {t('nav.home')}
         </NavLink>
-        <NavLink to="/create" className={getLinkClass}>
+        <NavLink to="/create" className={getLinkClass} onClick={closeMenu}>
           {t('nav.create')}
         </NavLink>
-        <NavLink to="/mint" className={getLinkClass}>
+        <NavLink to="/mint" className={getLinkClass} onClick={closeMenu}>
           {t('nav.mint')}
         </NavLink>
-        <NavLink to="/burn" className={getLinkClass}>
+        <NavLink to="/burn" className={getLinkClass} onClick={closeMenu}>
           {t('nav.burn')}
         </NavLink>
-        <NavLink to="/metadata" className={getLinkClass}>
+        <NavLink to="/metadata" className={getLinkClass} onClick={closeMenu}>
           {t('nav.metadata', 'Metadata')}
         </NavLink>
-        <NavLink to="/tokens" className={getLinkClass}>
+        <NavLink to="/tokens" className={getLinkClass} onClick={closeMenu}>
           {t('nav.tokens')}
         </NavLink>
-        <NavLink to="/explorer" className={getLinkClass}>
+        <NavLink to="/explorer" className={getLinkClass} onClick={closeMenu}>
           {t('nav.explorer', 'Explorer')}
         </NavLink>
         {isAdmin && (
           <NavLink
             to="/admin"
+            onClick={closeMenu}
             className={({ isActive }) =>
               `block px-3 sm:px-4 py-2 sm:py-3 rounded-md text-xs sm:text-sm font-medium min-h-[44px] flex items-center justify-center ${
                 isActive
@@ -55,7 +85,7 @@ export const NavBar: React.FC<NavBarProps> = ({ onHelpClick, isAdmin = false }) 
         )}
         {onHelpClick && (
           <button
-            onClick={onHelpClick}
+            onClick={() => { onHelpClick(); closeMenu() }}
             className="px-3 py-2 rounded-md text-xs sm:text-sm font-medium text-gray-500 hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-slate-700 sm:ml-auto min-h-[44px] min-w-[44px] flex items-center justify-center"
             aria-label="Open tutorial"
           >

--- a/frontend/src/components/NetworkSwitcher.tsx
+++ b/frontend/src/components/NetworkSwitcher.tsx
@@ -52,7 +52,7 @@ export const NetworkSwitcher: React.FC = () => {
           aria-haspopup="listbox"
           aria-expanded={open}
           aria-label={t('networkSwitcher.ariaLabel', { network: networkLabel(network) })}
-          className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-semibold cursor-pointer select-none transition-colors ${BADGE_COLORS[network]}`}
+          className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-semibold cursor-pointer select-none transition-colors min-h-[44px] ${BADGE_COLORS[network]}`}
         >
           <span
             className={`h-1.5 w-1.5 rounded-full ${network === 'mainnet' ? 'bg-green-500' : 'bg-yellow-500'}`}

--- a/frontend/src/components/TokenDetail.tsx
+++ b/frontend/src/components/TokenDetail.tsx
@@ -154,14 +154,14 @@ export const TokenDetail: React.FC = () => {
 
   return (
     <div className="space-y-6 max-w-2xl mx-auto">
-      <div className="flex items-center justify-between">
-        <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
-          {token.name}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <h2 className="text-2xl font-bold text-gray-900 dark:text-white min-w-0">
+          <span className="break-words">{token.name}</span>
           <span className="ml-2 text-base font-normal text-gray-500 dark:text-gray-400">
             ({token.symbol})
           </span>
         </h2>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 flex-shrink-0">
           {address && (
             <ShareButton
               tokenAddress={address}

--- a/frontend/src/components/TransactionHistory.tsx
+++ b/frontend/src/components/TransactionHistory.tsx
@@ -2,8 +2,10 @@
 import React from 'react';
 import { useTransactionHistory } from '../hooks/useTransactionHistory';
 import { useNetwork } from '../context/NetworkContext';
-import { stellarExplorerUrl } from '../utils/formatting';
+import { stellarExplorerUrl, formatTimestamp } from '../utils/formatting';
 import { ExplorerLink } from './ExplorerLink';
+import { CopyButton } from './CopyButton';
+import { useTranslation } from 'react-i18next';
 
 interface TransactionHistoryProps {
   publicKey?: string;
@@ -26,9 +28,9 @@ export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
   contractId,
   assetCodes,
   issuer,
-  contractId,
   contractIds,
 }) => {
+  const { t } = useTranslation()
   const resolvedContractIds = contractId ? [contractId, ...(contractIds ?? [])] : contractIds
   const { transactions, loading, error, hasMore, loadMore } = useTransactionHistory(publicKey, {
     assetCodes,
@@ -71,60 +73,92 @@ export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
       )}
 
       {transactions.length > 0 && (
-        <div className="overflow-x-auto">
-          <table className="min-w-full bg-white border rounded shadow">
-            <caption className="sr-only">Transaction history</caption>
-            <thead>
-              <tr>
-                <th scope="col" className="px-4 py-2">Type</th>
-                <th scope="col" className="px-4 py-2">Token</th>
-                <th scope="col" className="px-4 py-2">Amount</th>
-                <th scope="col" className="px-4 py-2">Date</th>
-                <th scope="col" className="px-4 py-2">Status</th>
-                <th scope="col" className="px-4 py-2">Link</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-200 dark:divide-slate-700">
-              {transactions.map((tx) => (
-                <tr key={tx.id} className="hover:bg-gray-50 dark:hover:bg-slate-700/50 transition-colors">
-                  <td className="px-4 py-3">
-                    <span
-                      className={`px-2 py-0.5 rounded text-[10px] uppercase font-bold ${badgeColors[tx.type] || 'bg-gray-100 text-gray-800'}`}
-                    >
-                      {t(`transactionHistory.eventLabels.${tx.type}`, { defaultValue: tx.type })}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 font-mono text-xs dark:text-gray-300">{tx.token}</td>
-                  <td className="px-4 py-3 dark:text-gray-300">{tx.amount}</td>
-                  <td className="px-4 py-3 text-gray-500 dark:text-gray-400">
-                    {formatTimestamp(new Date(tx.date).getTime() / 1000)}
-                  </td>
-                  <td className="px-4 py-3">
-                    <span
-                      className={`px-2 py-0.5 rounded text-[10px] uppercase font-bold ${badgeColors[tx.status] || 'bg-gray-100 text-gray-800'}`}
-                    >
-                      {tx.status}
-                    </span>
-                  </td>
-                  <td className="px-4 py-2">
-                    <div className="inline-flex items-center gap-2">
-                      <a
-                        href={`https://stellar.expert/explorer/public/tx/${tx.hash}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-blue-600 underline text-sm"
-                        aria-label={`View transaction ${tx.hash} on Stellar Explorer`}
-                      >
-                        View
-                      </a>
-                      <CopyButton value={tx.hash} ariaLabel={`Copy transaction hash ${tx.hash}`} />
-                    </div>
-                  </td>
+        <>
+          {/* Mobile: card list */}
+          <div className="sm:hidden space-y-3">
+            {transactions.map((tx) => (
+              <div key={tx.id} className="border border-gray-200 dark:border-gray-700 rounded-lg p-3 space-y-2 text-sm">
+                <div className="flex items-center justify-between gap-2">
+                  <span className={`px-2 py-0.5 rounded text-[10px] uppercase font-bold ${badgeColors[tx.type] || 'bg-gray-100 text-gray-800'}`}>
+                    {t(`transactionHistory.eventLabels.${tx.type}`, { defaultValue: tx.type })}
+                  </span>
+                  <span className={`px-2 py-0.5 rounded text-[10px] uppercase font-bold ${badgeColors[tx.status] || 'bg-gray-100 text-gray-800'}`}>
+                    {tx.status}
+                  </span>
+                </div>
+                <div className="font-mono text-xs text-gray-700 dark:text-gray-300 break-all">{tx.token}</div>
+                <div className="flex items-center justify-between gap-2 text-xs text-gray-500 dark:text-gray-400">
+                  <span>{tx.amount}</span>
+                  <span>{formatTimestamp(new Date(tx.date).getTime() / 1000)}</span>
+                </div>
+                <div className="flex items-center gap-2 pt-1 border-t border-gray-100 dark:border-gray-700">
+                  <a
+                    href={`https://stellar.expert/explorer/public/tx/${tx.hash}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 underline text-xs"
+                    aria-label={`View transaction ${tx.hash} on Stellar Explorer`}
+                  >
+                    View tx
+                  </a>
+                  <CopyButton value={tx.hash} ariaLabel={`Copy transaction hash ${tx.hash}`} />
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Desktop: table */}
+          <div className="hidden sm:block overflow-x-auto">
+            <table className="min-w-full bg-white border rounded shadow">
+              <caption className="sr-only">Transaction history</caption>
+              <thead>
+                <tr>
+                  <th scope="col" className="px-4 py-2">Type</th>
+                  <th scope="col" className="px-4 py-2">Token</th>
+                  <th scope="col" className="px-4 py-2">Amount</th>
+                  <th scope="col" className="px-4 py-2">Date</th>
+                  <th scope="col" className="px-4 py-2">Status</th>
+                  <th scope="col" className="px-4 py-2">Link</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody className="divide-y divide-gray-200 dark:divide-slate-700">
+                {transactions.map((tx) => (
+                  <tr key={tx.id} className="hover:bg-gray-50 dark:hover:bg-slate-700/50 transition-colors">
+                    <td className="px-4 py-3">
+                      <span className={`px-2 py-0.5 rounded text-[10px] uppercase font-bold ${badgeColors[tx.type] || 'bg-gray-100 text-gray-800'}`}>
+                        {t(`transactionHistory.eventLabels.${tx.type}`, { defaultValue: tx.type })}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 font-mono text-xs dark:text-gray-300">{tx.token}</td>
+                    <td className="px-4 py-3 dark:text-gray-300">{tx.amount}</td>
+                    <td className="px-4 py-3 text-gray-500 dark:text-gray-400">
+                      {formatTimestamp(new Date(tx.date).getTime() / 1000)}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className={`px-2 py-0.5 rounded text-[10px] uppercase font-bold ${badgeColors[tx.status] || 'bg-gray-100 text-gray-800'}`}>
+                        {tx.status}
+                      </span>
+                    </td>
+                    <td className="px-4 py-2">
+                      <div className="inline-flex items-center gap-2">
+                        <a
+                          href={`https://stellar.expert/explorer/public/tx/${tx.hash}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-blue-600 underline text-sm"
+                          aria-label={`View transaction ${tx.hash} on Stellar Explorer`}
+                        >
+                          View
+                        </a>
+                        <CopyButton value={tx.hash} ariaLabel={`Copy transaction hash ${tx.hash}`} />
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
       )}
 
       {loading && (


### PR DESCRIPTION

closes #616 
Description:
  
  ## Summary
  
  Implements mobile-first responsive layout across the app. All pages are usable at 375px/390px with no horizontal scroll.
  
  ## Changes
  
  ### NavBar — hamburger menu
  - Hide all nav links on mobile; show a ☰/✕ toggle button (`sm:hidden`)
  - Toggle link visibility with local `useState` — no external library
  - Links stack vertically on mobile, row on desktop (`flex-col sm:flex-row`)
  - Each link closes the menu on click
  
  ### TransactionHistory — responsive table
  - The 6-column table caused horizontal page scroll on mobile
  - On mobile (`sm:hidden`): render a card-per-transaction layout
  - On desktop (`hidden sm:block`): original table with `overflow-x-auto`
  - Also fixed pre-existing bug: duplicate `contractId` prop in destructure; added missing `useTranslation`, `formatTimestamp`, `CopyButton` imports
  
  ### FAQ — responsive heading sizes
  - `text-4xl` → `text-2xl sm:text-4xl`
  - `text-xl` subtitle → `text-base sm:text-xl`
  - Excessive margins halved with responsive equivalents
  
  ### TokenDetail — header overflow fix
  - Token name + action buttons row changed from `flex items-center justify-between` to `flex-col sm:flex-row`
  - Added `break-words` to token name to prevent overflow at 375px
  
  ### Touch targets (44px minimum)
  - **NetworkSwitcher**: added `min-h-[44px]` to badge trigger button
  - **LanguageSwitcher**: added `min-h-[44px]` + dark mode classes to select element
  - All buttons/inputs were already compliant via `UI/Button` and `UI/Input`
  
  ## Testing
  
  - TypeScript: `tsc --noEmit` passes with zero errors in modified files
  - Verify at 375px and 390px viewport widths — no horizontal scroll on any page
  - Hamburger opens/closes correctly; links close menu on click
