### PR TITLE
fix(frontend): filter-aware cache key, stable useCallback deps, re-fetch on filter change

### DIFF
--- a/frontend/src/hooks/useTransactionHistory.test.ts
+++ b/frontend/src/hooks/useTransactionHistory.test.ts
@@ -2,12 +2,12 @@ import { renderHook, act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { useTransactionHistory } from './useTransactionHistory'
 
-// Mutable so individual tests can override network
-const mockConfig = {
+// vi.mock is hoisted, so mockConfig must use vi.hoisted() to be available inside the factory
+const mockConfig = vi.hoisted(() => ({
   network: 'testnet' as 'testnet' | 'mainnet',
   testnet: { horizonUrl: 'https://horizon-testnet.stellar.org' },
   mainnet: { horizonUrl: 'https://horizon.stellar.org' },
-}
+}))
 
 vi.mock('../config/stellar', () => ({ STELLAR_CONFIG: mockConfig }))
 
@@ -180,7 +180,13 @@ describe('useTransactionHistory', () => {
       } as Response)
 
       const { result } = renderHook(() => useTransactionHistory(PUB))
-      act(() => { vi.advanceTimersByTime(400) })
+      // Advance the debounce timer and flush microtasks so fetch() resolves
+      // and resp.json() is called (setting resolveJson) before we invoke it
+      await act(async () => {
+        vi.advanceTimersByTime(400)
+        await Promise.resolve()
+        await Promise.resolve()
+      })
       expect(result.current.loading).toBe(true)
 
       await act(async () => {

--- a/frontend/src/hooks/useTransactionHistory.ts
+++ b/frontend/src/hooks/useTransactionHistory.ts
@@ -118,7 +118,7 @@ export function useTransactionHistory(
     pageRef.current = page;
   }, [page]);
 
-  // Debounce on publicKey change
+  // Debounce re-fetch when publicKey or filter options change
   useEffect(() => {
     if (!publicKey) return
     if (debounceRef.current) clearTimeout(debounceRef.current)
@@ -126,10 +126,9 @@ export function useTransactionHistory(
       cursorRef.current = '';
       setPage(1);
       setTransactions([]);
-      fetchTransactions(true);
+      fetchRef.current(true);
     }, 400);
-    // eslint-disable-next-line
-  }, [publicKey]);
+  }, [publicKey, filterKey]);
 
   // Fetch on page change
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes two related correctness bugs in `useTransactionHistory` caching and memoisation:

- **Cache key ignored filter options** — the key was `${publicKey}-${page}`, so switching `assetCodes`/`issuer`/`contractIds` returned stale cached rows from a previous filter set. The key now includes a stable serialised `filterKey`: `${publicKey}-${page}-${filterKey}`.
- **Unstable `useCallback` dependency** — `options` (a fresh object each render) was in the deps array, so `fetchTransactions` got a new identity on every render, defeating memoisation and risking redundant fetches. Replaced with `filterKey` (a stable string).
- **Filter changes never triggered a re-fetch** — the debounce effect only watched `publicKey`, so changing filter props silently returned wrong/stale data. Added `filterKey` to the debounce effect's dep array and switched to `fetchRef.current(true)` so the array is honest and exhaustive without the `eslint-disable` suppression.

Also fixes the test suite:
- `mockConfig` used inside `vi.mock()` factory caused `ReferenceError` due to hoisting — fixed with `vi.hoisted()`.
- The `loading=true` test called `resolveJson` before `resp.json()` had been invoked (microtasks not flushed) — fixed with `await act(async …)`.

## Test plan

- [x] `npm run test -- --run` passes (452/452)
- [x] `npm run lint` passes (0 warnings)
- [ ] Changing `assetCodes` prop in a rendered component triggers a new fetch instead of returning stale cached data
- [ ] `useCallback` identity is stable across renders where only unrelated state changes

closes #839 