### PR TITLE
fix: expand .gitignore to prevent accidental artifact commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,24 @@ dist/
 .env
 .env.local
 *.local
+
+# Test coverage
+coverage/
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Editor
+.idea/
+.vscode/
+
+# Build output
+build/
+out/

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,18 @@
+# Vite build output
+dist/
+dist-ssr/
+
+# Vitest coverage
+coverage/
+
+# Env files
+.env
+.env.local
+.env.*.local
+
+# Editor
+.vscode/
+.idea/
+
+# OS
+.DS_Store


### PR DESCRIPTION
## Summary
- Adds `coverage/`, `*.log`, `.DS_Store`, `.idea/`, `.vscode/`, `build/`, `out/` to the root `.gitignore`
- Adds `frontend/.gitignore` for Vite/Vitest-specific artifacts (`dist/`, `dist-ssr/`, `coverage/`, env files)

## Test plan
- [ ] Verify `frontend/coverage/` is no longer tracked after generating a coverage report
- [ ] Verify OS/editor files are not staged by `git add .`

Closes #850