### PR TITLE
feat: show XLM/USD equivalent in FeeDisplay component

### DIFF
--- a/frontend/src/components/FeeDisplay.tsx
+++ b/frontend/src/components/FeeDisplay.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 
 import { stellarService, type FactoryState } from '../services/stellar'
 import { stroopsToXLM, formatXLM } from '../utils/formatting'
+import { useXlmPrice } from '../hooks/useXlmPrice'
 
 interface FeeDisplayProps {
   feeType: 'base' | 'metadata'
@@ -34,6 +35,7 @@ export const FeeDisplay: React.FC<FeeDisplayProps> = ({
 }: FeeDisplayProps) => {
   const [xlm, setXlm] = useState<number | null>(null)
   const [error, setError] = useState(false)
+  const { price: xlmUsdPrice } = useXlmPrice()
 
   useEffect(() => {
     let cancelled = false
@@ -68,9 +70,12 @@ export const FeeDisplay: React.FC<FeeDisplayProps> = ({
     )
   }
 
+  const usdAmount = xlmUsdPrice !== null ? (xlm * xlmUsdPrice).toFixed(2) : null
+
   return (
     <span className={`text-sm text-gray-700 ${className}`}>
       {label}: {formatXLM(xlm)}
+      {usdAmount !== null && <span className="text-gray-400 ml-1">≈ ${usdAmount} USD</span>}
     </span>
   )
 }

--- a/frontend/src/hooks/useXlmPrice.ts
+++ b/frontend/src/hooks/useXlmPrice.ts
@@ -1,0 +1,102 @@
+import { useEffect, useState } from 'react'
+
+/** CoinGecko price cache — shared across all hook instances */
+let cachedPrice: number | null = null
+let cachedAt = 0
+const CACHE_TTL = 60_000 // 60 seconds
+let pendingFetch: Promise<number> | null = null
+
+async function fetchXlmUsdPrice(): Promise<number> {
+  const now = Date.now()
+  if (cachedPrice !== null && now - cachedAt < CACHE_TTL) {
+    return cachedPrice
+  }
+  if (pendingFetch) return pendingFetch
+
+  pendingFetch = fetch(
+    'https://api.coingecko.com/api/v3/simple/price?ids=stellar&vs_currencies=usd',
+    { signal: AbortSignal.timeout(5000) },
+  )
+    .then((res) => {
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      return res.json()
+    })
+    .then((data) => {
+      const price = data?.stellar?.usd ?? null
+      if (price === null) throw new Error('No price in response')
+      cachedPrice = price
+      cachedAt = Date.now()
+      pendingFetch = null
+      return price
+    })
+    .catch((err) => {
+      pendingFetch = null
+      throw err
+    })
+
+  return pendingFetch
+}
+
+export interface XlmPriceResult {
+  /** USD price per XLM, or null if loading / unavailable */
+  price: number | null
+  /** true when the price fetch is in flight */
+  loading: boolean
+  /** true when the price fetch failed and we fell back to hidden */
+  unavailable: boolean
+}
+
+export function useXlmPrice(): XlmPriceResult {
+  const [price, setPrice] = useState<number | null>(cachedPrice)
+  const [loading, setLoading] = useState(!cachedPrice)
+  const [unavailable, setUnavailable] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+
+    if (cachedPrice !== null) {
+      setPrice(cachedPrice)
+      setLoading(false)
+      setUnavailable(false)
+      return
+    }
+
+    setLoading(true)
+    fetchXlmUsdPrice()
+      .then((p) => {
+        if (!cancelled) {
+          setPrice(p)
+          setLoading(false)
+          setUnavailable(false)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setUnavailable(true)
+          setLoading(false)
+        }
+      })
+
+    // Refresh every 60s while mounted
+    const interval = setInterval(() => {
+      cachedPrice = null // invalidate cache
+      fetchXlmUsdPrice()
+        .then((p) => {
+          if (!cancelled) {
+            setPrice(p)
+            setUnavailable(false)
+          }
+        })
+        .catch(() => {
+          if (!cancelled) setUnavailable(true)
+        })
+    }, 60_000)
+
+    return () => {
+      cancelled = true
+      clearInterval(interval)
+    }
+  }, [])
+
+  return { price, loading, unavailable }
+}


### PR DESCRIPTION
Closes #733

## Changes

- Added `useXlmPrice` hook that fetches XLM/USD price from CoinGecko API
- Price is cached for 60 seconds to avoid excessive API calls
- FeeDisplay now shows `≈ .XX USD` next to the XLM fee amount
- USD line is hidden gracefully when price data is unavailable
- No error is thrown when the price API fails

## Verification

- [x] `npm run format:check` → PASS
- [x] `npm run build` → PASS
- [x] TypeScript errors: only pre-existing ones (none introduced by this PR)
- [x] Pre-existing lint failures unrelated to this change