### PR TITLE
docs: add mainnet deployment checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/mainnet-deployment.yml
+++ b/.github/ISSUE_TEMPLATE/mainnet-deployment.yml
@@ -1,0 +1,45 @@
+name: Mainnet Deployment
+description: Track a mainnet deployment using the documented release checklist.
+title: "Mainnet deployment: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Complete the mainnet deployment checklist before opening this issue for release approval:
+        https://github.com/Favourorg/Stellar-forge/blob/main/docs/mainnet-deployment-checklist.md
+  - type: input
+    id: deployment-owner
+    attributes:
+      label: Deployment owner
+      description: Who is responsible for running the deployment and coordinating rollback if needed?
+      placeholder: "@username"
+    validations:
+      required: true
+  - type: input
+    id: target-version
+    attributes:
+      label: Target version or commit
+      description: Provide the release tag, commit SHA, or branch planned for mainnet.
+      placeholder: "v1.2.3 or abc1234"
+    validations:
+      required: true
+  - type: checkboxes
+    id: checklist-confirmation
+    attributes:
+      label: Checklist confirmation
+      options:
+        - label: I completed the mainnet deployment checklist.
+          required: true
+        - label: I ran a testnet smoke test using the planned deployment steps.
+          required: true
+        - label: I prepared a rollback plan and identified the rollback owner.
+          required: true
+  - type: textarea
+    id: deployment-notes
+    attributes:
+      label: Deployment notes
+      description: Include relevant contract IDs, WASM hashes, transaction hashes, fee settings, and release-window notes.
+      placeholder: "Contract ID, WASM hash, fee configuration, CSP verification, rollback command..."
+    validations:
+      required: true
+

--- a/README.md
+++ b/README.md
@@ -366,6 +366,8 @@ npm run build
 
 ⚠️ **Warning**: Mainnet deployment involves real money. Test thoroughly on testnet first!
 
+Before deploying to mainnet, complete the [Mainnet Deployment Checklist](./docs/mainnet-deployment-checklist.md).
+
 The process is identical to testnet, but:
 1. Use `--network mainnet` instead of `--network testnet`
 2. Fund your account with real XLM (buy from an exchange)
@@ -731,7 +733,7 @@ add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https
 
 For users deploying tokens, we strongly recommend:
 - Always test on testnet first before mainnet deployment
-- Review all parameters carefully using the mainnet deployment checklist
+- Review all parameters carefully using the [Mainnet Deployment Checklist](./docs/mainnet-deployment-checklist.md)
 - Verify contract addresses and transaction details before signing
 
 ## Fee Bump Transactions

--- a/docs/mainnet-deployment-checklist.md
+++ b/docs/mainnet-deployment-checklist.md
@@ -1,0 +1,31 @@
+# Mainnet Deployment Checklist
+
+Use this checklist before promoting Stellar Forge from testnet to mainnet. Mainnet actions can move real funds, so keep a deployment owner, an approver, and a rollback owner available until smoke tests pass.
+
+## Pre-Deployment
+
+- [ ] Confirm the latest contract code has completed audit or peer security review, and document any accepted risks.
+- [ ] Resolve or explicitly defer all high and medium audit findings before signing mainnet transactions.
+- [ ] Build the release WASM with production optimizations enabled and record the final artifact hash.
+- [ ] Verify the optimized WASM hash matches the value configured for the frontend and deployment scripts.
+- [ ] Review fee configuration, including base fees, token creation fees, treasury account, and expected transaction cost.
+- [ ] Fund the deployer, treasury, and any operational accounts with the minimum mainnet XLM needed for deployment and reserves.
+- [ ] Confirm admin keys are stored securely, preferably using a hardware wallet, multisig policy, or offline key custody process.
+- [ ] Remove private keys, admin secrets, and mainnet credentials from local shell history, logs, screenshots, and committed files.
+
+## Configuration
+
+- [ ] Set `VITE_NETWORK=mainnet` and confirm no testnet network passphrase, RPC URL, or Friendbot reference remains.
+- [ ] Verify `VITE_FACTORY_CONTRACT_ID`, `VITE_TOKEN_WASM_HASH`, and Pinata/IPFS configuration point to production values.
+- [ ] Confirm Content Security Policy headers allow only the required Stellar, Pinata, and application origins.
+- [ ] Review deployment hosting settings, environment variables, redirects, and security headers before publishing.
+
+## Release Validation
+
+- [ ] Run a complete smoke test on testnet using the same deployment steps planned for mainnet.
+- [ ] Test token creation, metadata upload, minting, burning, transfer, and wallet connection flows on testnet.
+- [ ] Prepare a rollback plan that names the last known-good frontend deployment, contract IDs, owner, and rollback command.
+- [ ] Save deployment transaction hashes, contract IDs, WASM hashes, and release notes in the deployment log.
+- [ ] After mainnet deployment, verify contract state, transaction history, and frontend reads against Stellar Explorer.
+- [ ] Monitor application errors, failed transactions, fee spikes, and user-reported issues during the release window.
+


### PR DESCRIPTION
## Summary
- add `docs/mainnet-deployment-checklist.md` with 18 actionable mainnet readiness checks
- link the README deployment guidance to the checklist
- add a Mainnet Deployment issue template that references the checklist URL

## Validation
- `git diff --check`
- `grep -c "^- \\[ \\]" docs/mainnet-deployment-checklist.md`
- `rg -n "mainnet-deployment-checklist|Mainnet Deployment Checklist" README.md .github/ISSUE_TEMPLATE/mainnet-deployment.yml docs/mainnet-deployment-checklist.md`

Closes #759
