### PR TITLE
test: cover contract error parsing

### DIFF
--- a/frontend/src/test/contractErrors.test.ts
+++ b/frontend/src/test/contractErrors.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { CONTRACT_ERROR_MESSAGES, parseContractError } from '../utils/contractErrors'
+
+describe('parseContractError', () => {
+  it('maps every known contract error code to its user-facing message', () => {
+    for (const [rawCode, expectedMessage] of Object.entries(CONTRACT_ERROR_MESSAGES)) {
+      const parsed = parseContractError(new Error(`HostError: Error(Contract, ${rawCode})`))
+
+      expect(parsed).toBeInstanceOf(Error)
+      expect(parsed.message).toBe(expectedMessage)
+    }
+  })
+
+  it('returns a non-empty fallback for unknown contract error codes', () => {
+    const parsed = parseContractError('transaction failed: Error(Contract, 999)')
+
+    expect(parsed.message).toBe('An unexpected contract error occurred (code 999).')
+  })
+
+  it.each([
+    'Error(Contract, abc)',
+    'Error(Contract)',
+    'contract invocation failed',
+    '',
+    null,
+    undefined,
+  ])('does not throw for malformed contract error input: %s', (input) => {
+    const parsed = parseContractError(input)
+
+    expect(parsed).toBeInstanceOf(Error)
+  })
+})


### PR DESCRIPTION
## Summary
- add focused Vitest coverage for `parseContractError`
- verify every current `CONTRACT_ERROR_MESSAGES` entry maps to its user-facing message
- cover unknown contract codes and malformed inputs so regressions do not surface raw Soroban errors to users

Closes #751

## Validation
- `npm ci --ignore-scripts --no-audit --no-fund`
- `npm test -- --run src/test/contractErrors.test.ts` (8 tests passed)
- `git diff --check`

## Notes
- `npm run lint` currently exits before linting because the repo uses ESLint 9 but has no `eslint.config.*` flat config.
- `npm test -- --run` currently has unrelated existing failures in other suites (`TransactionStatus`, formatting, monitoring mocks, retry timers, etc.); the new contract error test passes in isolation.
- `npm run build` was stopped after the prebuild step hung in `npx tsx scripts/generateCSP.ts` while spawning `node-gyp` for the temporary npx install.