### PR TITLE
feat: render token metadata IPFS image

### DIFF
--- a/frontend/src/components/TokenMetadata.test.tsx
+++ b/frontend/src/components/TokenMetadata.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { TokenMetadata } from './TokenMetadata'
+import { ipfsService } from '../services/ipfs'
+
+vi.mock('../services/ipfs', () => ({
+  ipfsService: {
+    getMetadata: vi.fn(),
+  },
+}))
+
+const mockedGetMetadata = vi.mocked(ipfsService.getMetadata)
+
+describe('TokenMetadata', () => {
+  it('renders an IPFS metadata image through the Pinata gateway', async () => {
+    mockedGetMetadata.mockResolvedValueOnce({
+      image: 'ipfs://QmTokenImage',
+      description: 'Pinned token artwork',
+    })
+
+    render(<TokenMetadata metadataUri="ipfs://QmMetadata" name="Forge Token" symbol="FORGE" />)
+
+    const image = await screen.findByRole('img', { name: 'Forge Token' })
+
+    expect(mockedGetMetadata).toHaveBeenCalledWith('ipfs://QmMetadata')
+    expect(image).toHaveAttribute('src', 'https://gateway.pinata.cloud/ipfs/QmTokenImage')
+    expect(image).toHaveAttribute('loading', 'lazy')
+    expect(screen.getByText('Pinned token artwork')).toBeInTheDocument()
+  })
+
+  it('shows the placeholder when metadata has no image', async () => {
+    mockedGetMetadata.mockResolvedValueOnce({
+      description: 'No artwork was pinned',
+    })
+
+    render(<TokenMetadata metadataUri="ipfs://QmMetadata" name="Forge Token" symbol="FORGE" />)
+
+    const placeholder = await screen.findByTestId('placeholder-image')
+
+    expect(placeholder).toHaveAttribute('alt', 'Forge Token placeholder')
+    expect(screen.queryByRole('img', { name: 'Forge Token' })).not.toBeInTheDocument()
+  })
+
+  it('falls back to the placeholder when the image fails to load', async () => {
+    mockedGetMetadata.mockResolvedValueOnce({
+      image: 'ipfs://QmBrokenImage',
+    })
+
+    render(<TokenMetadata metadataUri="ipfs://QmMetadata" name="Forge Token" symbol="FORGE" />)
+
+    fireEvent.error(await screen.findByRole('img', { name: 'Forge Token' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('placeholder-image')).toHaveAttribute(
+        'alt',
+        'Forge Token placeholder',
+      )
+    })
+  })
+})

--- a/frontend/src/components/TokenMetadata.tsx
+++ b/frontend/src/components/TokenMetadata.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { Skeleton } from './UI/Skeleton'
 import { ipfsService } from '../services/ipfs'
+import { ipfsToGatewayUrl } from '../utils/formatting'
 
 interface TokenMetadataResponse {
   image?: string
@@ -17,9 +18,10 @@ interface TokenMetadataProps {
 
 type FetchState =
   | { status: 'idle' }
-  | { status: 'loading' }
-  | { status: 'resolved'; imageUrl: string; description: string | undefined }
-  | { status: 'error' }
+  | { status: 'resolved'; uri: string; imageUrl: string; description: string | undefined }
+  | { status: 'error'; uri: string }
+
+type ViewState = FetchState | { status: 'loading' }
 
 const PLACEHOLDER_SRC =
   'data:image/svg+xml,%3Csvg xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22 width%3D%22100%22 height%3D%22100%22 viewBox%3D%220 0 100 100%22%3E%3Crect width%3D%22100%22 height%3D%22100%22 fill%3D%22%23e5e7eb%22%2F%3E%3Ctext x%3D%2250%22 y%3D%2255%22 font-size%3D%2232%22 text-anchor%3D%22middle%22 fill%3D%22%239ca3af%22%3E%3F%3C%2Ftext%3E%3C%2Fsvg%3E'
@@ -31,53 +33,62 @@ export const TokenMetadata: React.FC<TokenMetadataProps> = ({
   className = '',
 }) => {
   const [state, setState] = useState<FetchState>({ status: 'idle' })
+  const normalizedMetadataUri = metadataUri?.trim() ?? ''
 
   useEffect(() => {
-    const uri = metadataUri?.trim()
-    if (!uri) {
-      setState({ status: 'idle' })
+    if (!normalizedMetadataUri) {
       return
     }
 
     let cancelled = false
-    setState({ status: 'loading' })
 
     ipfsService
-      .getMetadata(uri)
+      .getMetadata(normalizedMetadataUri)
       .then((data: TokenMetadataResponse) => {
         if (cancelled) return
         if (!data?.image) {
-          setState({ status: 'error' })
+          setState({ status: 'error', uri: normalizedMetadataUri })
           return
         }
-        setState({ status: 'resolved', imageUrl: data.image, description: data.description })
+        setState({
+          status: 'resolved',
+          uri: normalizedMetadataUri,
+          imageUrl: ipfsToGatewayUrl(data.image),
+          description: data.description,
+        })
       })
-      .catch((_err: unknown) => {
+      .catch(() => {
         if (cancelled) return
-        setState({ status: 'error' })
+        setState({ status: 'error', uri: normalizedMetadataUri })
       })
 
     return () => {
       cancelled = true
     }
-  }, [metadataUri])
+  }, [normalizedMetadataUri])
 
-  const showPlaceholder = state.status === 'idle' || state.status === 'error'
+  const viewState: ViewState =
+    normalizedMetadataUri && state.status !== 'idle' && state.uri === normalizedMetadataUri
+      ? state
+      : normalizedMetadataUri
+        ? { status: 'loading' }
+        : { status: 'idle' }
+  const showPlaceholder = viewState.status === 'idle' || viewState.status === 'error'
 
   return (
     <div className={`flex flex-col items-center gap-2 ${className}`}>
-      {state.status === 'loading' && (
+      {viewState.status === 'loading' && (
         <div aria-label="Loading token metadata" aria-busy="true">
           <Skeleton className="h-24 w-24 rounded-full" />
         </div>
       )}
 
-      {state.status === 'resolved' && (
+      {viewState.status === 'resolved' && (
         <img
-          src={state.imageUrl}
+          src={viewState.imageUrl}
           alt={name}
           loading="lazy"
-          onError={() => setState({ status: 'error' })}
+          onError={() => setState({ status: 'error', uri: viewState.uri })}
           className="h-24 w-24 rounded-full object-cover"
         />
       )}
@@ -95,8 +106,8 @@ export const TokenMetadata: React.FC<TokenMetadataProps> = ({
       <div className="text-center">
         <p className="font-semibold text-gray-900">{name}</p>
         <p className="text-sm text-gray-500">{symbol}</p>
-        {state.status === 'resolved' && state.description && (
-          <p className="mt-1 text-sm text-gray-600">{state.description}</p>
+        {viewState.status === 'resolved' && viewState.description && (
+          <p className="mt-1 text-sm text-gray-600">{viewState.description}</p>
         )}
       </div>
     </div>


### PR DESCRIPTION
Closes #753.

## Summary
- Convert token metadata `image: ipfs://...` values to the configured Pinata gateway URL before rendering.
- Keep lazy image loading and swap to the existing placeholder when metadata is missing, metadata fetch fails, or the image itself fails to load.
- Avoid stale image state when `metadataUri` changes by deriving the visible loading/idle state from the current normalized URI.
- Add focused `TokenMetadata` tests for gateway rendering, missing-image fallback, and broken-image fallback.

## Validation
- RED first: `npm test -- src/components/TokenMetadata.test.tsx --run` failed before the implementation because the rendered `img` src was still `ipfs://QmTokenImage` instead of `https://gateway.pinata.cloud/ipfs/QmTokenImage`.
- `npm test -- src/components/TokenMetadata.test.tsx --run`
- `npm run build`
- `npx prettier --check frontend/src/components/TokenMetadata.tsx frontend/src/components/TokenMetadata.test.tsx`
- `git diff --check`
- `ESLINT_USE_FLAT_CONFIG=false npx eslint src/components/TokenMetadata.tsx src/components/TokenMetadata.test.tsx --rule 'react-refresh/only-export-components: off'`

## Notes
- The repo's current ESLint setup uses `.eslintrc.cjs` with ESLint 9, so the regular `npm run lint` fails before linting with `ESLint couldn't find an eslint.config` unless legacy config mode is enabled. In legacy mode, the `react-refresh/only-export-components` rule also does not load cleanly from the current config, so I disabled only that known config-level rule for the touched-file lint command above.
- Full `npm test -- --run` still has unrelated main-branch failures in existing formatting, monitoring, retry, localStorage, MintForm, and TransactionStatus tests. The focused TokenMetadata tests pass.
