### PR TITLE
feat(frontend): block writes on network mismatch in metadata + admin forms

### DIFF
--- a/frontend/src/components/AdminPanel.test.tsx
+++ b/frontend/src/components/AdminPanel.test.tsx
@@ -19,6 +19,10 @@ vi.mock('../hooks/useTransaction', () => ({
   useTransaction: vi.fn(),
 }))
 
+vi.mock('../context/NetworkContext', () => ({
+  useNetwork: () => ({ network: 'testnet', mismatch: { isMismatch: false } }),
+}))
+
 const mockAddToast = vi.fn()
 const mockUpdateFees = vi.fn()
 const mockExecute = vi.fn()

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -5,6 +5,7 @@ import { useStellarContext } from '../context/StellarContext'
 import { useToast } from '../context/ToastContext'
 import { useFactoryState } from '../hooks/useFactoryState'
 import { useTransaction } from '../hooks/useTransaction'
+import { useNetworkGuard } from '../hooks/useNetworkGuard'
 
 // Stroops → display XLM (7 decimals)
 function stroopsToDisplay(stroops: string): string {
@@ -26,6 +27,7 @@ export const AdminPanel: React.FC = () => {
   const { stellarService } = useStellarContext()
   const { addToast } = useToast()
   const { state, isLoading: stateLoading, refetch } = useFactoryState()
+  const { blocked: networkBlocked, reason: networkReason } = useNetworkGuard()
 
   const [baseFee, setBaseFee] = useState('')
   const [metadataFee, setMetadataFee] = useState('')
@@ -149,11 +151,17 @@ export const AdminPanel: React.FC = () => {
           type="submit"
           variant="primary"
           loading={isPending}
-          disabled={isPending}
+          disabled={isPending || networkBlocked}
           className="w-full"
         >
           {isPending ? 'Submitting…' : 'Submit Changes'}
         </Button>
+
+        {networkBlocked && networkReason && (
+          <p className="mt-2 text-sm text-red-600 dark:text-red-400" role="alert">
+            {networkReason}
+          </p>
+        )}
       </form>
 
       <ConfirmModal

--- a/frontend/src/components/MetadataForm.test.tsx
+++ b/frontend/src/components/MetadataForm.test.tsx
@@ -15,7 +15,7 @@ vi.mock('../context/ToastContext', () => ({
 }))
 
 vi.mock('../context/NetworkContext', () => ({
-  useNetwork: () => ({ network: 'testnet' }),
+  useNetwork: () => ({ network: 'testnet', mismatch: { isMismatch: false } }),
 }))
 
 vi.mock('../hooks/useFactoryState', () => ({

--- a/frontend/src/components/MetadataForm.tsx
+++ b/frontend/src/components/MetadataForm.tsx
@@ -7,6 +7,7 @@ import { useToast } from '../context/ToastContext'
 import { useStellarContext } from '../context/StellarContext'
 import { useBalanceCheck } from '../hooks/useBalanceCheck'
 import { useNetwork } from '../context/NetworkContext'
+import { useNetworkGuard } from '../hooks/useNetworkGuard'
 import { useTos } from '../context/TosContext'
 import { isIpfsConfigured } from '../config/env'
 import { ExplorerLink } from './ExplorerLink'
@@ -26,6 +27,7 @@ export const MetadataForm: React.FC<MetadataFormProps> = ({ initialTokenAddress 
   const { ipfsService, stellarService } = useStellarContext()
   const { addToast } = useToast()
   const { network } = useNetwork()
+  const { blocked: networkBlocked, reason: networkReason } = useNetworkGuard()
   const { requireTos } = useTos()
   const { state: factoryState } = useFactoryState()
 
@@ -349,11 +351,17 @@ export const MetadataForm: React.FC<MetadataFormProps> = ({ initialTokenAddress 
 
         <Button
           type="submit"
-          disabled={!imageFile || !tokenAddress.trim() || !hasSufficientBalance}
+          disabled={!imageFile || !tokenAddress.trim() || !hasSufficientBalance || networkBlocked}
           className="w-full"
         >
           Set Metadata
         </Button>
+
+        {networkBlocked && networkReason && (
+          <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+            {networkReason}
+          </p>
+        )}
       </form>
 
       <ConfirmModal

--- a/frontend/src/components/SetMetadataForm.tsx
+++ b/frontend/src/components/SetMetadataForm.tsx
@@ -4,6 +4,7 @@ import { Input, Button, ConfirmModal, InsufficientBalanceWarning } from './UI'
 import { isValidIPFSUri } from '../utils/validation'
 import { useToast } from '../context/ToastContext'
 import { useBalanceCheck } from '../hooks/useBalanceCheck'
+import { useNetworkGuard } from '../hooks/useNetworkGuard'
 import { isIpfsConfigured } from '../config/env'
 
 const ESTIMATED_FEE = '0.01' // XLM
@@ -25,6 +26,7 @@ export const SetMetadataForm: React.FC<Props> = ({
   const [pending, setPending] = useState(false)
   const { addToast } = useToast()
   const ipfsReady = isIpfsConfigured()
+  const { blocked: networkBlocked, reason: networkReason } = useNetworkGuard()
   const { hasSufficientBalance, shortfall, isTestnet } = useBalanceCheck(ESTIMATED_FEE_XLM)
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -79,10 +81,18 @@ export const SetMetadataForm: React.FC<Props> = ({
           disabled={!ipfsReady}
         />
         <div title={!ipfsReady ? 'IPFS credentials are not configured' : undefined}>
-          <Button type="submit" disabled={loading || !ipfsReady || !hasSufficientBalance}>
+          <Button
+            type="submit"
+            disabled={loading || !ipfsReady || !hasSufficientBalance || networkBlocked}
+          >
             {loading ? 'Submitting...' : 'Set Metadata'}
           </Button>
         </div>
+        {networkBlocked && networkReason && (
+          <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+            {networkReason}
+          </p>
+        )}
         {!hasSufficientBalance && (
           <InsufficientBalanceWarning shortfall={shortfall} isTestnet={isTestnet} />
         )}


### PR DESCRIPTION
Follow-up to the network-mismatch safety work. `useNetworkGuard` was wired into create/mint/burn; this extends it to the remaining on-chain write forms so **all** writes are hard-blocked (submit disabled + reason) when Freighter's network differs from the app's — not just warned by the global `NetworkMismatchBanner`.

## Changes
- `MetadataForm` (`set_metadata` via `/metadata`) — guard submit
- `SetMetadataForm` (`set_metadata` via TokenDetail) — guard submit
- `AdminPanel` (`update_fees` + other admin ops) — guard submit
- Tests: add `mismatch` to the `useNetwork` mock in `MetadataForm.test`; add a `useNetwork` mock to `AdminPanel.test` (AdminPanel now consumes `NetworkContext` via the guard). `AdminPanel.integration.test` doesn't render the component, so it's unaffected.

## Verification
typecheck ✓ · lint ✓ · format ✓ · **452 tests ✓** · build ✓