### PR TITLE
Add route-specific ErrorBoundary fallbacks (closes #744)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,6 +37,41 @@ const ProtectedRoute: React.FC<{ children: React.ReactElement }> = ({ children }
   return children
 }
 
+interface RouteErrorFallbackProps {
+  routeName: string
+  resetErrorBoundary?: () => void
+}
+
+const RouteErrorFallback: React.FC<RouteErrorFallbackProps> = ({ routeName, resetErrorBoundary }) => (
+  <div className="min-h-[300px] flex items-center justify-center bg-gray-100 dark:bg-slate-900 p-6 rounded-lg">
+    <div className="bg-white dark:bg-slate-800 p-8 rounded-xl shadow-lg text-center max-w-lg w-full">
+      <div className="text-red-500 mb-4">
+        <svg className="h-12 w-12 mx-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+        </svg>
+      </div>
+      <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">{routeName} encountered an error</h2>
+      <p className="text-gray-600 dark:text-gray-400 mb-6">
+        Something went wrong while loading this page. You can try again without affecting the rest of the app.
+      </p>
+      <button
+        type="button"
+        onClick={resetErrorBoundary}
+        className="bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-400 text-white font-medium py-2 px-6 rounded-lg transition-colors"
+      >
+        Try again
+      </button>
+    </div>
+  </div>
+)
+
+const RouteBoundary: React.FC<{ routeName: string; children: React.ReactNode }> = ({ routeName, children }) => (
+  <ErrorBoundary fallback={<RouteErrorFallback routeName={routeName} />}>
+    {children}
+  </ErrorBoundary>
+)
+
 function AppContent() {
   const { wallet, error } = useWallet()
   const { t } = useTranslation()
@@ -153,18 +188,18 @@ function AppContent() {
                 <Route
                   path="/"
                   element={
-                    <ErrorBoundary>
+                    <RouteBoundary routeName="Home">
                       <Home />
-                    </ErrorBoundary>
+                    </RouteBoundary>
                   }
                 />
                 <Route
                   path="/create"
                   element={
                     <ProtectedRoute>
-                      <ErrorBoundary>
+                      <RouteBoundary routeName="Create Token">
                         <CreateToken />
-                      </ErrorBoundary>
+                      </RouteBoundary>
                     </ProtectedRoute>
                   }
                 />
@@ -172,9 +207,9 @@ function AppContent() {
                   path="/mint"
                   element={
                     <ProtectedRoute>
-                      <ErrorBoundary>
+                      <RouteBoundary routeName="Mint">
                         <MintForm />
-                      </ErrorBoundary>
+                      </RouteBoundary>
                     </ProtectedRoute>
                   }
                 />
@@ -182,9 +217,9 @@ function AppContent() {
                   path="/burn"
                   element={
                     <ProtectedRoute>
-                      <ErrorBoundary>
+                      <RouteBoundary routeName="Burn">
                         <BurnForm />
-                      </ErrorBoundary>
+                      </RouteBoundary>
                     </ProtectedRoute>
                   }
                 />
@@ -192,9 +227,9 @@ function AppContent() {
                   path="/tokens"
                   element={
                     <ProtectedRoute>
-                      <ErrorBoundary>
+                      <RouteBoundary routeName="Tokens">
                         <TokenDashboard />
-                      </ErrorBoundary>
+                      </RouteBoundary>
                     </ProtectedRoute>
                   }
                 />
@@ -202,9 +237,9 @@ function AppContent() {
                   path="/tokens/:address"
                   element={
                     <ProtectedRoute>
-                      <ErrorBoundary>
+                      <RouteBoundary routeName="Token Detail">
                         <TokenDetail />
-                      </ErrorBoundary>
+                      </RouteBoundary>
                     </ProtectedRoute>
                   }
                 />
@@ -212,30 +247,30 @@ function AppContent() {
                   path="/token/:address"
                   element={
                     <ProtectedRoute>
-                      <ErrorBoundary>
+                      <RouteBoundary routeName="Token Detail">
                         <TokenDetail />
-                      </ErrorBoundary>
+                      </RouteBoundary>
                     </ProtectedRoute>
                   }
                 />
                 <Route
                   path="/explorer"
                   element={
-                    <ErrorBoundary>
+                    <RouteBoundary routeName="Explorer">
                       <TokenExplorer />
-                    </ErrorBoundary>
+                    </RouteBoundary>
                   }
                 />
                 <Route
                   path="/metadata"
                   element={
                     <ProtectedRoute>
-                      <ErrorBoundary>
+                      <RouteBoundary routeName="Metadata">
                         <div className="max-w-lg mx-auto">
                           <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">Set Token Metadata</h2>
                           <MetadataForm />
                         </div>
-                      </ErrorBoundary>
+                      </RouteBoundary>
                     </ProtectedRoute>
                   }
                 />
@@ -243,9 +278,9 @@ function AppContent() {
                   path="/admin"
                   element={
                     <ProtectedRoute>
-                      <ErrorBoundary>
+                      <RouteBoundary routeName="Admin Panel">
                         <AdminPanel />
-                      </ErrorBoundary>
+                      </RouteBoundary>
                     </ProtectedRoute>
                   }
                 />
@@ -253,9 +288,9 @@ function AppContent() {
                   path="/dashboard"
                   element={
                     <ProtectedRoute>
-                      <ErrorBoundary>
+                      <RouteBoundary routeName="Dashboard">
                         <TokenDashboard />
-                      </ErrorBoundary>
+                      </RouteBoundary>
                     </ProtectedRoute>
                   }
                 />
@@ -263,9 +298,9 @@ function AppContent() {
                   path="/token/:address"
                   element={
                     <ProtectedRoute>
-                      <ErrorBoundary>
+                      <RouteBoundary routeName="Token Detail">
                         <TokenDetail />
-                      </ErrorBoundary>
+                      </RouteBoundary>
                     </ProtectedRoute>
                   }
                 />
@@ -273,9 +308,9 @@ function AppContent() {
                   path="/manage"
                   element={
                     <ProtectedRoute>
-                      <ErrorBoundary>
+                      <RouteBoundary routeName="Manage">
                         <Manage />
-                      </ErrorBoundary>
+                      </RouteBoundary>
                     </ProtectedRoute>
                   }
                 />

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,4 +1,8 @@
-import { Component, ErrorInfo, ReactNode } from 'react'
+import { Component, ErrorInfo, ReactElement, ReactNode, cloneElement, isValidElement } from 'react'
+
+interface FallbackProps {
+  resetErrorBoundary?: () => void
+}
 
 interface Props {
   children: ReactNode
@@ -24,9 +28,19 @@ class ErrorBoundary extends Component<Props, State> {
     console.error('[ErrorBoundary] Uncaught error:', error, errorInfo.componentStack)
   }
 
+  private resetErrorBoundary = (): void => {
+    this.setState({ hasError: false, error: null })
+  }
+
   render(): ReactNode {
     if (this.state.hasError) {
-      if (this.props.fallback) return this.props.fallback
+      if (this.props.fallback) {
+        return isValidElement(this.props.fallback)
+          ? cloneElement(this.props.fallback as ReactElement<FallbackProps>, {
+              resetErrorBoundary: this.resetErrorBoundary,
+            })
+          : this.props.fallback
+      }
 
       return (
         <div className="min-h-screen flex items-center justify-center bg-gray-100 dark:bg-slate-900">

--- a/frontend/src/test/monitoring/errorBoundary.test.tsx
+++ b/frontend/src/test/monitoring/errorBoundary.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { ErrorBoundary } from '../../lib/monitoring/errorBoundary'
 
 const mockCaptureException = vi.fn()
@@ -49,5 +49,37 @@ describe('ErrorBoundary', () => {
       </ErrorBoundary>,
     )
     expect(screen.getByText('custom fallback')).toBeTruthy()
+  })
+
+  it('allows a route fallback to reset the boundary and display recovered content', async () => {
+    let throwOnce = true
+
+    function FlakyRoute(): JSX.Element {
+      if (throwOnce) {
+        throwOnce = false
+        throw new Error('boom-once')
+      }
+      return <div>route restored</div>
+    }
+
+    const RouteFallback = ({ resetErrorBoundary }: { resetErrorBoundary?: () => void }) => (
+      <div>
+        <div>route error</div>
+        <button onClick={resetErrorBoundary}>Try again</button>
+      </div>
+    )
+
+    render(
+      <ErrorBoundary fallback={<RouteFallback />}>
+        <FlakyRoute />
+      </ErrorBoundary>,
+    )
+
+    expect(screen.getByText('route error')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /try again/i })).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }))
+
+    expect(await screen.findByText('route restored')).toBeTruthy()
   })
 })


### PR DESCRIPTION
Wrap each major route ([Home](vscode-file://vscode-app/snap/code/242/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), Create Token, Mint, Burn, Tokens, Token Detail, Explorer, Metadata, Admin Panel, [Dashboard](vscode-file://vscode-app/snap/code/242/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [Manage](vscode-file://vscode-app/snap/code/242/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) with its own [ErrorBoundary](vscode-file://vscode-app/snap/code/242/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Introduce route-specific fallback UI with page-specific messaging and a Try again button
Keep the top-level app boundary as a last-resort safety net
Update shared [ErrorBoundary](vscode-file://vscode-app/snap/code/242/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to support reset behavior for custom fallbacks
Add a test covering fallback rendering and reset behavior when a wrapped component throws
Closes #744