### PR TITLE
docs: add stories for UI primitives

### DIFF
--- a/frontend/src/components/UI/ConfirmModal.stories.tsx
+++ b/frontend/src/components/UI/ConfirmModal.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { fn } from '@storybook/test'
+import { ConfirmModal } from './ConfirmModal'
+
+const details = [
+  { label: 'Token name', value: 'Community Credit' },
+  { label: 'Symbol', value: 'CREDIT' },
+  { label: 'Initial supply', value: '1000000' },
+]
+
+const meta: Meta<typeof ConfirmModal> = {
+  title: 'UI/ConfirmModal',
+  component: ConfirmModal,
+  tags: ['autodocs'],
+  args: {
+    isOpen: true,
+    title: 'Confirm token deployment',
+    description: 'Review these details before submitting the transaction.',
+    details,
+    confirmLabel: 'Deploy token',
+    onConfirm: fn(),
+    onCancel: fn(),
+  },
+  parameters: { layout: 'fullscreen' },
+}
+export default meta
+
+type Story = StoryObj<typeof ConfirmModal>
+
+export const Default: Story = {}
+
+export const WithoutDescription: Story = {
+  args: { description: undefined },
+}
+
+export const LongValues: Story = {
+  args: {
+    details: [
+      { label: 'Contract ID', value: 'CB7QYNF7SOWQ3ZN3PZ2C5D3NOQY7HTYB5RILPZVIZQH4M4QDU2TKNODE' },
+      { label: 'Network', value: 'Mainnet' },
+    ],
+  },
+}
+
+export const Closed: Story = {
+  args: { isOpen: false },
+}

--- a/frontend/src/components/UI/InsufficientBalanceWarning.stories.tsx
+++ b/frontend/src/components/UI/InsufficientBalanceWarning.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { InsufficientBalanceWarning } from './InsufficientBalanceWarning'
+import { ToastContext } from '../../context/ToastContext'
+import { WalletContext } from '../../context/WalletContext'
+
+const walletContext = {
+  wallet: {
+    address: 'GCBGQ4DMKDGW6ZAX2Z7V4XQJDKFS7KJ7T6QX6K4AHZ4V2QZQXLMTEST',
+    isConnected: true,
+    balance: '0.2',
+  },
+  isConnecting: false,
+  error: null,
+  isInstalled: true,
+  connect: async () => {},
+  disconnect: () => {},
+  refreshBalance: async () => {},
+}
+
+const toastContext = {
+  toasts: [],
+  addToast: () => {},
+  removeToast: () => {},
+}
+
+const meta: Meta<typeof InsufficientBalanceWarning> = {
+  title: 'UI/InsufficientBalanceWarning',
+  component: InsufficientBalanceWarning,
+  tags: ['autodocs'],
+  args: {
+    shortfall: '1.25',
+    isTestnet: true,
+  },
+  decorators: [
+    (Story) => (
+      <WalletContext.Provider value={walletContext}>
+        <ToastContext.Provider value={toastContext}>
+          <Story />
+        </ToastContext.Provider>
+      </WalletContext.Provider>
+    ),
+  ],
+}
+export default meta
+
+type Story = StoryObj<typeof InsufficientBalanceWarning>
+
+export const Testnet: Story = {}
+
+export const Mainnet: Story = {
+  args: {
+    shortfall: '3.50',
+    isTestnet: false,
+  },
+}

--- a/frontend/src/components/UI/ProgressIndicator.stories.tsx
+++ b/frontend/src/components/UI/ProgressIndicator.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { ProgressIndicator } from './ProgressIndicator'
+
+const meta: Meta<typeof ProgressIndicator> = {
+  title: 'UI/ProgressIndicator',
+  component: ProgressIndicator,
+  tags: ['autodocs'],
+}
+export default meta
+
+type Story = StoryObj<typeof ProgressIndicator>
+
+export const Pending: Story = {
+  args: {
+    steps: [
+      { label: 'Prepare transaction', status: 'pending' },
+      { label: 'Sign with wallet', status: 'pending' },
+      { label: 'Submit to network', status: 'pending' },
+    ],
+  },
+}
+
+export const InProgress: Story = {
+  args: {
+    steps: [
+      { label: 'Prepare transaction', status: 'completed' },
+      { label: 'Sign with wallet', status: 'in-progress' },
+      { label: 'Submit to network', status: 'pending' },
+    ],
+  },
+}
+
+export const Completed: Story = {
+  args: {
+    steps: [
+      { label: 'Prepare transaction', status: 'completed' },
+      { label: 'Sign with wallet', status: 'completed' },
+      { label: 'Submit to network', status: 'completed' },
+    ],
+  },
+}
+
+export const WithError: Story = {
+  args: {
+    steps: [
+      { label: 'Prepare transaction', status: 'completed' },
+      { label: 'Sign with wallet', status: 'completed' },
+      { label: 'Submit to network', status: 'error' },
+    ],
+  },
+}


### PR DESCRIPTION
## Summary
- Add Storybook coverage for ConfirmModal, ProgressIndicator, and InsufficientBalanceWarning
- Cover modal open/closed and long-value states, progress pending/in-progress/completed/error states, and testnet/mainnet balance warning states
- Leave existing Button and Input stories unchanged

## Testing
- git diff --check
- Not run: frontend node_modules are not installed in this workspace

Closes #756