### PR TITLE
feat: add polling, last-updated indicator, and refresh to useTransactionHistory (#752)

### DIFF
--- a/frontend/src/components/TransactionHistory.tsx
+++ b/frontend/src/components/TransactionHistory.tsx
@@ -23,6 +23,17 @@ const badgeColors: Record<string, string> = {
   failed: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
 }
 
+function timeAgo(date: Date): string {
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
 export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
   publicKey = '',
   contractId,
@@ -32,7 +43,7 @@ export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
 }) => {
   const { t } = useTranslation()
   const resolvedContractIds = contractId ? [contractId, ...(contractIds ?? [])] : contractIds
-  const { transactions, loading, error, hasMore, loadMore } = useTransactionHistory(publicKey, {
+  const { transactions, loading, error, hasMore, loadMore, lastUpdated, refresh } = useTransactionHistory(publicKey, {
     assetCodes,
     issuer,
     contractIds: resolvedContractIds,
@@ -57,7 +68,38 @@ export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
 
   return (
     <div className="w-full max-w-3xl mx-auto p-4">
-      <h2 className="text-2xl font-bold mb-4">Transaction History</h2>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-2xl font-bold">Transaction History</h2>
+        <div className="flex items-center gap-3">
+          {lastUpdated && (
+            <span className="text-xs text-gray-400 dark:text-gray-500">
+              Last updated {timeAgo(lastUpdated)}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={refresh}
+            disabled={loading}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
+          >
+            <svg
+              className={`w-3.5 h-3.5 ${loading ? 'animate-spin' : ''}`}
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182"
+              />
+            </svg>
+            Refresh
+          </button>
+        </div>
+      </div>
       {loading && transactions.length === 0 && (
         <div className="animate-pulse space-y-2" aria-label="Loading transactions" aria-busy="true">
           {[...Array(5)].map((_, i) => (

--- a/frontend/src/hooks/useTransactionHistory.ts
+++ b/frontend/src/hooks/useTransactionHistory.ts
@@ -17,6 +17,7 @@ interface UseTransactionHistoryOptions {
   issuer?: string;
   contractIds?: string[];
   pageSize?: number;
+  pollIntervalMs?: number;
 }
 
 export function useTransactionHistory(
@@ -28,10 +29,14 @@ export function useTransactionHistory(
   const [error, setError] = useState<string | null>(null);
   const [hasMore, setHasMore] = useState(true);
   const [page, setPage] = useState(1);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const cacheRef = useRef<{ [key: string]: TransactionHistoryItem[] }>({});
   const debounceRef = useRef<number | null>(null);
+  const pollRef = useRef<number | null>(null);
+  const isMountedRef = useRef(true);
 
   const pageSize = options.pageSize || 10;
+  const pollIntervalMs = options.pollIntervalMs ?? 30_000;
 
   const fetchTransactions = useCallback(
     async (reset = false) => {
@@ -46,6 +51,7 @@ export function useTransactionHistory(
           );
           setHasMore(cacheRef.current[cacheKey].length === pageSize);
           setLoading(false);
+          setLastUpdated(new Date());
           return;
         }
         const url = `https://horizon.stellar.org/accounts/${publicKey}/operations?order=desc&limit=${pageSize}&cursor=`;
@@ -58,6 +64,7 @@ export function useTransactionHistory(
         cacheRef.current[cacheKey] = items;
         setTransactions((prev: TransactionHistoryItem[]) => (reset ? items : [...prev, ...items]));
         setHasMore(items.length === pageSize);
+        setLastUpdated(new Date());
       } catch (e: any) {
         setError(e.message || 'Unknown error');
       } finally {
@@ -86,11 +93,37 @@ export function useTransactionHistory(
     // eslint-disable-next-line
   }, [page]);
 
+  // Polling: re-fetch the first page every pollIntervalMs
+  useEffect(() => {
+    isMountedRef.current = true;
+    const id = setInterval(() => {
+      if (!publicKey || !isMountedRef.current) return;
+      if (page === 1) {
+        cacheRef.current = {};
+        fetchTransactions(true);
+      }
+    }, pollIntervalMs);
+    pollRef.current = id;
+    return () => {
+      isMountedRef.current = false;
+      clearInterval(id);
+    };
+    // eslint-disable-next-line
+  }, [publicKey, pollIntervalMs]);
+
   const loadMore = useCallback(() => {
     if (!loading && hasMore) setPage((p: number) => p + 1);
   }, [loading, hasMore]);
 
-  return { transactions, loading, error, hasMore, loadMore };
+  const refresh = useCallback(() => {
+    cacheRef.current = {};
+    setPage(1);
+    setTransactions([]);
+    fetchTransactions(true);
+    // eslint-disable-next-line
+  }, [publicKey, pageSize, options]);
+
+  return { transactions, loading, error, hasMore, loadMore, lastUpdated, refresh };
 }
 
 function parseOperation(op: any, options: UseTransactionHistoryOptions): TransactionHistoryItem | null {


### PR DESCRIPTION
## Summary

Closes #752

Adds automatic polling, a `lastUpdated` indicator, and a manual refresh button to `useTransactionHistory`, so new transactions appear without a page refresh.

## Changes

### `useTransactionHistory` hook
- Added `setInterval` (30s default) to re-fetch the first page periodically
- Added `lastUpdated` state (`Date | null`) updated on every successful fetch
- Added `refresh()` callback that resets cache, clears transactions, and re-fetches
- Added `pollIntervalMs` option to `UseTransactionHistoryOptions` (defaults to 30,000ms)
- Interval is cleared on unmount via `useRef` to prevent memory leaks
- `isMountedRef` guards against state updates after unmount

### `TransactionHistory` component
- Header row with title, last-updated indicator, and refresh button
- `timeAgo()` helper formats the elapsed time as "X s/m/h/d ago"
- Refresh button shows a spinning icon while loading, disabled during fetch

## Acceptance Criteria
- [x] New events appear within 30 seconds without a page refresh
- [x] Interval is cleared when the component unmounts (no memory leak)
- [x] Manual refresh button triggers an immediate fetch