### PR TITLE
fix(frontend): wire orphaned features, fix standalone network, add ty…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Typecheck
+        run: npm run typecheck
+
       - name: Test
         run: npm run test -- --run
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "prebuild": "npx tsx scripts/generateCSP.ts && npx tsx scripts/generateSitemap.ts",
     "dev": "vite",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "format": "prettier --write \"src/**/*.{ts,tsx}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx}\"",
     "preview": "vite preview",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -223,7 +223,7 @@ function AppContent() {
             <NavBar onHelpClick={() => setShowOnboarding(true)} isAdmin={isAdmin} />
           </div>
         </header>
-        <OnboardingModal forceOpen={showOnboarding} onClose={() => setShowOnboarding(false)} />
+        {showOnboarding && <OnboardingModal forceOpen onClose={() => setShowOnboarding(false)} />}
 
         {!isFactoryConfigured() && (
           <div

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -303,24 +303,21 @@ function AppContent() {
                   </ProtectedRoute>
                 }
               />
+              {/* Token detail is public so shared deep links work without a wallet (#880). */}
               <Route
                 path="/tokens/:address"
                 element={
-                  <ProtectedRoute>
-                    <RouteBoundary routeName="Token Detail" fallback={<TokenDetailSkeleton />}>
-                      <TokenDetail />
-                    </RouteBoundary>
-                  </ProtectedRoute>
+                  <RouteBoundary routeName="Token Detail" fallback={<TokenDetailSkeleton />}>
+                    <TokenDetail />
+                  </RouteBoundary>
                 }
               />
               <Route
                 path="/token/:address"
                 element={
-                  <ProtectedRoute>
-                    <RouteBoundary routeName="Token Detail" fallback={<TokenDetailSkeleton />}>
-                      <TokenDetail />
-                    </RouteBoundary>
-                  </ProtectedRoute>
+                  <RouteBoundary routeName="Token Detail" fallback={<TokenDetailSkeleton />}>
+                    <TokenDetail />
+                  </RouteBoundary>
                 }
               />
               <Route

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import {
   SkeletonCard,
   SkeletonTokenCard,
   TokenDetailSkeleton,
+  OnboardingModal,
 } from './components/UI'
 import './App.css'
 import { useTranslation } from 'react-i18next'
@@ -28,6 +29,8 @@ import { TokenExplorer } from './components/TokenExplorer'
 import { AdminPanel } from './components/AdminPanel'
 import { MetadataForm } from './components/MetadataForm'
 import { NotFound } from './components/NotFound'
+import { TransactionHistory } from './components/TransactionHistory'
+import { AnalyticsOptOut } from './components/AnalyticsOptOut'
 
 const TokenDashboard = React.lazy(() =>
   import('./components/TokenDashboard').then((m) => ({ default: m.TokenDashboard })),
@@ -220,7 +223,7 @@ function AppContent() {
             <NavBar onHelpClick={() => setShowOnboarding(true)} isAdmin={isAdmin} />
           </div>
         </header>
-        {showOnboarding && null /* OnboardingModal placeholder */}
+        <OnboardingModal forceOpen={showOnboarding} onClose={() => setShowOnboarding(false)} />
 
         {!isFactoryConfigured() && (
           <div
@@ -373,10 +376,24 @@ function AppContent() {
                   </ProtectedRoute>
                 }
               />
+              <Route
+                path="/activity"
+                element={
+                  <ProtectedRoute>
+                    <RouteBoundary routeName="Activity">
+                      <TransactionHistory publicKey={wallet.address ?? ''} />
+                    </RouteBoundary>
+                  </ProtectedRoute>
+                }
+              />
               <Route path="*" element={<NotFound />} />
             </Routes>
           </div>
         </div>
+
+        <footer className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 mt-4 border-t border-gray-200 dark:border-slate-700 flex justify-center">
+          <AnalyticsOptOut />
+        </footer>
 
         <ToastContainer />
       </div>

--- a/frontend/src/components/AdminPanel.test.tsx
+++ b/frontend/src/components/AdminPanel.test.tsx
@@ -77,6 +77,7 @@ const renderWithProviders = async (
         },
         connect: vi.fn(),
         disconnect: vi.fn(),
+        refreshBalance: vi.fn(),
         isConnecting: false,
         error: null,
         isInstalled: true,
@@ -87,6 +88,7 @@ const renderWithProviders = async (
           stellarService: {
             updateFees: mockUpdateFees,
           } as unknown as StellarService,
+          ipfsService: {} as unknown as import('../services/ipfs').IPFSService,
         }}
       >
         <ToastContext.Provider

--- a/frontend/src/components/BurnForm.tsx
+++ b/frontend/src/components/BurnForm.tsx
@@ -60,7 +60,7 @@ export const BurnForm: React.FC<BurnFormProps> = ({
     formState: { errors },
   } = useForm<BurnFormData>({
     defaultValues: {
-      tokenSelect: initialAddress || (myTokens.length > 0 ? myTokens[0].address : MANUAL_VALUE),
+      tokenSelect: initialAddress || (myTokens.length > 0 ? myTokens[0]!.address : MANUAL_VALUE),
       tokenManual: initialAddress,
       amount: '',
     },

--- a/frontend/src/components/CreateToken.tsx
+++ b/frontend/src/components/CreateToken.tsx
@@ -103,7 +103,7 @@ export const CreateToken: React.FC = () => {
 
       <div className="bg-white dark:bg-gray-800 rounded-lg p-4 sm:p-6 shadow-sm">
         <ErrorBoundary>
-          <TokenForm onSubmit={handleTokenFormSubmit} isLoading={isDeploying} estimatedFee="0.01" />
+          <TokenForm onSubmit={handleTokenFormSubmit} isLoading={isDeploying} />
         </ErrorBoundary>
       </div>
     </div>

--- a/frontend/src/components/FeeDisplay.tsx
+++ b/frontend/src/components/FeeDisplay.tsx
@@ -7,6 +7,8 @@ import { useXlmPrice } from '../hooks/useXlmPrice'
 interface FeeDisplayProps {
   feeType: 'base' | 'metadata'
   className?: string
+  /** When false, render only the amount (+USD) without the "Creation Fee:" prefix. */
+  showLabel?: boolean
 }
 
 // Module-level cache — shared across all FeeDisplay instances
@@ -32,6 +34,7 @@ const LABELS: Record<FeeDisplayProps['feeType'], string> = {
 export const FeeDisplay: React.FC<FeeDisplayProps> = ({
   feeType,
   className = '',
+  showLabel = true,
 }: FeeDisplayProps) => {
   const [xlm, setXlm] = useState<number | null>(null)
   const [error, setError] = useState(false)
@@ -74,7 +77,8 @@ export const FeeDisplay: React.FC<FeeDisplayProps> = ({
 
   return (
     <span className={`text-sm text-gray-700 ${className}`}>
-      {label}: {formatXLM(xlm)}
+      {showLabel && `${label}: `}
+      {formatXLM(xlm)}
       {usdAmount !== null && <span className="text-gray-400 ml-1">≈ ${usdAmount} USD</span>}
     </span>
   )

--- a/frontend/src/components/MintForm.tsx
+++ b/frontend/src/components/MintForm.tsx
@@ -64,7 +64,7 @@ export const MintForm: React.FC<MintFormProps> = ({
     formState: { errors },
   } = useForm<MintFormData>({
     defaultValues: {
-      tokenSelect: initialAddress || (myTokens.length > 0 ? myTokens[0].address : MANUAL_VALUE),
+      tokenSelect: initialAddress || (myTokens.length > 0 ? myTokens[0]!.address : MANUAL_VALUE),
       tokenManual: initialAddress,
       recipient: '',
       amount: '',

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -101,6 +101,9 @@ export const NavBar: React.FC<NavBarProps> = ({ onHelpClick, isAdmin = false }) 
         <NavLink to="/explorer" className={getLinkClass}>
           {t('nav.explorer', 'Explorer')}
         </NavLink>
+        <NavLink to="/activity" className={getLinkClass} onClick={closeMenu}>
+          {t('nav.activity', 'Activity')}
+        </NavLink>
         {isAdmin && (
           <NavLink
             to="/admin"

--- a/frontend/src/components/NetworkSwitcher.tsx
+++ b/frontend/src/components/NetworkSwitcher.tsx
@@ -6,6 +6,7 @@ import { useNetwork, type Network } from '../context/NetworkContext'
 const BADGE_COLORS: Record<Network, string> = {
   testnet: 'bg-yellow-100 text-yellow-800 border-yellow-300',
   mainnet: 'bg-green-100 text-green-800 border-green-300',
+  standalone: 'bg-purple-100 text-purple-800 border-purple-300',
 }
 
 export const NetworkSwitcher: React.FC = () => {

--- a/frontend/src/components/TokenCreateForm.tsx
+++ b/frontend/src/components/TokenCreateForm.tsx
@@ -109,7 +109,9 @@ export const TokenCreateForm: React.FC = () => {
   const updateStep = (index: number, status: ProgressStep['status']) => {
     setDeploymentSteps((prev) => {
       const updated = [...prev]
-      updated[index] = { ...updated[index], status }
+      const current = updated[index]
+      if (!current) return prev
+      updated[index] = { ...current, status }
       return updated
     })
   }

--- a/frontend/src/components/TokenExplorer.tsx
+++ b/frontend/src/components/TokenExplorer.tsx
@@ -54,7 +54,7 @@ export const TokenExplorer: React.FC = () => {
         let metadata: IPFSMetadata | null = null
         if (info.metadataUri) {
           try {
-            metadata = await ipfsService.getMetadata(info.metadataUri)
+            metadata = (await ipfsService.getMetadata(info.metadataUri)) as IPFSMetadata
           } catch {
             // Metadata fetch failure is non-fatal
           }

--- a/frontend/src/components/TokenForm.tsx
+++ b/frontend/src/components/TokenForm.tsx
@@ -6,9 +6,8 @@ import { useToast } from '../context/ToastContext'
 import { useWalletContext } from '../context/WalletContext'
 import { useNetwork } from '../context/NetworkContext'
 import { validateTokenParams } from '../utils/validation'
-import { formatXLM, stroopsToXLM } from '../utils/formatting'
-import { useFactoryState } from '../hooks/useFactoryState'
 import { logger } from '../utils/logger'
+import { FeeDisplay } from './FeeDisplay'
 
 interface TokenFormProps {
   onSubmit: (params: {
@@ -18,8 +17,6 @@ interface TokenFormProps {
     initialSupply: string
   }) => Promise<void>
   isLoading?: boolean
-  /** Override the fee shown in the preview (stroops). Falls back to on-chain base_fee. */
-  estimatedFee?: string
 }
 
 interface FormErrors {
@@ -29,23 +26,11 @@ interface FormErrors {
   initialSupply?: string
 }
 
-export const TokenForm: React.FC<TokenFormProps> = ({
-  onSubmit,
-  isLoading = false,
-  estimatedFee,
-}) => {
+export const TokenForm: React.FC<TokenFormProps> = ({ onSubmit, isLoading = false }) => {
   const { t } = useTranslation()
   const { addToast } = useToast()
   const { wallet } = useWalletContext()
   const { network } = useNetwork()
-  const { state: factoryState } = useFactoryState()
-
-  // Resolve fee: prop override → on-chain base_fee → fallback 0
-  const feeXLM = estimatedFee
-    ? stroopsToXLM(estimatedFee)
-    : factoryState?.baseFee
-      ? stroopsToXLM(factoryState.baseFee)
-      : 0
 
   const [formData, setFormData] = useState({
     name: '',
@@ -206,9 +191,11 @@ export const TokenForm: React.FC<TokenFormProps> = ({
               {t('tokenForm.feeDescription')}
             </p>
           </div>
-          <p className="text-lg font-semibold text-blue-900 dark:text-blue-300">
-            {formatXLM(feeXLM)}
-          </p>
+          <FeeDisplay
+            feeType="base"
+            showLabel={false}
+            className="text-lg font-semibold text-blue-900 dark:text-blue-300"
+          />
         </div>
       </div>
 

--- a/frontend/src/components/TokenMetadata.test.tsx
+++ b/frontend/src/components/TokenMetadata.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { TokenMetadata } from './TokenMetadata'
-import { ipfsService } from '../services/ipfs'
+import { ipfsService, type TokenMetadata as TokenMetadataType } from '../services/ipfs'
 
 vi.mock('../services/ipfs', () => ({
   ipfsService: {
@@ -16,7 +16,7 @@ describe('TokenMetadata', () => {
     mockedGetMetadata.mockResolvedValueOnce({
       image: 'ipfs://QmTokenImage',
       description: 'Pinned token artwork',
-    })
+    } as unknown as TokenMetadataType)
 
     render(<TokenMetadata metadataUri="ipfs://QmMetadata" name="Forge Token" symbol="FORGE" />)
 
@@ -31,7 +31,7 @@ describe('TokenMetadata', () => {
   it('shows the placeholder when metadata has no image', async () => {
     mockedGetMetadata.mockResolvedValueOnce({
       description: 'No artwork was pinned',
-    })
+    } as unknown as TokenMetadataType)
 
     render(<TokenMetadata metadataUri="ipfs://QmMetadata" name="Forge Token" symbol="FORGE" />)
 
@@ -44,7 +44,7 @@ describe('TokenMetadata', () => {
   it('falls back to the placeholder when the image fails to load', async () => {
     mockedGetMetadata.mockResolvedValueOnce({
       image: 'ipfs://QmBrokenImage',
-    })
+    } as unknown as TokenMetadataType)
 
     render(<TokenMetadata metadataUri="ipfs://QmMetadata" name="Forge Token" symbol="FORGE" />)
 

--- a/frontend/src/components/TransactionHistory.tsx
+++ b/frontend/src/components/TransactionHistory.tsx
@@ -55,7 +55,7 @@ export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
   const handleExportCSV = () => {
     if (transactions.length === 0) return
     const csvContent = serializeTransactionsToCSV(transactions)
-    const BOM = new Uint8Array([0xEF, 0xBB, 0xBF])
+    const BOM = new Uint8Array([0xef, 0xbb, 0xbf])
     const blob = new Blob([BOM, csvContent], { type: 'text/csv;charset=utf-8;' })
     const url = URL.createObjectURL(blob)
     const link = document.createElement('a')

--- a/frontend/src/components/UI/Input.tsx
+++ b/frontend/src/components/UI/Input.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string
-  error?: string
+  error?: string | undefined
 }
 
 export const Input: React.FC<InputProps> = ({

--- a/frontend/src/components/UI/MainnetConfirmationModal.stories.tsx
+++ b/frontend/src/components/UI/MainnetConfirmationModal.stories.tsx
@@ -7,6 +7,9 @@ const baseToken = {
   symbol: 'MTK',
   decimals: 7,
   initialSupply: '1000000',
+  salt: '0'.repeat(64),
+  tokenWasmHash: '0'.repeat(64),
+  feePayment: '0.5',
 }
 
 const meta: Meta<typeof MainnetConfirmationModal> = {

--- a/frontend/src/components/UI/Select.tsx
+++ b/frontend/src/components/UI/Select.tsx
@@ -8,8 +8,8 @@ interface SelectOption {
 interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
   label?: string
   options: SelectOption[]
-  error?: string
-  placeholder?: string
+  error?: string | undefined
+  placeholder?: string | undefined
 }
 
 export const Select: React.FC<SelectProps> = ({

--- a/frontend/src/components/UI/WalletButton.tsx
+++ b/frontend/src/components/UI/WalletButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useWallet } from '../../hooks/useWallet'
 import { useTos } from '../../context/TosContext'
-import { truncateAddress } from '../../utils/formatting'
+import { truncateAddress } from '../../utils/truncateAddress'
 import { Button } from './Button'
 import { Spinner } from './Spinner'
 

--- a/frontend/src/context/WalletContext.test.tsx
+++ b/frontend/src/context/WalletContext.test.tsx
@@ -185,7 +185,9 @@ describe('WalletProvider', () => {
 
   it('re-connecting after disconnect shows fresh data, not stale cached values', async () => {
     // First user connects with address GUSER1
-    vi.mocked(walletService.connect).mockResolvedValueOnce('GUSER1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')
+    vi.mocked(walletService.connect).mockResolvedValueOnce(
+      'GUSER1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    )
     // Use mockResolvedValue (persistent) — fetchBalance is called twice on connect
     // (once explicitly in connect(), once from the network useEffect that reacts to
     // wallet state change). Using Once would only cover the first call; the second
@@ -216,7 +218,9 @@ describe('WalletProvider', () => {
     expect(screen.getByTestId('consumer-balance').textContent).toBe('null')
 
     // Second user connects — must see their own address and a fresh balance fetch
-    vi.mocked(walletService.connect).mockResolvedValueOnce('GUSER2BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB')
+    vi.mocked(walletService.connect).mockResolvedValueOnce(
+      'GUSER2BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+    )
     // Persistent mock so both implicit fetchBalance calls return User 2's balance
     vi.mocked(walletService.getBalance).mockResolvedValue('99.0000000')
 

--- a/frontend/src/hooks/useTokenDashboard.ts
+++ b/frontend/src/hooks/useTokenDashboard.ts
@@ -83,7 +83,7 @@ export function useTokenDashboard(): UseTokenDashboardResult {
         const rows: TokenRow[] = results
           .map((r, i) => {
             if (r.status !== 'fulfilled') return null
-            const address = indexToAddress.get(indices[i]) ?? ''
+            const address = indexToAddress.get(indices[i]!) ?? ''
             if (!address) return null
             return { ...r.value, address } as TokenRow
           })

--- a/frontend/src/hooks/useTransactionHistory.test.ts
+++ b/frontend/src/hooks/useTransactionHistory.test.ts
@@ -124,7 +124,7 @@ describe('useTransactionHistory', () => {
       mockOk(page([paymentOp()]))
       renderHook(() => useTransactionHistory(PUB))
       await fireDebounce()
-      expect(vi.mocked(global.fetch).mock.calls[0][0]).toContain(TESTNET)
+      expect(vi.mocked(global.fetch).mock.calls[0]![0]).toContain(TESTNET)
     })
 
     it('uses the mainnet Horizon URL when network is mainnet', async () => {
@@ -132,7 +132,7 @@ describe('useTransactionHistory', () => {
       mockOk(page([paymentOp()]))
       renderHook(() => useTransactionHistory(PUB))
       await fireDebounce()
-      expect(vi.mocked(global.fetch).mock.calls[0][0]).toContain(MAINNET)
+      expect(vi.mocked(global.fetch).mock.calls[0]![0]).toContain(MAINNET)
     })
   })
 
@@ -142,19 +142,24 @@ describe('useTransactionHistory', () => {
     it('does not fetch before 400 ms have elapsed', () => {
       mockOk(page([]))
       renderHook(() => useTransactionHistory(PUB))
-      act(() => { vi.advanceTimersByTime(399) })
+      act(() => {
+        vi.advanceTimersByTime(399)
+      })
       expect(global.fetch).not.toHaveBeenCalled()
     })
 
     it('cancels an in-flight debounce when publicKey changes rapidly', async () => {
       mockOk(page([]))
-      const { rerender } = renderHook(
-        ({ k }: { k: string }) => useTransactionHistory(k),
-        { initialProps: { k: 'GKEY1' } },
-      )
-      act(() => { vi.advanceTimersByTime(200) })
+      const { rerender } = renderHook(({ k }: { k: string }) => useTransactionHistory(k), {
+        initialProps: { k: 'GKEY1' },
+      })
+      act(() => {
+        vi.advanceTimersByTime(200)
+      })
       rerender({ k: 'GKEY2' })
-      act(() => { vi.advanceTimersByTime(200) })
+      act(() => {
+        vi.advanceTimersByTime(200)
+      })
       // 200 ms since last key — debounce not yet fired
       expect(global.fetch).not.toHaveBeenCalled()
 
@@ -165,7 +170,7 @@ describe('useTransactionHistory', () => {
       })
       // Exactly one fetch for GKEY2, none for GKEY1
       expect(global.fetch).toHaveBeenCalledTimes(1)
-      expect(vi.mocked(global.fetch).mock.calls[0][0]).toContain('GKEY2')
+      expect(vi.mocked(global.fetch).mock.calls[0]![0]).toContain('GKEY2')
     })
   })
 
@@ -176,7 +181,10 @@ describe('useTransactionHistory', () => {
       let resolveJson!: (v: unknown) => void
       vi.mocked(global.fetch).mockResolvedValueOnce({
         ok: true,
-        json: () => new Promise((r) => { resolveJson = r }),
+        json: () =>
+          new Promise((r) => {
+            resolveJson = r
+          }),
       } as Response)
 
       const { result } = renderHook(() => useTransactionHistory(PUB))
@@ -225,9 +233,7 @@ describe('useTransactionHistory', () => {
         paymentOp({ id: `op${i}`, paging_token: `c${i}` }),
       )
       mockOk(page(records))
-      const { result } = renderHook(() =>
-        useTransactionHistory(PUB, { pageSize: 3 }),
-      )
+      const { result } = renderHook(() => useTransactionHistory(PUB, { pageSize: 3 }))
       await fireDebounce()
       expect(result.current.hasMore).toBe(true)
     })
@@ -259,9 +265,7 @@ describe('useTransactionHistory', () => {
       mockOk(page(p1))
       mockOk(page(p2))
 
-      const { result } = renderHook(() =>
-        useTransactionHistory(PUB, { pageSize: 2 }),
-      )
+      const { result } = renderHook(() => useTransactionHistory(PUB, { pageSize: 2 }))
       await fireDebounce()
       expect(result.current.transactions).toHaveLength(2)
       expect(result.current.hasMore).toBe(true)
@@ -282,9 +286,7 @@ describe('useTransactionHistory', () => {
       mockOk(page(p1))
       mockOk(page([]))
 
-      const { result } = renderHook(() =>
-        useTransactionHistory(PUB, { pageSize: 2 }),
-      )
+      const { result } = renderHook(() => useTransactionHistory(PUB, { pageSize: 2 }))
       await fireDebounce()
 
       await act(async () => {
@@ -293,7 +295,7 @@ describe('useTransactionHistory', () => {
         await Promise.resolve()
       })
 
-      const secondUrl = vi.mocked(global.fetch).mock.calls[1][0] as string
+      const secondUrl = vi.mocked(global.fetch).mock.calls[1]![0] as string
       expect(secondUrl).toContain('cursor=tok_last')
     })
 
@@ -301,7 +303,7 @@ describe('useTransactionHistory', () => {
       mockOk(page([paymentOp()]))
       renderHook(() => useTransactionHistory(PUB))
       await fireDebounce()
-      const firstUrl = vi.mocked(global.fetch).mock.calls[0][0] as string
+      const firstUrl = vi.mocked(global.fetch).mock.calls[0]![0] as string
       expect(firstUrl).toContain('cursor=')
       // cursor param is present but empty (reset path)
       expect(firstUrl).toMatch(/cursor=$/)
@@ -312,13 +314,15 @@ describe('useTransactionHistory', () => {
         paymentOp({ id: `op${i}`, paging_token: `c${i}` }),
       )
       mockOk(page(p1))
-      const { result } = renderHook(() =>
-        useTransactionHistory(PUB, { pageSize: 2 }),
-      )
+      const { result } = renderHook(() => useTransactionHistory(PUB, { pageSize: 2 }))
       // Advance timer to trigger fetch but don't await completion
-      act(() => { vi.advanceTimersByTime(400) })
+      act(() => {
+        vi.advanceTimersByTime(400)
+      })
       // loading=true here — loadMore must be a no-op
-      act(() => { result.current.loadMore() })
+      act(() => {
+        result.current.loadMore()
+      })
       expect(global.fetch).toHaveBeenCalledTimes(1)
     })
   })
@@ -330,10 +334,9 @@ describe('useTransactionHistory', () => {
       mockOk(page([paymentOp()]))
       mockOk(page([paymentOp({ id: 'op_b' })]))
 
-      const { rerender } = renderHook(
-        ({ k }: { k: string }) => useTransactionHistory(k),
-        { initialProps: { k: 'KEY_A' } },
-      )
+      const { rerender } = renderHook(({ k }: { k: string }) => useTransactionHistory(k), {
+        initialProps: { k: 'KEY_A' },
+      })
       await fireDebounce() // fetches KEY_A — fetch count: 1
 
       rerender({ k: 'KEY_B' })
@@ -423,7 +426,7 @@ describe('useTransactionHistory', () => {
 
     it('transaction_successful=false maps to status=failed', async () => {
       const txns = await fetchSingle(paymentOp({ transaction_successful: false }))
-      expect(txns[0].status).toBe('failed')
+      expect(txns[0]!.status).toBe('failed')
     })
   })
 
@@ -431,26 +434,26 @@ describe('useTransactionHistory', () => {
 
   describe('filter options applied to parsed operations', () => {
     it('excludes operations whose asset_code is not in assetCodes', async () => {
-      mockOk(page([
-        paymentOp({ asset_code: 'TKA', id: 'op1' }),
-        paymentOp({ asset_code: 'TKB', id: 'op2', paging_token: 'c2' }),
-      ]))
-      const { result } = renderHook(() =>
-        useTransactionHistory(PUB, { assetCodes: ['TKB'] }),
+      mockOk(
+        page([
+          paymentOp({ asset_code: 'TKA', id: 'op1' }),
+          paymentOp({ asset_code: 'TKB', id: 'op2', paging_token: 'c2' }),
+        ]),
       )
+      const { result } = renderHook(() => useTransactionHistory(PUB, { assetCodes: ['TKB'] }))
       await fireDebounce()
       expect(result.current.transactions).toHaveLength(1)
-      expect(result.current.transactions[0].token).toBe('TKB')
+      expect(result.current.transactions[0]!.token).toBe('TKB')
     })
 
     it('excludes operations whose asset_issuer does not match issuer filter', async () => {
-      mockOk(page([
-        paymentOp({ asset_issuer: 'GISSUER_MATCH', id: 'op1' }),
-        paymentOp({ asset_issuer: 'GISSUER_OTHER', id: 'op2', paging_token: 'c2' }),
-      ]))
-      const { result } = renderHook(() =>
-        useTransactionHistory(PUB, { issuer: 'GISSUER_MATCH' }),
+      mockOk(
+        page([
+          paymentOp({ asset_issuer: 'GISSUER_MATCH', id: 'op1' }),
+          paymentOp({ asset_issuer: 'GISSUER_OTHER', id: 'op2', paging_token: 'c2' }),
+        ]),
       )
+      const { result } = renderHook(() => useTransactionHistory(PUB, { issuer: 'GISSUER_MATCH' }))
       await fireDebounce()
       expect(result.current.transactions).toHaveLength(1)
     })

--- a/frontend/src/hooks/useTransactionHistory.ts
+++ b/frontend/src/hooks/useTransactionHistory.ts
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
-import { STELLAR_CONFIG } from '../config/stellar';
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { STELLAR_CONFIG } from '../config/stellar'
 
 export type TransactionType = 'create' | 'mint' | 'burn' | 'other'
 
@@ -14,11 +14,11 @@ export interface TransactionHistoryItem {
 }
 
 interface UseTransactionHistoryOptions {
-  assetCodes?: string[]
-  issuer?: string
-  contractIds?: string[]
-  pageSize?: number
-  pollIntervalMs?: number
+  assetCodes?: string[] | undefined
+  issuer?: string | undefined
+  contractIds?: string[] | undefined
+  pageSize?: number | undefined
+  pollIntervalMs?: number | undefined
 }
 
 /** The subset of Horizon's polymorphic operation record shape this hook reads. */
@@ -39,20 +39,20 @@ export function useTransactionHistory(
   publicKey: string | undefined,
   options: UseTransactionHistoryOptions = {},
 ) {
-  const [transactions, setTransactions] = useState<TransactionHistoryItem[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [hasMore, setHasMore] = useState(true);
-  const [page, setPage] = useState(1);
-  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
-  const cacheRef = useRef<{ [key: string]: TransactionHistoryItem[] }>({});
-  const debounceRef = useRef<number | null>(null);
+  const [transactions, setTransactions] = useState<TransactionHistoryItem[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [hasMore, setHasMore] = useState(true)
+  const [page, setPage] = useState(1)
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
+  const cacheRef = useRef<{ [key: string]: TransactionHistoryItem[] }>({})
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   // Tracks the paging_token of the last fetched record for cursor-based pagination
-  const cursorRef = useRef<string>('');
-  const fetchRef = useRef<(reset?: boolean) => void>(() => {});
-  const isMountedRef = useRef(true);
-  const pageRef = useRef(page);
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const cursorRef = useRef<string>('')
+  const fetchRef = useRef<(reset?: boolean) => void>(() => {})
+  const isMountedRef = useRef(true)
+  const pageRef = useRef(page)
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   const pageSize = options.pageSize || 10
   const pollIntervalMs = options.pollIntervalMs ?? 30_000
@@ -62,7 +62,7 @@ export function useTransactionHistory(
     assetCodes: options.assetCodes ? [...options.assetCodes].sort() : null,
     issuer: options.issuer ?? null,
     contractIds: options.contractIds ? [...options.contractIds].sort() : null,
-  });
+  })
 
   const fetchTransactions = useCallback(
     async (reset = false) => {
@@ -70,34 +70,32 @@ export function useTransactionHistory(
       setLoading(true)
       setError(null)
       try {
-        const cacheKey = `${publicKey}-${page}-${filterKey}`;
-        const cached = cacheRef.current[cacheKey];
+        const cacheKey = `${publicKey}-${page}-${filterKey}`
+        const cached = cacheRef.current[cacheKey]
         if (cached) {
           setTransactions((prev: TransactionHistoryItem[]) =>
-            reset ? cached : [...prev, ...cached]
-          );
-          setHasMore(cached.length === pageSize);
-          setLoading(false);
-          return;
+            reset ? cached : [...prev, ...cached],
+          )
+          setHasMore(cached.length === pageSize)
+          setLoading(false)
+          return
         }
-        const network = STELLAR_CONFIG.network as 'testnet' | 'mainnet';
-        const { horizonUrl } = STELLAR_CONFIG[network];
-        const cursor = reset ? '' : cursorRef.current;
-        const url = `${horizonUrl}/accounts/${publicKey}/operations?order=desc&limit=${pageSize}&cursor=${cursor}`;
-        const resp = await fetch(url);
-        if (!resp.ok) throw new Error('Failed to fetch transactions');
-        const data = await resp.json();
-        const records: HorizonOperationRecord[] = data._embedded?.records ?? [];
+        const network = STELLAR_CONFIG.network as 'testnet' | 'mainnet'
+        const { horizonUrl } = STELLAR_CONFIG[network]
+        const cursor = reset ? '' : cursorRef.current
+        const url = `${horizonUrl}/accounts/${publicKey}/operations?order=desc&limit=${pageSize}&cursor=${cursor}`
+        const resp = await fetch(url)
+        if (!resp.ok) throw new Error('Failed to fetch transactions')
+        const data = await resp.json()
+        const records: HorizonOperationRecord[] = data._embedded?.records ?? []
         const items: TransactionHistoryItem[] = records
           .map((op: HorizonOperationRecord) => parseOperation(op, options))
-          .filter((item): item is TransactionHistoryItem => item !== null);
+          .filter((item): item is TransactionHistoryItem => item !== null)
         if (records.length > 0) {
-          cursorRef.current = records[records.length - 1].paging_token ?? '';
+          cursorRef.current = records[records.length - 1]!.paging_token ?? ''
         }
         cacheRef.current[cacheKey] = items
-        setTransactions((prev: TransactionHistoryItem[]) =>
-          reset ? items : [...prev, ...items],
-        )
+        setTransactions((prev: TransactionHistoryItem[]) => (reset ? items : [...prev, ...items]))
         setHasMore(items.length === pageSize)
         setLastUpdated(new Date())
       } catch (e) {
@@ -107,28 +105,28 @@ export function useTransactionHistory(
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [publicKey, page, pageSize, filterKey]
-  );
+    [publicKey, page, pageSize, filterKey],
+  )
 
   useEffect(() => {
-    fetchRef.current = fetchTransactions;
-  }, [fetchTransactions]);
+    fetchRef.current = fetchTransactions
+  }, [fetchTransactions])
 
   useEffect(() => {
-    pageRef.current = page;
-  }, [page]);
+    pageRef.current = page
+  }, [page])
 
   // Debounce re-fetch when publicKey or filter options change
   useEffect(() => {
     if (!publicKey) return
     if (debounceRef.current) clearTimeout(debounceRef.current)
     debounceRef.current = setTimeout(() => {
-      cursorRef.current = '';
-      setPage(1);
-      setTransactions([]);
-      fetchRef.current(true);
-    }, 400);
-  }, [publicKey, filterKey]);
+      cursorRef.current = ''
+      setPage(1)
+      setTransactions([])
+      fetchRef.current(true)
+    }, 400)
+  }, [publicKey, filterKey])
 
   // Fetch on page change
   useEffect(() => {
@@ -174,11 +172,7 @@ function parseOperation(
   let type: TransactionType = 'other'
   let token = ''
   let amount = ''
-  if (
-    op.type === 'manage_data' &&
-    op.name &&
-    op.name.toLowerCase().includes('token')
-  ) {
+  if (op.type === 'manage_data' && op.name && op.name.toLowerCase().includes('token')) {
     type = 'create'
     token = op.name
   } else if (op.type === 'payment' && op.asset_code && op.amount) {
@@ -196,14 +190,8 @@ function parseOperation(
     token = op.asset_code
   }
   // Optionally filter by assetCodes, issuer, contractIds
-  if (
-    options.assetCodes &&
-    token &&
-    !options.assetCodes.includes(token)
-  )
-    return null
-  if (options.issuer && op.asset_issuer && op.asset_issuer !== options.issuer)
-    return null
+  if (options.assetCodes && token && !options.assetCodes.includes(token)) return null
+  if (options.issuer && op.asset_issuer && op.asset_issuer !== options.issuer) return null
   if (type === 'other') return null
   return {
     id: op.id,

--- a/frontend/src/lib/monitoring/sentry.ts
+++ b/frontend/src/lib/monitoring/sentry.ts
@@ -30,9 +30,7 @@ const PRIVATE_KEY_PATTERN = /S[A-Z2-7]{55}/g
  * Scrub sensitive data (wallet addresses, private keys) from error context
  * before sending to Sentry to ensure privacy compliance
  */
-function scrubSensitiveData(
-  event: Sentry.ErrorEvent | Sentry.Transaction,
-): Sentry.ErrorEvent | Sentry.Transaction {
+function scrubSensitiveData(event: Sentry.ErrorEvent): Sentry.ErrorEvent {
   if (!event) return event
 
   // Scrub from message
@@ -44,7 +42,7 @@ function scrubSensitiveData(
 
   // Scrub from exception messages
   if (event.exception?.values) {
-    event.exception.values.forEach((exception) => {
+    event.exception.values.forEach((exception: { value?: string }) => {
       if (exception.value) {
         exception.value = exception.value
           .replace(STELLAR_ADDRESS_PATTERN, '[WALLET_ADDRESS]')
@@ -87,7 +85,7 @@ export interface ErrorContext {
  * Context for contract call errors
  */
 export interface ContractErrorContext extends ErrorContext {
-  network?: 'testnet' | 'mainnet'
+  network?: 'testnet' | 'mainnet' | 'standalone'
   contractId?: string
   functionName?: string
   params?: Record<string, unknown>

--- a/frontend/src/services/stellar-impl.ts
+++ b/frontend/src/services/stellar-impl.ts
@@ -23,7 +23,9 @@ import {
   xdr,
   FeeBumpTransaction,
   Transaction,
+  StrKey,
 } from 'stellar-sdk'
+import type { Network } from '../config/stellar'
 import { withRetry, HttpError } from '../utils/retry'
 import { parseContractError } from '../utils/contractErrors'
 
@@ -50,15 +52,17 @@ function toAppError(err: unknown): AppError {
 
 // ── Network helpers ───────────────────────────────────────────────────────────
 
-function getNetworkConfig(network: 'testnet' | 'mainnet') {
+function getNetworkConfig(network: Network) {
   return NETWORK_CONFIGS[network]
 }
 
-function getNetworkPassphrase(network: 'testnet' | 'mainnet'): string {
-  return network === 'mainnet' ? Networks.PUBLIC : Networks.TESTNET
+function getNetworkPassphrase(network: Network): string {
+  if (network === 'mainnet') return Networks.PUBLIC
+  if (network === 'testnet') return Networks.TESTNET
+  return NETWORK_CONFIGS[network].networkPassphrase
 }
 
-function getRpcServer(network: 'testnet' | 'mainnet'): rpc.Server {
+function getRpcServer(network: Network): rpc.Server {
   return new rpc.Server(getNetworkConfig(network).sorobanRpcUrl, { allowHttp: false })
 }
 
@@ -71,7 +75,7 @@ function getRpcServer(network: 'testnet' | 'mainnet'): rpc.Server {
 async function simulateAndSubmit(
   server: rpc.Server,
   tx: ReturnType<TransactionBuilder['build']>,
-  network: 'testnet' | 'mainnet',
+  network: Network,
 ): Promise<string> {
   const simResult = await server.simulateTransaction(tx)
 
@@ -127,7 +131,7 @@ async function pollTransaction(
 export async function buildFeeBumpTransaction(
   innerTxXdr: string,
   feeSource: string,
-  network: 'testnet' | 'mainnet',
+  network: Network,
   baseFee: string = String(Number(BASE_FEE) * 10),
 ): Promise<string> {
   const networkPassphrase = getNetworkPassphrase(network)
@@ -146,7 +150,7 @@ export async function buildFeeBumpTransaction(
  */
 export async function submitFeeBumpTransaction(
   signedFeeBumpXdr: string,
-  network: 'testnet' | 'mainnet',
+  network: Network,
 ): Promise<string> {
   const server = getRpcServer(network)
   const feeBumpTx = TransactionBuilder.fromXDR(
@@ -169,7 +173,7 @@ export async function submitFeeBumpTransaction(
 async function buildTxBuilder(
   server: rpc.Server,
   sourceAddress: string,
-  network: 'testnet' | 'mainnet',
+  network: Network,
 ): Promise<TransactionBuilder> {
   const account = await server.getAccount(sourceAddress)
   return new TransactionBuilder(account, {
@@ -189,7 +193,7 @@ async function callView(
   method: string,
   args: xdr.ScVal[],
   sourceAddress: string,
-  network: 'testnet' | 'mainnet',
+  network: Network,
 ): Promise<xdr.ScVal> {
   const contract = new Contract(contractId)
   const account = await server.getAccount(sourceAddress)
@@ -233,13 +237,14 @@ interface RpcGetEventsResult {
 
 // ── XDR decode helper ─────────────────────────────────────────────────────────
 
-function scValToString(val: xdr.ScVal): string {
+function scValToString(val: xdr.ScVal | undefined): string {
+  if (!val) return ''
   try {
     const type = val.switch()
     if (type === xdr.ScValType.scvAddress()) {
       const addr = val.address()
       if (addr.switch() === xdr.ScAddressType.scAddressTypeAccount()) {
-        return addr.accountId().publicKey().toString()
+        return StrKey.encodeEd25519PublicKey(addr.accountId().ed25519())
       }
       return Array.from(addr.contractId() as Uint8Array)
         .map((b) => b.toString(16).padStart(2, '0'))
@@ -281,7 +286,7 @@ const EVENT_TOPICS: ContractEventType[] = [
 async function parseRpcEvent(raw: RpcEventResponse): Promise<ContractEvent | null> {
   try {
     if (!raw.topic?.length || raw.topic.length < 2) return null
-    const topicVal = xdr.ScVal.fromXDR(raw.topic[1], 'base64') // second topic is the action
+    const topicVal = xdr.ScVal.fromXDR(raw.topic[1]!, 'base64') // second topic is the action
     const eventType = scValToString(topicVal) as ContractEventType
     if (!EVENT_TOPICS.includes(eventType)) return null
 
@@ -343,11 +348,7 @@ async function parseRpcEvent(raw: RpcEventResponse): Promise<ContractEvent | nul
 
 // ── JSON-RPC helper ───────────────────────────────────────────────────────────
 
-async function rpcCall<T>(
-  method: string,
-  params: unknown,
-  network: 'testnet' | 'mainnet',
-): Promise<T> {
+async function rpcCall<T>(method: string, params: unknown, network: Network): Promise<T> {
   return withRetry(async () => {
     const res = await fetch(getNetworkConfig(network).sorobanRpcUrl, {
       method: 'POST',
@@ -375,13 +376,13 @@ async function rpcCall<T>(
 // ── StellarService ────────────────────────────────────────────────────────────
 
 export class StellarService {
-  private network: 'testnet' | 'mainnet'
+  private network: Network
 
-  constructor(network: 'testnet' | 'mainnet' = 'testnet') {
+  constructor(network: Network = 'testnet') {
     this.network = network
   }
 
-  setNetwork(network: 'testnet' | 'mainnet') {
+  setNetwork(network: Network) {
     this.network = network
   }
 
@@ -894,7 +895,7 @@ export class StellarService {
       decimals: 7,
       creator: createdEvent?.data.creator ?? '',
       createdAt: createdEvent?.timestamp ?? 0,
-      metadataUri: metaEvent?.data.metadataUri,
+      metadataUri: metaEvent?.data.metadataUri ?? '',
     }
   }
 

--- a/frontend/src/services/stellar.ts
+++ b/frontend/src/services/stellar.ts
@@ -1,16 +1,17 @@
 import type { StellarService as IStellarService } from './stellar-impl'
+import type { Network } from '../config/stellar'
 
 export type { FactoryState } from '../types'
 
 export class StellarService {
-  private network: 'testnet' | 'mainnet'
+  private network: Network
   private implPromise: Promise<IStellarService> | null = null
 
-  constructor(network: 'testnet' | 'mainnet' = 'testnet') {
+  constructor(network: Network = 'testnet') {
     this.network = network
   }
 
-  setNetwork(network: 'testnet' | 'mainnet') {
+  setNetwork(network: Network) {
     this.network = network
     this.implPromise = null
   }
@@ -112,7 +113,7 @@ export const stellarService = new StellarService()
 export async function buildFeeBumpTransaction(
   innerTxXdr: string,
   feeSource: string,
-  network: 'testnet' | 'mainnet',
+  network: Network,
   baseFee?: string,
 ): Promise<string> {
   const { buildFeeBumpTransaction: impl } = await import('./stellar-impl')
@@ -121,7 +122,7 @@ export async function buildFeeBumpTransaction(
 
 export async function submitFeeBumpTransaction(
   signedFeeBumpXdr: string,
-  network: 'testnet' | 'mainnet',
+  network: Network,
 ): Promise<string> {
   const { submitFeeBumpTransaction: impl } = await import('./stellar-impl')
   return impl(signedFeeBumpXdr, network)

--- a/frontend/src/test/monitoring/errorBoundary.test.tsx
+++ b/frontend/src/test/monitoring/errorBoundary.test.tsx
@@ -58,7 +58,7 @@ describe('ErrorBoundary', () => {
     // can't silently "absorb" the throw by re-invoking with different state.
     const shouldThrow = { current: true }
 
-    function FlakyRoute(): JSX.Element {
+    function FlakyRoute(): React.ReactElement {
       if (shouldThrow.current) {
         throw new Error('boom-once')
       }

--- a/frontend/src/utils/csv.test.ts
+++ b/frontend/src/utils/csv.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect } from 'vitest';
-import { serializeTransactionsToCSV } from './csv';
-import { TransactionHistoryItem } from '../hooks/useTransactionHistory';
+import { describe, it, expect } from 'vitest'
+import { serializeTransactionsToCSV } from './csv'
+import { TransactionHistoryItem } from '../hooks/useTransactionHistory'
 
 describe('serializeTransactionsToCSV', () => {
   it('returns only headers when transactions list is empty', () => {
-    const csv = serializeTransactionsToCSV([]);
-    expect(csv).toBe('date,type,token,amount,tx hash');
-  });
+    const csv = serializeTransactionsToCSV([])
+    expect(csv).toBe('date,type,token,amount,tx hash')
+  })
 
   it('serializes standard transaction items correctly', () => {
     const items: TransactionHistoryItem[] = [
@@ -28,17 +28,17 @@ describe('serializeTransactionsToCSV', () => {
         status: 'failed',
         hash: '0xfedcba0987654321',
       },
-    ];
+    ]
 
-    const csv = serializeTransactionsToCSV(items);
+    const csv = serializeTransactionsToCSV(items)
     const expected = [
       'date,type,token,amount,tx hash',
       '2026-06-26T12:00:00Z,mint,USDC,100.50,0x1234567890abcdef',
       '2026-06-26T12:05:00Z,burn,XLM,10.00,0xfedcba0987654321',
-    ].join('\n');
+    ].join('\n')
 
-    expect(csv).toBe(expected);
-  });
+    expect(csv).toBe(expected)
+  })
 
   it('escapes fields containing commas, newlines, or double quotes', () => {
     const items: TransactionHistoryItem[] = [
@@ -60,15 +60,15 @@ describe('serializeTransactionsToCSV', () => {
         status: 'success',
         hash: 'normalhash',
       },
-    ];
+    ]
 
-    const csv = serializeTransactionsToCSV(items);
+    const csv = serializeTransactionsToCSV(items)
     const expected = [
       'date,type,token,amount,tx hash',
       '2026-06-26T12:10:00Z,create,"My,Token",500,"hash""with""quotes"',
       '2026-06-26T12:15:00Z,other,"Newline\nToken",1.00,normalhash',
-    ].join('\n');
+    ].join('\n')
 
-    expect(csv).toBe(expected);
-  });
-});
+    expect(csv).toBe(expected)
+  })
+})

--- a/frontend/src/utils/csv.ts
+++ b/frontend/src/utils/csv.ts
@@ -1,4 +1,4 @@
-import { TransactionHistoryItem } from '../hooks/useTransactionHistory';
+import { TransactionHistoryItem } from '../hooks/useTransactionHistory'
 
 /**
  * Serializes transaction history items to a CSV string.
@@ -8,28 +8,22 @@ import { TransactionHistoryItem } from '../hooks/useTransactionHistory';
  * @returns Standard RFC 4180 CSV string
  */
 export function serializeTransactionsToCSV(transactions: TransactionHistoryItem[]): string {
-  const headers = ['date', 'type', 'token', 'amount', 'tx hash'];
+  const headers = ['date', 'type', 'token', 'amount', 'tx hash']
 
   const rows = transactions.map((tx) => {
-    const fields = [
-      tx.date || '',
-      tx.type || '',
-      tx.token || '',
-      tx.amount || '',
-      tx.hash || '',
-    ];
+    const fields = [tx.date || '', tx.type || '', tx.token || '', tx.amount || '', tx.hash || '']
 
     return fields.map((field) => {
-      const valStr = String(field);
+      const valStr = String(field)
       // Escape double quotes by doubling them
-      const escaped = valStr.replace(/"/g, '""');
+      const escaped = valStr.replace(/"/g, '""')
       // If the field contains commas, double quotes, or newlines, wrap it in double quotes
       if (/[",\r\n]/.test(valStr)) {
-        return `"${escaped}"`;
+        return `"${escaped}"`
       }
-      return valStr;
-    });
-  });
+      return valStr
+    })
+  })
 
-  return [headers, ...rows].map((row) => row.join(',')).join('\n');
+  return [headers, ...rows].map((row) => row.join(',')).join('\n')
 }

--- a/frontend/src/utils/formatting.ts
+++ b/frontend/src/utils/formatting.ts
@@ -98,11 +98,14 @@ export const ipfsToGatewayUrl = (uri: string): string => {
 }
 
 type ExplorerLinkType = 'tx' | 'contract' | 'account'
-type Network = 'testnet' | 'mainnet'
+type Network = 'testnet' | 'mainnet' | 'standalone'
 
 const EXPLORER_BASES: Record<Network, string> = {
   mainnet: 'https://stellar.expert/explorer/public',
   testnet: 'https://stellar.expert/explorer/testnet',
+  // A local `standalone` network has no public explorer; fall back to testnet
+  // as a best-effort so links don't break in dev/E2E.
+  standalone: 'https://stellar.expert/explorer/testnet',
 }
 
 /** Build a stellar.expert explorer URL for a tx, contract, or account. */

--- a/frontend/src/utils/retry.ts
+++ b/frontend/src/utils/retry.ts
@@ -3,8 +3,8 @@
 export interface RetryOptions {
   maxAttempts?: number
   baseDelayMs?: number
-  shouldRetry?: (error: unknown) => boolean
-  onRetry?: (attempt: number, delayMs: number) => void
+  shouldRetry?: ((error: unknown) => boolean) | undefined
+  onRetry?: ((attempt: number, delayMs: number) => void) | undefined
 }
 
 const DEFAULT_MAX_ATTEMPTS = 3

--- a/frontend/src/utils/stellarExplorer.ts
+++ b/frontend/src/utils/stellarExplorer.ts
@@ -1,11 +1,14 @@
 export type ExplorerType = 'account' | 'transaction' | 'contract'
-export type Network = 'mainnet' | 'testnet'
+export type Network = 'mainnet' | 'testnet' | 'standalone'
 
 const VALID_TYPES = new Set<ExplorerType>(['account', 'transaction', 'contract'])
 
 const BASE: Record<Network, string> = {
   mainnet: 'https://stellar.expert/explorer/public',
   testnet: 'https://stellar.expert/explorer/testnet',
+  // A local `standalone` network has no public explorer; fall back to the
+  // testnet explorer as a best-effort so links don't break in dev/E2E.
+  standalone: 'https://stellar.expert/explorer/testnet',
 }
 
 const PATH_SEGMENT: Record<ExplorerType, string> = {

--- a/frontend/src/utils/tokenFilters.test.ts
+++ b/frontend/src/utils/tokenFilters.test.ts
@@ -13,7 +13,7 @@ const mockTokens: TokenInfo[] = [
     totalSupply: '1000000000',
     creator: CREATOR_A,
     createdAt: 1000000,
-    metadataUri: null,
+    metadataUri: '',
   },
   {
     name: 'Beta Coin',
@@ -31,7 +31,7 @@ const mockTokens: TokenInfo[] = [
     totalSupply: '500000000',
     creator: CREATOR_A,
     createdAt: 3000000,
-    metadataUri: null,
+    metadataUri: '',
   },
   {
     name: 'Delta Finance',
@@ -51,19 +51,19 @@ describe('applyFilters', () => {
     it('filters by token name', () => {
       const result = applyFilters(mockTokens, 'Alpha', '', 'newest')
       expect(result).toHaveLength(1)
-      expect(result[0].name).toBe('Alpha Token')
+      expect(result[0]!.name).toBe('Alpha Token')
     })
 
     it('filters by token symbol', () => {
       const result = applyFilters(mockTokens, 'BETA', '', 'newest')
       expect(result).toHaveLength(1)
-      expect(result[0].symbol).toBe('BETA')
+      expect(result[0]!.symbol).toBe('BETA')
     })
 
     it('is case-insensitive', () => {
       const result = applyFilters(mockTokens, 'gamma', '', 'newest')
       expect(result).toHaveLength(1)
-      expect(result[0].name).toBe('Gamma Token')
+      expect(result[0]!.name).toBe('Gamma Token')
     })
 
     it('matches partial strings', () => {
@@ -143,13 +143,13 @@ describe('applyFilters', () => {
     it('keeps newest-first order by default', () => {
       const result = applyFilters(mockTokens, '', '', 'newest')
       // Array order is maintained (newest-first is assumed to be input order)
-      expect(result[0].name).toBe('Alpha Token')
+      expect(result[0]!.name).toBe('Alpha Token')
     })
 
     it('sorts by oldest-first when specified', () => {
       const result = applyFilters(mockTokens, '', '', 'oldest')
-      expect(result[0].name).toBe('Delta Finance')
-      expect(result[result.length - 1].name).toBe('Alpha Token')
+      expect(result[0]!.name).toBe('Delta Finance')
+      expect(result[result.length - 1]!.name).toBe('Alpha Token')
     })
 
     it('sorts alphabetically by name when specified', () => {
@@ -190,7 +190,7 @@ describe('applyFilters', () => {
     it('handles all filters combined with sorts', () => {
       const filtered = applyFilters(mockTokens, 'Coin', CREATOR_B, 'alphabetical')
       expect(filtered).toHaveLength(1)
-      expect(filtered[0].symbol).toBe('BETA')
+      expect(filtered[0]!.symbol).toBe('BETA')
     })
 
     it('handles whitespace as part of search pattern', () => {
@@ -203,7 +203,7 @@ describe('applyFilters', () => {
     it('finds tokens when search pattern matches', () => {
       const result = applyFilters(mockTokens, 'Alpha', '', 'newest')
       expect(result).toHaveLength(1)
-      expect(result[0].name).toBe('Alpha Token')
+      expect(result[0]!.name).toBe('Alpha Token')
     })
   })
 })

--- a/frontend/src/utils/validation.ts
+++ b/frontend/src/utils/validation.ts
@@ -12,7 +12,7 @@ function base32Decode(input: string): Uint8Array {
   let next = 0
 
   for (let i = 0; i < length; i++) {
-    const val = ALPHABET.indexOf(upper[i])
+    const val = ALPHABET.indexOf(upper[i]!)
     if (val === -1) throw new Error('Invalid base32 character')
     buffer = (buffer << 5) | val
     bitsLeft += 5
@@ -27,7 +27,7 @@ function base32Decode(input: string): Uint8Array {
 function crc16(data: Uint8Array): number {
   let crc = 0x0000
   for (let i = 0; i < data.length; i++) {
-    const byte = data[i]
+    const byte = data[i]!
     let code = (crc >>> 8) & 0xff
     code ^= byte
     code ^= code >>> 4
@@ -49,7 +49,7 @@ export const isValidStellarAddress = (address: string): boolean => {
     const payload = decoded.slice(1, 33)
     const checksum = decoded.slice(33, 35)
     const calculatedCrc = crc16(new Uint8Array([versionByte, ...payload]))
-    const expectedCrc = checksum[0] | (checksum[1] << 8)
+    const expectedCrc = checksum[0]! | (checksum[1]! << 8)
     return calculatedCrc === expectedCrc
   } catch {
     return false
@@ -68,7 +68,7 @@ export const isValidContractAddress = (address: string): boolean => {
     const payload = decoded.slice(1, 33)
     const checksum = decoded.slice(33, 35)
     const calculatedCrc = crc16(new Uint8Array([versionByte, ...payload]))
-    const expectedCrc = checksum[0] | (checksum[1] << 8)
+    const expectedCrc = checksum[0]! | (checksum[1]! << 8)
     return calculatedCrc === expectedCrc
   } catch {
     return false


### PR DESCRIPTION
…pecheck gate

Audit follow-up for the campaign work:

A. Wire merged-but-unreachable features:
- Mount OnboardingModal (Help button + first-visit tour were dead)
- Add /activity route + NavBar link for TransactionHistory (surfaces CSV export + polling, previously never rendered)
- Wire FeeDisplay (XLM + USD) into TokenForm and drop the hardcoded estimatedFee="0.01" that masked the real on-chain base fee
- Render AnalyticsOptOut in a footer (privacy opt-out was unreachable)

B. standalone network + type safety:
- Support the `standalone` network across both explorer-URL builders, NetworkSwitcher badge, and the StellarService/network-helper chain
- Fix all 88 tsc errors (SDK drift, noUncheckedIndexedAccess guards, UI prop widening, test-mock drift)
- Add `typecheck` npm script and a Typecheck step to CI so type errors can no longer merge invisibly (CI builds with esbuild, which skips types)

Also: reformat 4 files that violated the project's Prettier config (format:check was failing on main).