### PR TITLE
fix(#944): add txHash, network, contractId Sentry tagging on transact…

### DIFF
--- a/frontend/src/components/TransactionStatus.tsx
+++ b/frontend/src/components/TransactionStatus.tsx
@@ -16,7 +16,7 @@ export const TransactionStatus: React.FC<TransactionStatusProps> = ({
   onSuccess,
   onError,
 }) => {
-  const { status, error } = useTransactionPolling(txHash)
+  const { status, error, sentryEventId } = useTransactionPolling(txHash)
   const { network } = useNetwork()
 
   React.useEffect(() => {
@@ -96,6 +96,46 @@ export const TransactionStatus: React.FC<TransactionStatusProps> = ({
           >
             View on Stellar Expert
           </a>
+
+          {/* Report an issue affordance — surfaces both the txHash and Sentry
+              event ID so support can correlate on-chain data with the captured
+              error report in a single step. */}
+          <div
+            className="mt-2 w-full rounded-lg border border-red-200 bg-red-50 p-3 text-left text-xs text-gray-600"
+            data-testid="report-issue-panel"
+          >
+            <p className="mb-2 font-semibold text-gray-700">Having trouble? Report this issue</p>
+            <div className="space-y-1">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-gray-500">Transaction hash:</span>
+                <span className="flex items-center gap-1 font-mono">
+                  {txHash.slice(0, 8)}…{txHash.slice(-8)}
+                  <CopyButton value={txHash} ariaLabel="Copy transaction hash" />
+                </span>
+              </div>
+              {sentryEventId && (
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-gray-500">Error reference ID:</span>
+                  <span className="flex items-center gap-1 font-mono">
+                    {sentryEventId.slice(0, 8)}
+                    <CopyButton value={sentryEventId} ariaLabel="Copy error reference ID" />
+                  </span>
+                </div>
+              )}
+            </div>
+            <p className="mt-2 text-gray-500">
+              Include both values when{' '}
+              <a
+                href="https://github.com/Favourorg/Stellar-forge/issues/new"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-500 hover:text-blue-700 underline"
+              >
+                opening a support issue
+              </a>
+              .
+            </p>
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/hooks/useTransactionPolling.ts
+++ b/frontend/src/hooks/useTransactionPolling.ts
@@ -1,11 +1,15 @@
 import { useEffect, useState } from 'react'
 import { stellarService } from '../services/stellar'
+import { captureTransactionError } from '../lib/monitoring/sentry'
+import { STELLAR_CONFIG } from '../config/stellar'
 
 export type TransactionPollStatus = 'pending' | 'success' | 'failed'
 
 export interface UseTransactionPollingResult {
   status: TransactionPollStatus
   error?: string
+  /** Sentry event ID for the polling failure, when available. */
+  sentryEventId?: string
 }
 
 const POLL_INTERVAL_MS = 250
@@ -14,10 +18,15 @@ const TIMEOUT_MS = 60000
 /**
  * Polls stellarService.getTransaction(txHash) until it resolves to a
  * terminal status (success/error) or TIMEOUT_MS elapses.
+ *
+ * On failure, captures a Sentry event tagged with the txHash, network, and
+ * factoryContractId so support can correlate any error report to the on-chain
+ * transaction without manual timestamp cross-referencing.
  */
 export function useTransactionPolling(txHash: string): UseTransactionPollingResult {
   const [status, setStatus] = useState<TransactionPollStatus>('pending')
   const [error, setError] = useState<string | undefined>(undefined)
+  const [sentryEventId, setSentryEventId] = useState<string | undefined>(undefined)
 
   useEffect(() => {
     // Reset to pending whenever txHash changes so a new poll cycle doesn't
@@ -25,6 +34,7 @@ export function useTransactionPolling(txHash: string): UseTransactionPollingResu
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setStatus('pending')
     setError(undefined)
+    setSentryEventId(undefined)
 
     let settled = false
 
@@ -41,7 +51,20 @@ export function useTransactionPolling(txHash: string): UseTransactionPollingResu
           settled = true
           clearInterval(intervalId)
           setStatus('failed')
-          setError(typeof result.error === 'string' ? result.error : 'Transaction failed')
+          const errorMessage = typeof result.error === 'string' ? result.error : 'Transaction failed'
+          setError(errorMessage)
+
+          // Capture to Sentry with full transaction correlation tags
+          const eventId = captureTransactionError(
+            new Error(`Transaction failed: ${errorMessage}`),
+            {
+              txHash,
+              network: STELLAR_CONFIG.network,
+              contractId: STELLAR_CONFIG.factoryContractId ?? undefined,
+              functionName: 'pollTransaction',
+            },
+          )
+          if (eventId) setSentryEventId(eventId)
         }
         // status === 'pending' — keep polling
       } catch (err) {
@@ -49,7 +72,20 @@ export function useTransactionPolling(txHash: string): UseTransactionPollingResu
         settled = true
         clearInterval(intervalId)
         setStatus('failed')
-        setError(err instanceof Error ? err.message : 'Transaction failed')
+        const errorMessage = err instanceof Error ? err.message : 'Transaction failed'
+        setError(errorMessage)
+
+        // Capture to Sentry with full transaction correlation tags
+        const eventId = captureTransactionError(
+          err instanceof Error ? err : new Error(errorMessage),
+          {
+            txHash,
+            network: STELLAR_CONFIG.network,
+            contractId: STELLAR_CONFIG.factoryContractId ?? undefined,
+            functionName: 'pollTransaction',
+          },
+        )
+        if (eventId) setSentryEventId(eventId)
       }
     }
 
@@ -61,7 +97,15 @@ export function useTransactionPolling(txHash: string): UseTransactionPollingResu
       settled = true
       clearInterval(intervalId)
       setStatus('failed')
-      setError('Timeout')
+      const errorMessage = 'Timeout'
+      setError(errorMessage)
+
+      captureTransactionError(new Error(`Transaction polling timed out: ${txHash}`), {
+        txHash,
+        network: STELLAR_CONFIG.network,
+        contractId: STELLAR_CONFIG.factoryContractId ?? undefined,
+        functionName: 'pollTransaction',
+      })
     }, TIMEOUT_MS)
 
     return () => {
@@ -71,5 +115,6 @@ export function useTransactionPolling(txHash: string): UseTransactionPollingResu
     }
   }, [txHash])
 
-  return error === undefined ? { status } : { status, error }
+  if (error === undefined) return { status, sentryEventId }
+  return { status, error, sentryEventId }
 }

--- a/frontend/src/lib/monitoring/sentry.ts
+++ b/frontend/src/lib/monitoring/sentry.ts
@@ -91,6 +91,16 @@ export interface ContractErrorContext extends ErrorContext {
   params?: Record<string, unknown>
 }
 
+/**
+ * Context for transaction lifecycle errors.
+ * Extends ContractErrorContext with the transaction hash so every Sentry event
+ * captured during or after a transaction can be correlated to the on-chain tx.
+ */
+export interface TransactionErrorContext extends ContractErrorContext {
+  /** Stellar transaction hash (64 hex characters) */
+  txHash?: string
+}
+
 export function captureException(error: Error, context?: ErrorContext): void {
   if (!IS_SENTRY_ENABLED) return
   Sentry.withScope((scope: Scope) => {
@@ -103,7 +113,7 @@ export function captureException(error: Error, context?: ErrorContext): void {
  * Capture contract call errors with structured context
  * This helps track failed RPC calls and contract invocations in production
  */
-export function captureContractError(error: Error, context: ContractErrorContext): void {
+export function captureContractError(error: Error, context: ContractErrorContext & { txHash?: string }): void {
   if (!IS_SENTRY_ENABLED) return
 
   Sentry.withScope((scope: Scope) => {
@@ -111,9 +121,52 @@ export function captureContractError(error: Error, context: ContractErrorContext
     if (context.network) scope.setTag('network', context.network)
     if (context.contractId) scope.setTag('contractId', context.contractId)
     if (context.functionName) scope.setTag('functionName', context.functionName)
+    // Tag txHash when available so the event can be correlated to the on-chain transaction
+    if (context.txHash) scope.setTag('txHash', context.txHash)
 
     // Add context as extras
     const extras: Record<string, unknown> = {}
+    if (context.network) extras.network = context.network
+    if (context.contractId) extras.contractId = context.contractId
+    if (context.functionName) extras.functionName = context.functionName
+    if (context.params) extras.params = context.params
+    if (context.txHash) extras.txHash = context.txHash
+
+    scope.setExtras(extras)
+    Sentry.captureException(error)
+  })
+}
+
+/**
+ * Capture a transaction lifecycle error with full structured correlation context.
+ *
+ * Tags every captured event with:
+ *   - `txHash`          — the Stellar transaction hash (allows direct pivot to on-chain data)
+ *   - `network`         — testnet/mainnet (avoids cross-environment noise in alerts)
+ *   - `contractId`      — factory contract ID (correlates events across upgrade deploys)
+ *   - `functionName`    — the RPC method that failed
+ *
+ * This is the primary capture function for any error that occurs during the
+ * simulate → sign → submit → poll lifecycle of a Soroban transaction.
+ *
+ * Returns the Sentry event ID so callers can surface it alongside the txHash
+ * in the "Report an issue" affordance — giving support both pieces of context
+ * in one step.
+ */
+export function captureTransactionError(
+  error: Error,
+  context: TransactionErrorContext,
+): string | undefined {
+  if (!IS_SENTRY_ENABLED) return undefined
+
+  Sentry.withScope((scope: Scope) => {
+    if (context.txHash) scope.setTag('txHash', context.txHash)
+    if (context.network) scope.setTag('network', context.network)
+    if (context.contractId) scope.setTag('contractId', context.contractId)
+    if (context.functionName) scope.setTag('functionName', context.functionName)
+
+    const extras: Record<string, unknown> = {}
+    if (context.txHash) extras.txHash = context.txHash
     if (context.network) extras.network = context.network
     if (context.contractId) extras.contractId = context.contractId
     if (context.functionName) extras.functionName = context.functionName
@@ -122,6 +175,10 @@ export function captureContractError(error: Error, context: ContractErrorContext
     scope.setExtras(extras)
     Sentry.captureException(error)
   })
+
+  // lastEventId() returns the ID of the most recently captured event —
+  // safe to read immediately after withScope because withScope is synchronous.
+  return Sentry.lastEventId() ?? undefined
 }
 
 export function captureMessage(message: string, level: SeverityLevel = 'info'): void {

--- a/frontend/src/services/stellar-impl.ts
+++ b/frontend/src/services/stellar-impl.ts
@@ -1,7 +1,7 @@
 // Stellar SDK integration service
 import { STELLAR_CONFIG, NETWORK_CONFIGS } from '../config/stellar'
 import { walletService } from './wallet'
-import { captureContractError } from '../lib/monitoring/sentry'
+import { captureContractError, captureTransactionError } from '../lib/monitoring/sentry'
 import type {
   AppError,
   ContractEvent,
@@ -125,9 +125,7 @@ async function pollTransaction(
     await new Promise((r) => setTimeout(r, base + jitter))
   }
   throw new Error(`Transaction ${hash} timed out after ${maxAttempts} attempts`)
-}
-
-// ── Fee Bump Transactions ─────────────────────────────────────────────────────
+}// ── Fee Bump Transactions ─────────────────────────────────────────────────────
 
 /**
  * Wrap a signed inner transaction in a fee bump envelope.
@@ -676,13 +674,12 @@ export class StellarService {
       captureContractError(err instanceof Error ? err : new Error(String(err)), {
         network: this.network,
         functionName,
+        txHash: hash,
         params: { hash },
       })
       throw new Error(appErr.message)
     }
-  }
-
-  // ── getFactoryState ─────────────────────────────────────────────────────────
+  } ─────────────────────────────────────────────────────────
 
   async getFactoryState(): Promise<FactoryState> {
     const functionName = 'getFactoryState'

--- a/frontend/src/test/monitoring/txSentryTags.test.ts
+++ b/frontend/src/test/monitoring/txSentryTags.test.ts
@@ -1,0 +1,149 @@
+/**
+ * #944 — Sentry tag correlation during transaction poll errors
+ *
+ * Verifies that a client-side error occurring during an active transaction
+ * poll carries the expected structured tags (txHash, network, contractId,
+ * functionName) through to the Sentry-captured payload.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Mock @sentry/react before any module under test is imported ───────────────
+const mockScope = {
+  setTag: vi.fn(),
+  setExtras: vi.fn(),
+}
+const mockWithScope = vi.fn((cb: (scope: typeof mockScope) => void) => cb(mockScope))
+const mockCaptureException = vi.fn()
+const mockLastEventId = vi.fn(() => 'test-event-id-abcd1234')
+
+vi.mock('@sentry/react', () => ({
+  init: vi.fn(),
+  captureException: mockCaptureException,
+  captureMessage: vi.fn(),
+  setUser: vi.fn(),
+  setTag: vi.fn(),
+  withScope: mockWithScope,
+  withProfiler: vi.fn((c) => c),
+  browserTracingIntegration: vi.fn(),
+  replayIntegration: vi.fn(),
+  lastEventId: mockLastEventId,
+  ErrorBoundary: ({ children }: { children: unknown }) => children,
+}))
+
+// Enable Sentry by simulating production environment before importing sentry.ts
+vi.stubEnv('MODE', 'production')
+vi.stubEnv('VITE_SENTRY_DSN', 'https://test@sentry.io/1')
+
+describe('#944 captureTransactionError Sentry tag correlation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockLastEventId.mockReturnValue('test-event-id-abcd1234')
+  })
+
+  it('tags txHash, network, contractId, and functionName on a poll failure', async () => {
+    const { captureTransactionError } = await import('../../lib/monitoring/sentry')
+
+    const testTxHash = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2'
+    const error = new Error('Transaction failed: simulate poll error')
+
+    captureTransactionError(error, {
+      txHash: testTxHash,
+      network: 'testnet',
+      contractId: 'CABC1234TEST',
+      functionName: 'pollTransaction',
+    })
+
+    // withScope must have been called
+    expect(mockWithScope).toHaveBeenCalledOnce()
+
+    // All four required tags must be present
+    expect(mockScope.setTag).toHaveBeenCalledWith('txHash', testTxHash)
+    expect(mockScope.setTag).toHaveBeenCalledWith('network', 'testnet')
+    expect(mockScope.setTag).toHaveBeenCalledWith('contractId', 'CABC1234TEST')
+    expect(mockScope.setTag).toHaveBeenCalledWith('functionName', 'pollTransaction')
+
+    // The error itself must be captured
+    expect(mockCaptureException).toHaveBeenCalledWith(error)
+
+    // Extras must mirror the tags for rich event detail
+    expect(mockScope.setExtras).toHaveBeenCalledWith(
+      expect.objectContaining({
+        txHash: testTxHash,
+        network: 'testnet',
+        contractId: 'CABC1234TEST',
+        functionName: 'pollTransaction',
+      }),
+    )
+  })
+
+  it('returns the Sentry event ID so the UI can surface it to the user', async () => {
+    const { captureTransactionError } = await import('../../lib/monitoring/sentry')
+
+    const eventId = captureTransactionError(new Error('poll timeout'), {
+      txHash: 'deadbeef'.repeat(8),
+      network: 'mainnet',
+      contractId: 'CMAINNET',
+      functionName: 'pollTransaction',
+    })
+
+    expect(eventId).toBe('test-event-id-abcd1234')
+  })
+
+  it('returns undefined and is a no-op when Sentry is disabled (development)', async () => {
+    vi.resetModules()
+    vi.stubEnv('MODE', 'development')
+    vi.unstubAllEnvs()
+    vi.stubEnv('MODE', 'development')
+
+    const { captureTransactionError: devCapture } = await import('../../lib/monitoring/sentry')
+    const result = devCapture(new Error('noop'), { txHash: 'abc', network: 'testnet' })
+
+    expect(result).toBeUndefined()
+    expect(mockWithScope).not.toHaveBeenCalled()
+
+    vi.unstubAllEnvs()
+    vi.stubEnv('MODE', 'production')
+    vi.stubEnv('VITE_SENTRY_DSN', 'https://test@sentry.io/1')
+  })
+
+  it('works without optional fields — only provided context is tagged', async () => {
+    vi.resetModules()
+    vi.stubEnv('MODE', 'production')
+    vi.stubEnv('VITE_SENTRY_DSN', 'https://test@sentry.io/1')
+
+    const { captureTransactionError } = await import('../../lib/monitoring/sentry')
+
+    captureTransactionError(new Error('minimal context'), {
+      txHash: 'cafebabe'.repeat(8),
+    })
+
+    // txHash must be tagged
+    expect(mockScope.setTag).toHaveBeenCalledWith('txHash', 'cafebabe'.repeat(8))
+    // Other optional tags should NOT be set when not provided
+    const tagCalls = mockScope.setTag.mock.calls.map(([k]) => k)
+    expect(tagCalls).not.toContain('network')
+    expect(tagCalls).not.toContain('contractId')
+    expect(tagCalls).not.toContain('functionName')
+  })
+
+  it('captureContractError also tags txHash when provided', async () => {
+    vi.resetModules()
+    vi.stubEnv('MODE', 'production')
+    vi.stubEnv('VITE_SENTRY_DSN', 'https://test@sentry.io/1')
+
+    const { captureContractError } = await import('../../lib/monitoring/sentry')
+
+    const txHash = 'deadcafe'.repeat(8)
+    captureContractError(new Error('contract revert'), {
+      network: 'testnet',
+      contractId: 'CTEST',
+      functionName: 'deployToken',
+      txHash,
+    })
+
+    expect(mockScope.setTag).toHaveBeenCalledWith('txHash', txHash)
+    expect(mockScope.setTag).toHaveBeenCalledWith('network', 'testnet')
+    expect(mockScope.setTag).toHaveBeenCalledWith('contractId', 'CTEST')
+    expect(mockScope.setTag).toHaveBeenCalledWith('functionName', 'deployToken')
+  })
+})


### PR DESCRIPTION
…ion failures

- Add captureTransactionError() to sentry.ts — tags txHash, network, contractId, functionName on every captured event during transaction lifecycle; returns the Sentry event ID so the UI can surface it to the user
- Update captureContractError() to accept an optional txHash tag
- Update useTransactionPolling to call captureTransactionError on poll failures and expose sentryEventId in the hook result
- Update TransactionStatus failure state with a Report an issue panel that shows the txHash and Sentry event ID side-by-side for one-step support handoff
- Update stellar-impl.ts getTransaction to include txHash in its Sentry context
- Add txSentryTags.test.ts verifying all four tags are set on captured events

Closes #944 