### PR TITLE
Move CSP enforcement to deployment headers

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,18 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <!--
-      DEVELOPMENT FALLBACK ONLY — meta tags cannot enforce frame-ancestors.
-      Production CSP is set via HTTP headers in vercel.json / public/_headers,
-      generated from src/csp/policy.ts. Do not rely on this tag for production
-      security and do not edit it by hand — run `npm run prebuild` instead.
-
-      X-Frame-Options and frame-ancestors are header-only directives; browsers
-      silently ignore them when set via meta tags.
-    -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://gateway.pinata.cloud; connect-src 'self' https://horizon.stellar.org https://horizon-testnet.stellar.org https://soroban-testnet.stellar.org https://rpc-mainnet.stellar.org https://gateway.pinata.cloud https://api.pinata.cloud https://*.ingest.sentry.io; font-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; upgrade-insecure-requests; worker-src blob:" />
-    <!-- X-Content-Type-Options prevents MIME-type sniffing attacks. -->
-    <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <link rel="apple-touch-icon" href="/icons/icon-192x192.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -43,7 +31,7 @@
     <link rel="manifest" href="/manifest.json" />
     <link rel="sitemap" type="application/xml" href="/sitemap.xml" />
     <title>StellarForge - Stellar Token Deployer</title>
-    <!-- Plausible Analytics — loaded only when VITE_PLAUSIBLE_DOMAIN is set -->
+    <!-- Plausible Analytics - loaded only when VITE_PLAUSIBLE_DOMAIN is set -->
     <!-- defer + data-api keeps it privacy-respecting and non-blocking -->
     <script
       defer

--- a/frontend/src/csp/policy.ts
+++ b/frontend/src/csp/policy.ts
@@ -93,14 +93,3 @@ export function buildCSPString(directives: CSPDirectives): string {
     )
     .join('; ')
 }
-
-/**
- * Returns the value for a <meta http-equiv="Content-Security-Policy"> tag.
- *
- * NOTE: meta tags cannot enforce frame-ancestors or X-Frame-Options.
- * This output is for development only. Production security depends on
- * HTTP headers set in vercel.json / public/_headers.
- */
-export function buildCSPMeta(directives: CSPDirectives): string {
-  return buildCSPString(directives)
-}


### PR DESCRIPTION
## Summary
- remove the HTML CSP meta fallback so deployment headers are the enforcement point
- keep CSP generated through ercel.json / public/_headers
- remove the now-unused meta CSP helper export

Fixes #747

## Testing
- git diff --check
- Not run: 
pm --prefix frontend test -- --run src/test/csp/policy.test.ts (frontend/node_modules is not installed in this checkout)