### PR TITLE
fix(ipfs): retry image upload on transient Pinata errors

### DIFF
--- a/frontend/src/components/MetadataForm.tsx
+++ b/frontend/src/components/MetadataForm.tsx
@@ -122,8 +122,12 @@ export const MetadataForm: React.FC<MetadataFormProps> = ({ initialTokenAddress 
     setStep('uploading-ipfs')
     let metadataUri: string
     try {
-      metadataUri = await ipfsService.uploadMetadata(imageFile!, description, tokenAddress, (p) =>
-        setUploadProgress(p),
+      metadataUri = await ipfsService.uploadMetadata(
+        imageFile!,
+        description,
+        tokenAddress,
+        (p) => setUploadProgress(p),
+        (attempt) => addToast(`Retrying upload… (attempt ${attempt}/3)`, 'warning'),
       )
       setFinalUri(metadataUri)
     } catch (err) {

--- a/frontend/src/components/MetadataUploadForm.tsx
+++ b/frontend/src/components/MetadataUploadForm.tsx
@@ -82,7 +82,12 @@ export const MetadataUploadForm: React.FC<MetadataUploadFormProps> = ({
         description,
         tokenName,
         (progress) => setUploadProgress(progress),
-      )
+        (attempt) =>
+          addToast(
+            `Retrying upload… (attempt ${attempt}/3)`,
+            "warning",
+          ),
+      );
 
       addToast('Metadata uploaded successfully!', 'success')
       onUploadComplete(metadataUri)

--- a/frontend/src/services/ipfs.ts
+++ b/frontend/src/services/ipfs.ts
@@ -1,23 +1,31 @@
 // IPFS service for metadata upload via Pinata
 
-import { IPFS_CONFIG } from '../config/ipfs'
-import { withRetry, isTransientError } from '../utils/retry'
-import { isValidImageFile } from '../utils/validation'
-import { IPFSConfigError, IPFSUploadError } from './ipfs-errors'
+import { IPFS_CONFIG } from "../config/ipfs";
+import { withRetry, isTransientError, HttpError } from "../utils/retry";
+import { isValidImageFile } from "../utils/validation";
+import { IPFSConfigError, IPFSUploadError } from "./ipfs-errors";
 
-export { IPFSConfigError, IPFSUploadError } from './ipfs-errors'
+export { IPFSConfigError, IPFSUploadError } from "./ipfs-errors";
 
 export interface TokenMetadata {
-  name: string
-  description: string
-  image: string // ipfs:// URI
+  name: string;
+  description: string;
+  image: string; // ipfs:// URI
+}
+
+export interface UploadMetadataOptions {
+  image: File;
+  description: string;
+  tokenName: string;
+  onProgress?: (percent: number) => void;
+  onRetry?: (attempt: number, delayMs: number) => void;
 }
 
 function validateConfig(): void {
   if (!IPFS_CONFIG.apiKey || !IPFS_CONFIG.apiSecret) {
     throw new IPFSConfigError(
-      'Pinata API credentials are not configured. Please set VITE_IPFS_API_KEY and VITE_IPFS_API_SECRET in your .env file.',
-    )
+      "Pinata API credentials are not configured. Please set VITE_IPFS_API_KEY and VITE_IPFS_API_SECRET in your .env file.",
+    );
   }
 }
 
@@ -29,39 +37,47 @@ export class IPFSService {
    * @param description - Token description
    * @param tokenName   - Token name (used as metadata `name` field)
    * @param onProgress  - Optional progress callback (0–100)
+   * @param onRetry     - Optional callback fired before each retry attempt
    * @returns           Metadata URI in ipfs:// format
    *
    * @throws {IPFSConfigError}  When API credentials are missing
-   * @throws {IPFSUploadError}  On validation failures, auth errors, or network errors
+   * @throws {IPFSUploadError}  On validation failures, auth errors, or exhausted retries
    */
   async uploadMetadata(
     image: File,
     description: string,
     tokenName: string,
     onProgress?: (percent: number) => void,
+    onRetry?: (attempt: number, delayMs: number) => void,
   ): Promise<string> {
-    validateConfig()
+    validateConfig();
 
-    const validation = isValidImageFile(image)
+    const validation = isValidImageFile(image);
     if (!validation.valid) {
-      throw new IPFSUploadError(validation.error ?? 'Invalid image file.')
+      throw new IPFSUploadError(
+        validation.error ?? "Invalid image file.",
+      );
     }
 
     // Step 1: Upload image file (progress 0 → 75)
-    onProgress?.(0)
-    const imageCid = await this._uploadFile(image, onProgress)
+    onProgress?.(0);
+    const imageCid = await this._uploadFile(image, onProgress, onRetry);
 
     // Step 2: Build and upload metadata JSON (progress 75 → 100)
-    onProgress?.(75)
+    onProgress?.(75);
     const metadata: TokenMetadata = {
       name: tokenName,
       description,
       image: `ipfs://${imageCid}`,
-    }
-    const metadataCid = await this._uploadJSON(metadata, `${tokenName}-metadata.json`)
-    onProgress?.(100)
+    };
+    const metadataCid = await this._uploadJSON(
+      metadata,
+      `${tokenName}-metadata.json`,
+      onRetry,
+    );
+    onProgress?.(100);
 
-    return `ipfs://${metadataCid}`
+    return `ipfs://${metadataCid}`;
   }
 
   /**
@@ -70,146 +86,242 @@ export class IPFSService {
    * @throws {IPFSUploadError} On invalid URI, network errors, or non-JSON responses
    */
   async getMetadata(uri: string): Promise<TokenMetadata> {
-    if (!uri.startsWith('ipfs://')) {
-      throw new IPFSUploadError(`Invalid IPFS URI: "${uri}". Expected format: ipfs://<CID>`)
+    if (!uri.startsWith("ipfs://")) {
+      throw new IPFSUploadError(
+        `Invalid IPFS URI: "${uri}". Expected format: ipfs://<CID>`,
+      );
     }
 
-    const cid = uri.replace('ipfs://', '')
-    const url = `${IPFS_CONFIG.pinataGateway}/${cid}`
+    const cid = uri.replace("ipfs://", "");
+    const url = `${IPFS_CONFIG.pinataGateway}/${cid}`;
 
-    let response: Response
+    let response: Response;
     try {
       response = await withRetry(() => fetch(url), {
         shouldRetry: (err) => isTransientError(err),
-      })
+      });
     } catch {
       throw new IPFSUploadError(
-        'Network error while fetching metadata from IPFS gateway. Check your connection.',
-      )
+        "Network error while fetching metadata from IPFS gateway. Check your connection.",
+      );
     }
 
     if (!response.ok) {
       throw new IPFSUploadError(
         `Failed to fetch metadata (HTTP ${response.status}). The CID may not be pinned yet.`,
-      )
+      );
     }
 
     try {
-      return (await response.json()) as TokenMetadata
+      return (await response.json()) as TokenMetadata;
     } catch {
-      throw new IPFSUploadError('Metadata response is not valid JSON.')
+      throw new IPFSUploadError(
+        "Metadata response is not valid JSON.",
+      );
     }
   }
 
   // ── Private helpers ──────────────────────────────────────────────────────────
 
-  private _uploadFile(file: File, onProgress?: (percent: number) => void): Promise<string> {
-    const formData = new FormData()
-    formData.append('file', file)
-    formData.append('pinataMetadata', JSON.stringify({ name: file.name }))
-    formData.append('pinataOptions', JSON.stringify({ cidVersion: 1 }))
+  private _uploadFile(
+    file: File,
+    onProgress?: (percent: number) => void,
+    onRetry?: (attempt: number, delayMs: number) => void,
+  ): Promise<string> {
+    const doUpload = (): Promise<string> =>
+      new Promise<string>((resolve, reject) => {
+        const xhr = new XMLHttpRequest();
 
-    return new Promise<string>((resolve, reject) => {
-      const xhr = new XMLHttpRequest()
-
-      xhr.upload.addEventListener('progress', (e) => {
-        if (e.lengthComputable && onProgress) {
-          onProgress(Math.round((e.loaded / e.total) * 75))
-        }
-      })
-
-      xhr.addEventListener('load', () => {
-        if (xhr.status === 401) {
-          reject(
-            new IPFSUploadError('Pinata authentication failed. Check your API key and secret.'),
-          )
-          return
-        }
-        if (xhr.status !== 200) {
-          reject(new IPFSUploadError(`Image upload failed (HTTP ${xhr.status}). Please try again.`))
-          return
-        }
-        try {
-          const data = JSON.parse(xhr.responseText) as { IpfsHash: string }
-          if (!data.IpfsHash) {
-            reject(new IPFSUploadError('Pinata returned an unexpected response: missing IpfsHash.'))
-            return
+        xhr.upload.addEventListener("progress", (e) => {
+          if (e.lengthComputable && onProgress) {
+            onProgress(
+              Math.round((e.loaded / e.total) * 75),
+            );
           }
-          resolve(data.IpfsHash)
-        } catch {
-          reject(new IPFSUploadError('Unexpected response from Pinata while uploading image.'))
-        }
-      })
+        });
 
-      xhr.addEventListener('error', () => {
-        reject(
-          new IPFSUploadError(
-            'Network error during image upload. Check your connection and try again.',
-          ),
-        )
-      })
+        xhr.addEventListener("load", () => {
+          if (
+            xhr.status === 429 ||
+            (xhr.status >= 500 && xhr.status < 600)
+          ) {
+            reject(
+              new HttpError(
+                xhr.status,
+                `Image upload failed (HTTP ${xhr.status})`,
+                xhr.status === 429
+                  ? parseInt(
+                      xhr.getResponseHeader("Retry-After") ?? "0",
+                    ) || undefined
+                  : undefined,
+              ),
+            );
+            return;
+          }
 
-      xhr.addEventListener('abort', () => {
-        reject(new IPFSUploadError('Image upload was aborted.'))
-      })
+          if (xhr.status === 401) {
+            reject(
+              new IPFSUploadError(
+                "Pinata authentication failed. Check your API key and secret.",
+              ),
+            );
+            return;
+          }
+          if (xhr.status !== 200) {
+            reject(
+              new IPFSUploadError(
+                `Image upload failed (HTTP ${xhr.status}). Please try again.`,
+              ),
+            );
+            return;
+          }
+          try {
+            const data = JSON.parse(xhr.responseText) as {
+              IpfsHash: string;
+            };
+            if (!data.IpfsHash) {
+              reject(
+                new IPFSUploadError(
+                  "Pinata returned an unexpected response: missing IpfsHash.",
+                ),
+              );
+              return;
+            }
+            resolve(data.IpfsHash);
+          } catch {
+            reject(
+              new IPFSUploadError(
+                "Unexpected response from Pinata while uploading image.",
+              ),
+            );
+          }
+        });
 
-      xhr.open('POST', `${IPFS_CONFIG.pinataApiUrl}/pinning/pinFileToIPFS`)
-      xhr.setRequestHeader('pinata_api_key', IPFS_CONFIG.apiKey)
-      xhr.setRequestHeader('pinata_secret_api_key', IPFS_CONFIG.apiSecret)
-      xhr.send(formData)
-    })
+        xhr.addEventListener("error", () => {
+          reject(
+            new HttpError(
+              0,
+              "Network error during image upload",
+            ),
+          );
+        });
+
+        xhr.addEventListener("abort", () => {
+          reject(new IPFSUploadError("Image upload was aborted."));
+        });
+
+        xhr.open(
+          "POST",
+          `${IPFS_CONFIG.pinataApiUrl}/pinning/pinFileToIPFS`,
+        );
+        xhr.setRequestHeader(
+          "pinata_api_key",
+          IPFS_CONFIG.apiKey,
+        );
+        xhr.setRequestHeader(
+          "pinata_secret_api_key",
+          IPFS_CONFIG.apiSecret,
+        );
+        xhr.send(formData);
+      });
+
+    const formData = new FormData();
+    formData.append("file", file);
+    formData.append(
+      "pinataMetadata",
+      JSON.stringify({ name: file.name }),
+    );
+    formData.append(
+      "pinataOptions",
+      JSON.stringify({ cidVersion: 1 }),
+    );
+
+    return withRetry(doUpload, {
+      maxAttempts: 3,
+      shouldRetry: (err) => isTransientError(err),
+      onRetry,
+    }).catch((err) => {
+      if (err instanceof IPFSUploadError) throw err;
+      const httpErr = err instanceof HttpError ? err : null;
+      if (httpErr) {
+        throw new IPFSUploadError(
+          httpErr.status === 0
+            ? "Network error during image upload. Check your connection and try again."
+            : `Image upload failed (HTTP ${httpErr.status}). Please try again.`,
+        );
+      }
+      throw err;
+    });
   }
 
-  private async _uploadJSON(json: object, name: string): Promise<string> {
+  private async _uploadJSON(
+    json: object,
+    name: string,
+    onRetry?: (attempt: number, delayMs: number) => void,
+  ): Promise<string> {
     const body = {
       pinataContent: json,
       pinataMetadata: { name },
       pinataOptions: { cidVersion: 1 },
-    }
+    };
 
-    let response: Response
+    let response: Response;
     try {
       response = await withRetry(
         () =>
-          fetch(`${IPFS_CONFIG.pinataApiUrl}/pinning/pinJSONToIPFS`, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              pinata_api_key: IPFS_CONFIG.apiKey,
-              pinata_secret_api_key: IPFS_CONFIG.apiSecret,
+          fetch(
+            `${IPFS_CONFIG.pinataApiUrl}/pinning/pinJSONToIPFS`,
+            {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                pinata_api_key: IPFS_CONFIG.apiKey,
+                pinata_secret_api_key: IPFS_CONFIG.apiSecret,
+              },
+              body: JSON.stringify(body),
             },
-            body: JSON.stringify(body),
-          }),
-        { shouldRetry: isTransientError },
-      )
+          ),
+        {
+          shouldRetry: (err) => isTransientError(err),
+          onRetry,
+        },
+      );
     } catch {
       throw new IPFSUploadError(
-        'Network error during metadata upload. Check your connection and try again.',
-      )
+        "Network error during metadata upload. Check your connection and try again.",
+      );
     }
 
     if (response.status === 401) {
-      throw new IPFSUploadError('Pinata authentication failed. Check your API key and secret.')
+      throw new IPFSUploadError(
+        "Pinata authentication failed. Check your API key and secret.",
+      );
     }
     if (!response.ok) {
       throw new IPFSUploadError(
         `Metadata upload failed (HTTP ${response.status}). Please try again.`,
-      )
+      );
     }
 
-    let data: { IpfsHash: string }
+    let data: { IpfsHash: string };
     try {
-      data = (await response.json()) as { IpfsHash: string }
+      data = (await response.json()) as {
+        IpfsHash: string;
+      };
     } catch {
-      throw new IPFSUploadError('Pinata returned a non-JSON response for metadata upload.')
+      throw new IPFSUploadError(
+        "Pinata returned a non-JSON response for metadata upload.",
+      );
     }
 
     if (!data.IpfsHash) {
-      throw new IPFSUploadError('Pinata returned an unexpected response: missing IpfsHash.')
+      throw new IPFSUploadError(
+        "Pinata returned an unexpected response: missing IpfsHash.",
+      );
     }
 
-    return data.IpfsHash
+    return data.IpfsHash;
   }
 }
 
-export const ipfsService = new IPFSService()
+export const ipfsService = new IPFSService();

--- a/frontend/src/test/ipfs.test.ts
+++ b/frontend/src/test/ipfs.test.ts
@@ -376,6 +376,78 @@ describe('IPFSService', () => {
       )
     })
 
+    it('retries image upload on transient 503 and succeeds on second attempt', async () => {
+      vi.useFakeTimers()
+      vi.resetModules()
+      const { IPFSService: Fresh } = await import('../services/ipfs')
+      const fresh = new Fresh()
+
+      let xhrCallCount = 0
+      vi.stubGlobal(
+        'XMLHttpRequest',
+        vi.fn().mockImplementation(function (this: XMLHttpRequest) {
+          const listeners: Record<string, EventListener> = {}
+          const uploadListeners: Record<string, EventListener> = {}
+          const xhr = this
+
+          xhrCallCount++
+          xhr.open = vi.fn()
+          xhr.setRequestHeader = vi.fn()
+          xhr.addEventListener = vi.fn((event: string, cb: EventListener) => {
+            listeners[event] = cb
+          })
+          xhr.send = vi.fn().mockImplementation(() => {
+            Promise.resolve().then(() => {
+              if (xhrCallCount === 1) {
+                ;(xhr as unknown as Record<string, unknown>).status = 503
+                ;(xhr as unknown as Record<string, unknown>).responseText = JSON.stringify({})
+                listeners['load']?.({} as Event)
+              } else {
+                ;(xhr as unknown as Record<string, unknown>).status = 200
+                ;(xhr as unknown as Record<string, unknown>).responseText = JSON.stringify({
+                  IpfsHash: 'QmRetryCID',
+                })
+                listeners['load']?.({} as Event)
+              }
+            })
+          })
+
+          Object.defineProperty(xhr, 'upload', {
+            value: {
+              addEventListener: vi.fn((event: string, cb: EventListener) => {
+                uploadListeners[event] = cb
+              }),
+            },
+          })
+
+          return xhr
+        }),
+      )
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: async () => ({ IpfsHash: 'QmMetaRetry' }),
+        }),
+      )
+
+      const retryCalls: number[] = []
+      const promise = fresh.uploadMetadata(makeFile(), 'desc', 'Token', undefined, (attempt) =>
+        retryCalls.push(attempt),
+      )
+
+      await vi.runAllTimersAsync()
+      const uri = await promise
+
+      expect(uri).toBe('ipfs://QmMetaRetry')
+      expect(xhrCallCount).toBe(2)
+      expect(retryCalls).toEqual([2])
+
+      vi.useRealTimers()
+    })
+
     it('throws IPFSUploadError when JSON upload response is missing IpfsHash', async () => {
       vi.resetModules()
       const { IPFSService: Fresh } = await import('../services/ipfs')

--- a/frontend/src/utils/retry.ts
+++ b/frontend/src/utils/retry.ts
@@ -4,6 +4,7 @@ export interface RetryOptions {
   maxAttempts?: number
   baseDelayMs?: number
   shouldRetry?: (error: unknown) => boolean
+  onRetry?: (attempt: number, delayMs: number) => void
 }
 
 const DEFAULT_MAX_ATTEMPTS = 3
@@ -112,6 +113,7 @@ export async function withRetry<T>(fn: () => Promise<T>, options: RetryOptions =
     maxAttempts = DEFAULT_MAX_ATTEMPTS,
     baseDelayMs = DEFAULT_BASE_DELAY_MS,
     shouldRetry = isTransientError,
+    onRetry,
   } = options
 
   let lastError: unknown
@@ -138,6 +140,9 @@ export async function withRetry<T>(fn: () => Promise<T>, options: RetryOptions =
         error instanceof HttpError && error.retryAfter !== undefined
           ? error.retryAfter * 1000
           : baseDelayMs * Math.pow(2, attempt - 1)
+
+      const nextAttempt = attempt + 1
+      onRetry?.(nextAttempt, delayMs)
 
       if (import.meta.env.DEV) {
         console.warn(`[withRetry] attempt ${attempt} failed, retrying in ${delayMs}ms`, error)


### PR DESCRIPTION
Closes #743

## Summary
Wraps the Pinata image upload (XHR) with the existing `withRetry` utility so transient HTTP errors (429, 503) are retried up to 3 times with exponential backoff.

## Changes
- **`src/services/ipfs.ts`**: `_uploadFile` now uses `withRetry` with `isTransientError` as the retry predicate. Transient XHR status codes (429, 5xx) are converted to `HttpError` so the retry utility can detect them. Exhausted retries are re-thrown as `IPFSUploadError` to maintain the public API contract. `_uploadJSON` also accepts `onRetry` for toast feedback.
- **`src/utils/retry.ts`**: Added optional `onRetry(attempt, delayMs)` callback to `RetryOptions`, called before each retry attempt.
- **`src/components/MetadataForm.tsx`**: Passes `onRetry` callback showing toast: `Retrying upload… (attempt 2/3)`.
- **`src/components/MetadataUploadForm.tsx`**: Same toast integration.
- **`src/test/ipfs.test.ts`**: New test simulates 503 on first attempt → 200 on retry.

## Acceptance Criteria
- [x] Transient Pinata errors (429, 503) are retried up to 3 times
- [x] A toast informs the user of the retry
- [x] Permanent errors (400, 401) are not retried
- [x] All 31 IPFS tests pass + all 10 retry tests pass