### PR TITLE
feat: gate wallet and metadata actions behind ToS

### DIFF
--- a/frontend/src/components/MetadataForm.test.tsx
+++ b/frontend/src/components/MetadataForm.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TosProvider } from '../context/TosContext'
+import { MetadataForm } from './MetadataForm'
+
+vi.mock('../context/StellarContext', () => ({
+  useStellarContext: () => ({
+    ipfsService: { uploadMetadata: vi.fn() },
+    stellarService: { setMetadata: vi.fn() },
+  }),
+}))
+
+vi.mock('../context/ToastContext', () => ({
+  useToast: () => ({ addToast: vi.fn() }),
+}))
+
+vi.mock('../context/NetworkContext', () => ({
+  useNetwork: () => ({ network: 'testnet' }),
+}))
+
+vi.mock('../hooks/useFactoryState', () => ({
+  useFactoryState: () => ({ state: { metadataFee: '100000' } }),
+}))
+
+vi.mock('../hooks/useBalanceCheck', () => ({
+  useBalanceCheck: () => ({ hasSufficientBalance: true, shortfall: 0, isTestnet: true }),
+}))
+
+vi.mock('../config/env', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../config/env')>()),
+  isIpfsConfigured: () => true,
+}))
+
+const renderMetadataForm = () =>
+  render(
+    <TosProvider>
+      <MetadataForm />
+    </TosProvider>,
+  )
+
+describe('MetadataForm ToS gate', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('requires accepting the terms before showing the on-chain metadata confirmation', () => {
+    const { container } = renderMetadataForm()
+
+    fireEvent.change(screen.getByLabelText(/token address/i), {
+      target: { value: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' },
+    })
+
+    const fileInput = container.querySelector<HTMLInputElement>('input[type="file"]')
+    expect(fileInput).not.toBeNull()
+    fireEvent.change(fileInput!, {
+      target: {
+        files: [new File(['token image'], 'token.png', { type: 'image/png' })],
+      },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /set metadata/i }))
+
+    expect(screen.getByRole('dialog', { name: /terms of service/i })).toBeInTheDocument()
+    expect(screen.queryByRole('dialog', { name: /confirm set metadata/i })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText(/accept the terms/i))
+    fireEvent.click(screen.getByRole('button', { name: /^accept$/i }))
+
+    expect(screen.getByRole('dialog', { name: /confirm set metadata/i })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/MetadataForm.tsx
+++ b/frontend/src/components/MetadataForm.tsx
@@ -7,6 +7,7 @@ import { useToast } from '../context/ToastContext'
 import { useStellarContext } from '../context/StellarContext'
 import { useBalanceCheck } from '../hooks/useBalanceCheck'
 import { useNetwork } from '../context/NetworkContext'
+import { useTos } from '../context/TosContext'
 import { isIpfsConfigured } from '../config/env'
 import { ExplorerLink } from './ExplorerLink'
 import { useFactoryState } from '../hooks/useFactoryState'
@@ -25,6 +26,7 @@ export const MetadataForm: React.FC<MetadataFormProps> = ({ initialTokenAddress 
   const { ipfsService, stellarService } = useStellarContext()
   const { addToast } = useToast()
   const { network } = useNetwork()
+  const { requireTos } = useTos()
   const { state: factoryState } = useFactoryState()
 
   const metadataFeeXlm = factoryState?.metadataFee
@@ -99,9 +101,15 @@ export const MetadataForm: React.FC<MetadataFormProps> = ({ initialTokenAddress 
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    if (!imageFile) { addToast('Please select an image file', 'error'); return }
-    if (!tokenAddress.trim()) { addToast('Please enter a token address', 'error'); return }
-    setPendingConfirm(true)
+    if (!imageFile) {
+      addToast('Please select an image file', 'error')
+      return
+    }
+    if (!tokenAddress.trim()) {
+      addToast('Please enter a token address', 'error')
+      return
+    }
+    requireTos(() => setPendingConfirm(true))
   }
 
   const handleConfirm = async () => {
@@ -114,11 +122,8 @@ export const MetadataForm: React.FC<MetadataFormProps> = ({ initialTokenAddress 
     setStep('uploading-ipfs')
     let metadataUri: string
     try {
-      metadataUri = await ipfsService.uploadMetadata(
-        imageFile!,
-        description,
-        tokenAddress,
-        (p) => setUploadProgress(p),
+      metadataUri = await ipfsService.uploadMetadata(imageFile!, description, tokenAddress, (p) =>
+        setUploadProgress(p),
       )
       setFinalUri(metadataUri)
     } catch (err) {
@@ -145,10 +150,7 @@ export const MetadataForm: React.FC<MetadataFormProps> = ({ initialTokenAddress 
       const msg = err instanceof Error ? err.message : 'Stellar transaction failed'
       setErrorMsg(msg)
       // Metadata is pinned but not linked — surface this clearly
-      addToast(
-        `Metadata pinned at ${metadataUri} but on-chain linking failed: ${msg}`,
-        'error',
-      )
+      addToast(`Metadata pinned at ${metadataUri} but on-chain linking failed: ${msg}`, 'error')
     }
   }
 
@@ -169,9 +171,13 @@ export const MetadataForm: React.FC<MetadataFormProps> = ({ initialTokenAddress 
     return (
       <div className="rounded-lg bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-300 dark:border-yellow-700 p-4 text-sm text-yellow-800 dark:text-yellow-300">
         IPFS upload is disabled. Set{' '}
-        <code className="font-mono bg-yellow-100 dark:bg-yellow-900 px-1 rounded">VITE_IPFS_API_KEY</code>{' '}
+        <code className="font-mono bg-yellow-100 dark:bg-yellow-900 px-1 rounded">
+          VITE_IPFS_API_KEY
+        </code>{' '}
         and{' '}
-        <code className="font-mono bg-yellow-100 dark:bg-yellow-900 px-1 rounded">VITE_IPFS_API_SECRET</code>{' '}
+        <code className="font-mono bg-yellow-100 dark:bg-yellow-900 px-1 rounded">
+          VITE_IPFS_API_SECRET
+        </code>{' '}
         to enable metadata uploads.
       </div>
     )
@@ -182,7 +188,9 @@ export const MetadataForm: React.FC<MetadataFormProps> = ({ initialTokenAddress 
     return (
       <div className="space-y-4">
         <div className="rounded-lg bg-green-50 dark:bg-green-900/20 border border-green-300 dark:border-green-700 p-4 space-y-2">
-          <p className="font-semibold text-green-800 dark:text-green-300">✓ Metadata set successfully!</p>
+          <p className="font-semibold text-green-800 dark:text-green-300">
+            ✓ Metadata set successfully!
+          </p>
           <p className="text-sm text-green-700 dark:text-green-400 break-all">
             <span className="font-medium">IPFS URI:</span> {finalUri}
           </p>
@@ -204,7 +212,7 @@ export const MetadataForm: React.FC<MetadataFormProps> = ({ initialTokenAddress 
   }
 
   // ── In-progress / error state ────────────────────────────────────────────────
-  if (isSubmitting || (step === 'error')) {
+  if (isSubmitting || step === 'error') {
     return (
       <div className="space-y-4">
         <ProgressIndicator steps={progressSteps} />
@@ -230,7 +238,9 @@ export const MetadataForm: React.FC<MetadataFormProps> = ({ initialTokenAddress 
               <div className="rounded-md bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 p-3 text-sm text-blue-800 dark:text-blue-300">
                 <p className="font-medium">Metadata pinned but not yet linked on-chain.</p>
                 <p className="break-all mt-1">IPFS URI: {finalUri}</p>
-                <p className="mt-1 text-xs">You can retry the Stellar step or set this URI manually.</p>
+                <p className="mt-1 text-xs">
+                  You can retry the Stellar step or set this URI manually.
+                </p>
               </div>
             )}
             {errorMsg && (
@@ -262,7 +272,8 @@ export const MetadataForm: React.FC<MetadataFormProps> = ({ initialTokenAddress 
         {/* Image upload */}
         <div>
           <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-            Token Image <span className="text-gray-400 font-normal">(JPEG, PNG, GIF · max 5 MB)</span>
+            Token Image{' '}
+            <span className="text-gray-400 font-normal">(JPEG, PNG, GIF · max 5 MB)</span>
           </label>
           <input
             ref={fileInputRef}
@@ -284,7 +295,9 @@ export const MetadataForm: React.FC<MetadataFormProps> = ({ initialTokenAddress 
                 className="w-20 h-20 object-contain rounded-md border border-gray-300 dark:border-gray-600 shrink-0"
               />
               <div className="text-sm text-gray-600 dark:text-gray-400 space-y-0.5">
-                <p className="font-medium text-gray-800 dark:text-gray-200 break-all">{imageFile?.name}</p>
+                <p className="font-medium text-gray-800 dark:text-gray-200 break-all">
+                  {imageFile?.name}
+                </p>
                 <p>{imageFile ? (imageFile.size / 1024).toFixed(0) : 0} KB</p>
                 <button
                   type="button"
@@ -317,7 +330,9 @@ export const MetadataForm: React.FC<MetadataFormProps> = ({ initialTokenAddress 
         {/* Fee preview */}
         <div className="rounded-md bg-gray-50 dark:bg-gray-700/50 border border-gray-200 dark:border-gray-600 px-4 py-3 text-sm flex justify-between">
           <span className="text-gray-600 dark:text-gray-400">Estimated fee</span>
-          <span className="font-semibold text-gray-900 dark:text-white">{metadataFeeXlm.toFixed(7)} XLM</span>
+          <span className="font-semibold text-gray-900 dark:text-white">
+            {metadataFeeXlm.toFixed(7)} XLM
+          </span>
         </div>
 
         {!hasSufficientBalance && (

--- a/frontend/src/components/UI/TermsModal.tsx
+++ b/frontend/src/components/UI/TermsModal.tsx
@@ -4,12 +4,17 @@ import { Button } from './Button'
 interface TermsModalProps {
   isOpen: boolean
   onAccept: () => void
+  onDecline?: () => void
 }
 
-export const TermsModal: React.FC<TermsModalProps> = ({ isOpen, onAccept }) => {
+export const TermsModal: React.FC<TermsModalProps> = ({ isOpen, onAccept, onDecline }) => {
   const [checked, setChecked] = useState(false)
 
-  // Block Escape key — modal is non-dismissible
+  useEffect(() => {
+    if (!isOpen) setChecked(false)
+  }, [isOpen])
+
+  // Block Escape key so users choose Accept or Decline explicitly.
   useEffect(() => {
     if (!isOpen) return
     const block = (e: KeyboardEvent) => {
@@ -27,7 +32,7 @@ export const TermsModal: React.FC<TermsModalProps> = ({ isOpen, onAccept }) => {
       role="dialog"
       aria-modal="true"
       aria-labelledby="tos-modal-title"
-      // Swallow backdrop clicks — non-dismissible
+      // Swallow backdrop clicks so users choose Accept or Decline explicitly.
       onClick={(e) => e.stopPropagation()}
     >
       <div
@@ -90,9 +95,14 @@ export const TermsModal: React.FC<TermsModalProps> = ({ isOpen, onAccept }) => {
           >
             Read full terms document
           </a>
-          <Button onClick={onAccept} disabled={!checked}>
-            Accept
-          </Button>
+          <div className="flex items-center gap-3">
+            <Button type="button" variant="outline" onClick={onDecline}>
+              Decline
+            </Button>
+            <Button type="button" onClick={onAccept} disabled={!checked}>
+              Accept
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/components/UI/WalletButton.test.tsx
+++ b/frontend/src/components/UI/WalletButton.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TosProvider } from '../../context/TosContext'
+import { WalletButton } from './WalletButton'
+
+const mockConnect = vi.fn()
+const mockDisconnect = vi.fn()
+
+vi.mock('../../hooks/useWallet', () => ({
+  useWallet: () => ({
+    wallet: { isConnected: false, address: null },
+    isConnecting: false,
+    isInstalled: true,
+    error: null,
+    connect: mockConnect,
+    disconnect: mockDisconnect,
+  }),
+}))
+
+const renderButton = () =>
+  render(
+    <TosProvider>
+      <WalletButton />
+    </TosProvider>,
+  )
+
+describe('WalletButton ToS gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+  })
+
+  it('requires accepting the terms before connecting the wallet', () => {
+    renderButton()
+
+    fireEvent.click(screen.getByRole('button', { name: /connect wallet/i }))
+
+    expect(mockConnect).not.toHaveBeenCalled()
+    expect(screen.getByRole('dialog', { name: /terms of service/i })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText(/accept the terms/i))
+    fireEvent.click(screen.getByRole('button', { name: /^accept$/i }))
+
+    expect(mockConnect).toHaveBeenCalledTimes(1)
+  })
+
+  it('disconnects cleanly when the terms are declined during wallet connection', () => {
+    renderButton()
+
+    fireEvent.click(screen.getByRole('button', { name: /connect wallet/i }))
+    fireEvent.click(screen.getByRole('button', { name: /decline/i }))
+
+    expect(mockConnect).not.toHaveBeenCalled()
+    expect(mockDisconnect).toHaveBeenCalledTimes(1)
+    expect(screen.queryByRole('dialog', { name: /terms of service/i })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/UI/WalletButton.tsx
+++ b/frontend/src/components/UI/WalletButton.tsx
@@ -1,11 +1,19 @@
 import React from 'react'
 import { useWallet } from '../../hooks/useWallet'
+import { useTos } from '../../context/TosContext'
 import { truncateAddress } from '../../utils/formatting'
 import { Button } from './Button'
 import { Spinner } from './Spinner'
 
 export const WalletButton: React.FC = () => {
   const { wallet, isConnecting, isInstalled, error, connect, disconnect } = useWallet()
+  const { requireTos } = useTos()
+
+  const handleConnect = () => {
+    requireTos(() => {
+      void connect()
+    }, disconnect)
+  }
 
   if (!isInstalled) {
     return (
@@ -15,8 +23,19 @@ export const WalletButton: React.FC = () => {
         rel="noopener noreferrer"
         className="inline-flex items-center gap-1.5 px-3 py-2 rounded-md text-sm font-medium text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 hover:bg-blue-100 dark:hover:bg-blue-900/50 transition-colors min-h-[44px]"
       >
-        <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+        <svg
+          className="w-4 h-4 shrink-0"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+          />
         </svg>
         Install Freighter
       </a>
@@ -41,7 +60,13 @@ export const WalletButton: React.FC = () => {
         >
           {truncateAddress(wallet.address)}
         </span>
-        <Button onClick={disconnect} variant="outline" size="sm" aria-label="Disconnect wallet" className="shrink-0">
+        <Button
+          onClick={disconnect}
+          variant="outline"
+          size="sm"
+          aria-label="Disconnect wallet"
+          className="shrink-0"
+        >
           Disconnect
         </Button>
       </div>
@@ -50,7 +75,7 @@ export const WalletButton: React.FC = () => {
 
   return (
     <div className="flex flex-col items-end gap-1">
-      <Button onClick={connect} size="sm" aria-label="Connect wallet" className="shrink-0">
+      <Button onClick={handleConnect} size="sm" aria-label="Connect wallet" className="shrink-0">
         Connect Wallet
       </Button>
       {error && (

--- a/frontend/src/context/TosContext.tsx
+++ b/frontend/src/context/TosContext.tsx
@@ -7,21 +7,24 @@ const TOS_KEY = 'stellar_forge_tos_accepted'
 interface TosContextValue {
   /** Call before any transaction. Runs `proceed` immediately if ToS already accepted,
    *  otherwise shows the modal and runs `proceed` after acceptance. */
-  requireTos: (proceed: () => void) => void
+  requireTos: (proceed: () => void, onDecline?: () => void) => void
 }
 
 const TosContext = createContext<TosContextValue | null>(null)
 
 export const TosProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [accepted, setAccepted] = useLocalStorage<boolean>(TOS_KEY, false)
-  const [pendingCallback, setPendingCallback] = useState<(() => void) | null>(null)
+  const [pendingAction, setPendingAction] = useState<{
+    proceed: () => void
+    onDecline?: () => void
+  } | null>(null)
 
   const requireTos = useCallback(
-    (proceed: () => void) => {
+    (proceed: () => void, onDecline?: () => void) => {
       if (accepted) {
         proceed()
       } else {
-        setPendingCallback(() => proceed)
+        setPendingAction(onDecline ? { proceed, onDecline } : { proceed })
       }
     },
     [accepted],
@@ -29,14 +32,23 @@ export const TosProvider: React.FC<{ children: React.ReactNode }> = ({ children 
 
   const handleAccept = () => {
     setAccepted(true)
-    pendingCallback?.()
-    setPendingCallback(null)
+    pendingAction?.proceed()
+    setPendingAction(null)
+  }
+
+  const handleDecline = () => {
+    pendingAction?.onDecline?.()
+    setPendingAction(null)
   }
 
   return (
     <TosContext.Provider value={{ requireTos }}>
       {children}
-      <TermsModal isOpen={pendingCallback !== null} onAccept={handleAccept} />
+      <TermsModal
+        isOpen={pendingAction !== null}
+        onAccept={handleAccept}
+        onDecline={handleDecline}
+      />
     </TosContext.Provider>
   )
 }


### PR DESCRIPTION
Closes #754

## Summary
- extend `TosContext` and `TermsModal` with an explicit decline path for pending gated actions
- gate wallet connection behind the ToS modal so acceptance proceeds to Freighter connect and decline disconnects/keeps the wallet state clean
- gate the metadata on-chain confirmation behind the same ToS flow; existing create/mint/burn gates remain in place
- add focused coverage for wallet connect accept/decline behavior and metadata confirmation gating

## Validation
- TDD red check first: new tests initially failed because wallet connect ran immediately, decline was unavailable, and metadata confirmation appeared before ToS acceptance
- `npm test -- --run src/components/UI/WalletButton.test.tsx src/components/MetadataForm.test.tsx`
- `npx prettier --check src/context/TosContext.tsx src/components/UI/TermsModal.tsx src/components/UI/WalletButton.tsx src/components/MetadataForm.tsx src/components/UI/WalletButton.test.tsx src/components/MetadataForm.test.tsx`
- `npm run build`
- `git diff --check`

## Notes
- Existing repo-wide checks are currently blocked outside this change: `npm run lint` fails because ESLint 9 expects `eslint.config.*`; `npm run format:check` reports many pre-existing files; `npx tsc --noEmit` reports repo-wide pre-existing type errors.