### PR TITLE
Add Dependabot configuration for npm and Cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,35 @@
 version: 2
+
+# Group minor and patch updates together to reduce PR noise
+groups:
+  minor-patch:
+    update-types:
+      - minor
+      - patch
+    patterns:
+      - "*"
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    assignees:
+      - bigvictoh
+    reviewers:
+      - bigvictoh
+
+  - package-ecosystem: "cargo"
+    directory: "/contracts"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    assignees:
+      - bigvictoh
+    reviewers:
+      - bigvictoh
+version: 2
 updates:
   # Frontend npm dependencies
   - package-ecosystem: npm


### PR DESCRIPTION
Adds .github/dependabot.yml to enable weekly Dependabot updates for npm (frontend) and Cargo (contracts). Groups minor/patch updates into aggregated PRs. Closes #749