### PR TITLE
fix: validate hexToBytes input is exactly 64 hex chars

### DIFF
--- a/frontend/src/services/stellar.ts
+++ b/frontend/src/services/stellar.ts
@@ -32,10 +32,12 @@ export type { FactoryState } from '../types'
 // ── Utilities ─────────────────────────────────────────────────────────────────
 
 function hexToBytes(hex: string): Uint8Array {
-  const h = hex.padEnd(64, '0').slice(0, 64)
+  if (!/^[0-9a-fA-F]{64}$/.test(hex)) {
+    throw new Error(`Invalid WASM hash: expected exactly 64 hex characters, got "${hex}"`)
+  }
   const bytes = new Uint8Array(32)
   for (let i = 0; i < 32; i++) {
-    bytes[i] = parseInt(h.slice(i * 2, i * 2 + 2), 16)
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
   }
   return bytes
 }


### PR DESCRIPTION
## Summary
Replace silent pad/truncate logic in `hexToBytes` with a strict regex validation. Malformed or short WASM hashes now throw a clear error (`Invalid WASM hash: expected exactly 64 hex characters`) instead of returning a zero-padded array that silently passes as valid.

## Test plan
- [ ] Pass a valid 64-char hex string → should return correct 32-byte array
- [ ] Pass a short/malformed string → should throw with a clear message
- [ ] Verify contract deployment still works with a correct `VITE_TOKEN_WASM_HASH`

Closes #851 