### PR TITLE
Fix transaction history load more cursor pagination

### DIFF
--- a/frontend/src/hooks/__tests__/useTransactionHistory.test.tsx
+++ b/frontend/src/hooks/__tests__/useTransactionHistory.test.tsx
@@ -1,0 +1,68 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useTransactionHistory } from '../useTransactionHistory'
+
+const PUBLIC_KEY = 'GBQXR7K7KX7X7X7X7X7X7X7X7X7X7X7X7X7X7X7X7X7X7X7X7X7X7X7'
+
+function paymentOperation(id: string, pagingToken: string) {
+  return {
+    id,
+    paging_token: pagingToken,
+    type: 'payment',
+    asset_code: 'FORGE',
+    amount: '12.5',
+    created_at: '2026-06-24T00:00:00Z',
+    transaction_successful: true,
+    transaction_hash: `hash-${id}`,
+  }
+}
+
+function horizonResponse(records: ReturnType<typeof paymentOperation>[]) {
+  return {
+    ok: true,
+    json: async () => ({
+      _embedded: {
+        records,
+      },
+    }),
+  } as Response
+}
+
+describe('useTransactionHistory', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('uses the last operation paging token when loading more transactions', async () => {
+    const fetchMock = vi.mocked(fetch)
+    fetchMock
+      .mockResolvedValueOnce(
+        horizonResponse([paymentOperation('1', 'cursor-1'), paymentOperation('2', 'cursor-2')]),
+      )
+      .mockResolvedValueOnce(horizonResponse([paymentOperation('3', 'cursor-3')]))
+
+    const { result } = renderHook(() => useTransactionHistory(PUBLIC_KEY, { pageSize: 2 }))
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 450))
+    })
+
+    await waitFor(() => expect(result.current.transactions).toHaveLength(2))
+
+    act(() => {
+      result.current.loadMore()
+    })
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+
+    const secondRequestUrl = new URL(fetchMock.mock.calls[1]?.[0] as string)
+    expect(secondRequestUrl.searchParams.get('cursor')).toBe('cursor-2')
+
+    await waitFor(() => expect(result.current.transactions).toHaveLength(3))
+  })
+})

--- a/frontend/src/hooks/useTransactionHistory.ts
+++ b/frontend/src/hooks/useTransactionHistory.ts
@@ -19,6 +19,12 @@ interface UseTransactionHistoryOptions {
   pageSize?: number;
 }
 
+interface TransactionHistoryCacheEntry {
+  items: TransactionHistoryItem[];
+  nextCursor: string | null;
+  hasMore: boolean;
+}
+
 export function useTransactionHistory(
   publicKey: string | undefined,
   options: UseTransactionHistoryOptions = {}
@@ -28,8 +34,9 @@ export function useTransactionHistory(
   const [error, setError] = useState<string | null>(null);
   const [hasMore, setHasMore] = useState(true);
   const [page, setPage] = useState(1);
-  const cacheRef = useRef<{ [key: string]: TransactionHistoryItem[] }>({});
-  const debounceRef = useRef<number | null>(null);
+  const cacheRef = useRef<{ [key: string]: TransactionHistoryCacheEntry }>({});
+  const nextCursorRef = useRef<string | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const pageSize = options.pageSize || 10;
 
@@ -39,25 +46,36 @@ export function useTransactionHistory(
       setLoading(true);
       setError(null);
       try {
-        const cacheKey = `${publicKey}-${page}`;
+        const cursor = reset ? null : nextCursorRef.current;
+        const cacheKey = `${publicKey}-${pageSize}-${cursor || 'initial'}`;
         if (cacheRef.current[cacheKey]) {
+          const cached = cacheRef.current[cacheKey];
           setTransactions((prev: TransactionHistoryItem[]) =>
-            reset ? cacheRef.current[cacheKey] : [...prev, ...cacheRef.current[cacheKey]]
+            reset ? cached.items : [...prev, ...cached.items]
           );
-          setHasMore(cacheRef.current[cacheKey].length === pageSize);
+          nextCursorRef.current = cached.nextCursor;
+          setHasMore(cached.hasMore);
           setLoading(false);
           return;
         }
-        const url = `https://horizon.stellar.org/accounts/${publicKey}/operations?order=desc&limit=${pageSize}&cursor=`;
-        const resp = await fetch(url);
+        const url = new URL(`https://horizon.stellar.org/accounts/${publicKey}/operations`);
+        url.searchParams.set('order', 'desc');
+        url.searchParams.set('limit', String(pageSize));
+        if (cursor) url.searchParams.set('cursor', cursor);
+        const resp = await fetch(url.toString());
         if (!resp.ok) throw new Error('Failed to fetch transactions');
         const data = await resp.json();
-        const items: TransactionHistoryItem[] = (data._embedded?.records || [])
+        const records: any[] = data._embedded?.records || [];
+        const items: TransactionHistoryItem[] = records
           .map((op: any) => parseOperation(op, options))
           .filter((item: TransactionHistoryItem | null) => item !== null);
-        cacheRef.current[cacheKey] = items;
+        const lastRecord = records.length > 0 ? records[records.length - 1] : null;
+        const nextCursor = lastRecord?.paging_token || null;
+        const hasMoreResults = records.length === pageSize && nextCursor !== null;
+        cacheRef.current[cacheKey] = { items, nextCursor, hasMore: hasMoreResults };
+        nextCursorRef.current = nextCursor;
         setTransactions((prev: TransactionHistoryItem[]) => (reset ? items : [...prev, ...items]));
-        setHasMore(items.length === pageSize);
+        setHasMore(hasMoreResults);
       } catch (e: any) {
         setError(e.message || 'Unknown error');
       } finally {
@@ -72,6 +90,7 @@ export function useTransactionHistory(
     if (!publicKey) return;
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
+      nextCursorRef.current = null;
       setPage(1);
       setTransactions([]);
       fetchTransactions(true);


### PR DESCRIPTION
## Summary

- track the Horizon operation `paging_token` from the last record in each fetched page
- pass that cursor into the next `operations` request when loading more transaction history
- add a regression test covering the second request cursor after `loadMore()`

Fixes #838.

## Verification

- `npm test -- --run src/hooks/__tests__/useTransactionHistory.test.tsx`
- `npx tsc --noEmit --target ES2020 --lib ES2020,DOM,DOM.Iterable,ES2020.BigInt --module ESNext --moduleResolution bundler --jsx react-jsx --skipLibCheck --strict --noUncheckedIndexedAccess --exactOptionalPropertyTypes --allowImportingTsExtensions --types vitest/globals,@testing-library/jest-dom src/hooks/useTransactionHistory.ts src/hooks/__tests__/useTransactionHistory.test.tsx`

Note: full-project `npx tsc --noEmit --project tsconfig.json` currently fails on existing unrelated files.