### PR TITLE
docs: add mainnet deployment checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/mainnet_deployment.yml
+++ b/.github/ISSUE_TEMPLATE/mainnet_deployment.yml
@@ -1,0 +1,72 @@
+name: Mainnet Deployment
+description: Track readiness and sign-off before deploying Stellar Forge to mainnet.
+title: "Mainnet deployment: "
+labels:
+  - deployment
+  - mainnet
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Complete the [mainnet deployment checklist](../../docs/mainnet-deployment-checklist.md) before opening this tracker for final approval.
+  - type: input
+    id: release
+    attributes:
+      label: Release commit or tag
+      description: Exact commit SHA or release tag planned for mainnet.
+      placeholder: v1.2.3 or 0123abcd
+    validations:
+      required: true
+  - type: input
+    id: network
+    attributes:
+      label: Network
+      description: Confirm the target Stellar network.
+      placeholder: mainnet
+    validations:
+      required: true
+  - type: textarea
+    id: contracts
+    attributes:
+      label: Contract IDs and artifact hashes
+      description: List each contract ID, WASM hash, and build artifact location.
+    validations:
+      required: true
+  - type: textarea
+    id: smoke-tests
+    attributes:
+      label: Testnet smoke-test evidence
+      description: Link testnet transactions, screenshots, logs, or release notes that prove the deployment path was exercised.
+    validations:
+      required: true
+  - type: textarea
+    id: rollback
+    attributes:
+      label: Rollback plan
+      description: Summarize the rollback trigger, operator, and steps.
+    validations:
+      required: true
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist confirmation
+      options:
+        - label: Contract audit status has been reviewed.
+          required: true
+        - label: WASM optimization and artifact hashes have been verified.
+          required: true
+        - label: Fee configuration and admin addresses have been reviewed.
+          required: true
+        - label: Admin key security has been approved.
+          required: true
+        - label: CSP headers and frontend mainnet configuration have been verified.
+          required: true
+        - label: Rollback owner and steps are documented.
+          required: true
+  - type: textarea
+    id: signoff
+    attributes:
+      label: Sign-off
+      description: List deployment, security, and operations reviewers.
+    validations:
+      required: true

--- a/README.md
+++ b/README.md
@@ -366,6 +366,8 @@ npm run build
 
 ⚠️ **Warning**: Mainnet deployment involves real money. Test thoroughly on testnet first!
 
+Before switching to mainnet, complete the [mainnet deployment checklist](./docs/mainnet-deployment-checklist.md).
+
 The process is identical to testnet, but:
 1. Use `--network mainnet` instead of `--network testnet`
 2. Fund your account with real XLM (buy from an exchange)

--- a/docs/mainnet-deployment-checklist.md
+++ b/docs/mainnet-deployment-checklist.md
@@ -1,0 +1,40 @@
+# Mainnet Deployment Checklist
+
+Use this checklist before promoting Stellar Forge from testnet to mainnet. Mainnet actions use real assets, so every item should be reviewed by at least one operator who did not prepare the deployment.
+
+## Readiness
+
+- [ ] Freeze the release branch and tag the exact commit that will be deployed.
+- [ ] Confirm all contract audit findings are closed, accepted, or tracked with an explicit launch decision.
+- [ ] Rebuild contracts from a clean checkout and record the resulting WASM hashes.
+- [ ] Run WASM optimization and confirm optimized artifacts match the hashes shared with reviewers.
+- [ ] Verify fee settings, network passphrase, RPC URL, and Horizon endpoint all target mainnet.
+- [ ] Store the admin key in a hardware wallet, multisig account, or other approved custody process.
+- [ ] Confirm treasury, fee collector, and emergency admin addresses are correct and funded.
+- [ ] Review frontend environment variables, CSP headers, and allowed wallet connection origins.
+- [ ] Pin or publish the final frontend build artifacts before switching traffic.
+- [ ] Run the full deployment once on testnet with the same scripts and configuration shape.
+- [ ] Complete a testnet smoke test for wallet connect, contract calls, error handling, and explorer links.
+- [ ] Prepare the mainnet transaction envelope review log before signing.
+
+## Mainnet Smoke Test
+
+- [ ] Open the deployed frontend with `VITE_NETWORK=mainnet` and verify the displayed network.
+- [ ] Connect a funded wallet and confirm the account address is shown correctly.
+- [ ] Submit a low-value contract interaction and verify it succeeds on-chain.
+- [ ] Confirm generated explorer links point to Stellar mainnet, not testnet.
+- [ ] Check browser console and API logs for CSP, RPC, or wallet adapter errors.
+
+## Rollback Plan
+
+- [ ] Keep the previous frontend build available for immediate redeploy.
+- [ ] Document the DNS, hosting, or feature-flag steps needed to restore the previous build.
+- [ ] Record the operator who can pause or disable affected contract actions.
+- [ ] Prepare a public incident note template with contact and status page links.
+- [ ] Define the decision point for rollback, including failed smoke-test criteria.
+
+## Sign-off
+
+- [ ] Deployment owner confirms all required checklist items are complete.
+- [ ] Security reviewer signs off on admin key handling and audit status.
+- [ ] Product or operations reviewer signs off on the launch window and rollback plan.


### PR DESCRIPTION
## Summary
- add a mainnet deployment checklist covering audits, WASM artifacts, fee/admin review, CSP verification, smoke tests, and rollback planning
- link the checklist from the README mainnet deployment section
- add a Mainnet Deployment issue template that references the checklist and captures sign-off evidence

Closes #759.

## Validation
- git diff --check