### PR TITLE
fix: validate mint recipient before submission

### DIFF
--- a/frontend/src/components/MintForm.test.tsx
+++ b/frontend/src/components/MintForm.test.tsx
@@ -9,6 +9,7 @@ const mockStellarService = {
   accountExists: vi.fn(),
   mintTokens: vi.fn(),
 }
+const VALID_RECIPIENT = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF'
 
 vi.mock('../context/StellarContext', () => ({
   useStellarContext: () => ({ stellarService: mockStellarService }),
@@ -24,6 +25,10 @@ vi.mock('../context/WalletContext', () => ({
 
 vi.mock('../hooks/useFactoryState', () => ({
   useFactoryState: () => ({ state: { baseFee: '100000' } }),
+}))
+
+vi.mock('../hooks/useBalanceCheck', () => ({
+  useBalanceCheck: () => ({ hasSufficientBalance: true, shortfall: 0, isTestnet: true }),
 }))
 
 const renderMintForm = () =>
@@ -51,7 +56,7 @@ describe('MintForm', () => {
 
     const recipientInput = screen.getByLabelText('Recipient Address', { exact: false })
     fireEvent.change(recipientInput, {
-      target: { value: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF' },
+      target: { value: VALID_RECIPIENT },
     })
 
     expect(mockStellarService.accountExists).not.toHaveBeenCalled()
@@ -77,7 +82,7 @@ describe('MintForm', () => {
     renderMintForm()
 
     fireEvent.change(screen.getByLabelText('Recipient Address', { exact: false }), {
-      target: { value: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF' },
+      target: { value: VALID_RECIPIENT },
     })
 
     act(() => {
@@ -89,5 +94,32 @@ describe('MintForm', () => {
         'This address does not have a Stellar account yet. It may need to be funded first.',
       ),
     ).toBeInTheDocument()
+  })
+
+  it('shows an inline error and disables minting for an invalid recipient address', () => {
+    renderMintForm()
+
+    fireEvent.change(screen.getByLabelText('Recipient Address', { exact: false }), {
+      target: { value: 'not-a-stellar-address' },
+    })
+
+    expect(screen.getByText('Enter a valid Stellar account address')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Mint Tokens' })).toBeDisabled()
+    expect(mockStellarService.accountExists).not.toHaveBeenCalled()
+  })
+
+  it('enables minting after the recipient address becomes valid', () => {
+    renderMintForm()
+
+    const recipientInput = screen.getByLabelText('Recipient Address', { exact: false })
+    fireEvent.change(recipientInput, {
+      target: { value: 'not-a-stellar-address' },
+    })
+    fireEvent.change(recipientInput, {
+      target: { value: VALID_RECIPIENT },
+    })
+
+    expect(screen.queryByText('Enter a valid Stellar account address')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Mint Tokens' })).toBeEnabled()
   })
 })

--- a/frontend/src/components/MintForm.tsx
+++ b/frontend/src/components/MintForm.tsx
@@ -88,6 +88,9 @@ export const MintForm: React.FC<MintFormProps> = ({
 
   // Debounced recipient for account-existence check
   const debouncedRecipient = useDebounce(recipient, 500)
+  const trimmedRecipient = recipient.trim()
+  const recipientHasInput = trimmedRecipient.length > 0
+  const recipientAddressIsValid = isValidStellarAddress(trimmedRecipient)
 
   useEffect(() => {
     const trimmed = debouncedRecipient.trim()
@@ -131,6 +134,15 @@ export const MintForm: React.FC<MintFormProps> = ({
     txStatus === 'signing' ||
     txStatus === 'submitting' ||
     txStatus === 'polling'
+  const recipientAddressError =
+    recipientHasInput && !recipientAddressIsValid
+      ? 'Enter a valid Stellar account address'
+      : errors.recipient?.message
+  const recipientRegistration = register('recipient', {
+    required: 'Recipient address is required',
+    validate: (v) => isValidStellarAddress(v.trim()) || 'Enter a valid Stellar account address',
+  })
+  const mintDisabled = isSubmitting || !hasSufficientBalance || !recipientAddressIsValid
 
   const onValid = () => {
     if (!wallet.isConnected) {
@@ -217,14 +229,10 @@ export const MintForm: React.FC<MintFormProps> = ({
             label="Recipient Address"
             placeholder="G..."
             required
-            error={errors.recipient?.message}
-            {...register('recipient', {
-              required: 'Recipient address is required',
-              validate: (v) =>
-                isValidStellarAddress(v.trim()) || 'Enter a valid Stellar account address',
-            })}
+            error={recipientAddressError}
+            {...recipientRegistration}
             onChange={(e) => {
-              register('recipient').onChange(e)
+              recipientRegistration.onChange(e)
               setRecipientHasAccount(null)
               setIsCheckingRecipient(false)
             }}
@@ -267,7 +275,7 @@ export const MintForm: React.FC<MintFormProps> = ({
           type="submit"
           variant="primary"
           loading={isSubmitting}
-          disabled={isSubmitting || !hasSufficientBalance}
+          disabled={mintDisabled}
           className="w-full sm:w-auto"
         >
           {isSubmitting ? 'Processing Transaction…' : 'Mint Tokens'}


### PR DESCRIPTION
## Summary
- Validate the mint recipient address as the user types with the existing Stellar address validator.
- Show an inline validation message for invalid recipients and keep mint submission disabled until the address is valid.
- Add focused MintForm coverage for invalid and valid recipient address states.

## Validation
- `npm.cmd test -- --run src/components/MintForm.test.tsx`
- `npm.cmd run build`
- `npx.cmd eslint src/components/MintForm.tsx src/components/MintForm.test.tsx`
- `git diff --check`

Closes #742