### PR TITLE
BurnForm: show current token balance before burn

### DIFF
--- a/frontend/src/components/BurnForm.tsx
+++ b/frontend/src/components/BurnForm.tsx
@@ -163,9 +163,15 @@ export const BurnForm: React.FC<BurnFormProps> = ({
 
         {/* Balance display */}
         {wallet.address && debouncedAddress && (
-          <div className="flex items-center justify-between rounded-md bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm">
+          <div
+            className="flex items-center justify-between rounded-md bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm"
+            data-testid="burn-balance-display"
+          >
             <span className="text-gray-500 dark:text-gray-400">Your balance</span>
-            <span className="font-mono font-medium text-gray-900 dark:text-gray-100">
+            <span
+              className="font-mono font-medium text-gray-900 dark:text-gray-100"
+              data-testid="burn-balance-value"
+            >
               {balanceLoading ? (
                 <span className="animate-pulse text-gray-400">Loading…</span>
               ) : (
@@ -206,12 +212,13 @@ export const BurnForm: React.FC<BurnFormProps> = ({
               disabled={!balance || balance === '0' || balanceLoading}
               onClick={() => setValue('amount', balance, { shouldValidate: true })}
               className="mb-0.5 border-red-300 text-red-600 hover:bg-red-50 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-900/20"
+              data-testid="burn-max-button"
             >
               Max
             </Button>
           </div>
           {amountExceedsBalance && (
-            <p className="mt-1 text-xs text-red-600 dark:text-red-400" role="alert">
+            <p className="mt-1 text-xs text-red-600 dark:text-red-400" role="alert" data-testid="burn-exceeds-balance-error">
               Amount exceeds your balance of {balance}
             </p>
           )}


### PR DESCRIPTION
## Description

All four acceptance criteria from issue #755 are **already implemented** in the current BurnForm component:
- ✅ `useTokenBalance` hook fetches the connected wallet's balance for the selected token
- ✅ Balance is displayed above the amount input
- ✅ "Max" button fills the amount field with the full balance
- ✅ Amount exceeding balance shows an inline error

This PR adds `data-testid` attributes across the balance display, Max button, and validation error for **testability** (E2E and integration tests).

## Changes

| Element | data-testid |
|---------|-------------|
| Balance display container | `burn-balance-display` |
| Balance value + symbol | `burn-balance-value` |
| Max button | `burn-max-button` |
| Over-balance error message | `burn-exceeds-balance-error` |

Closes #755
