### PR TITLE
fix: validate token supply before minting to prevent u128 overflow

### DIFF
--- a/contracts/token-factory/fuzz/Cargo.toml
+++ b/contracts/token-factory/fuzz/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.0.0"
 publish = false
 edition = "2021"
 
+[workspace]
+
+[package.metadata]
+cargo-fuzz = true
+
 [dependencies]
 libfuzzer-sys = "0.4"
 arbitrary = { version = "1", features = ["derive"] }

--- a/contracts/token-factory/fuzz/fuzz_targets/fuzz_create_token.rs
+++ b/contracts/token-factory/fuzz/fuzz_targets/fuzz_create_token.rs
@@ -6,24 +6,27 @@ use libfuzzer_sys::fuzz_target;
 #[derive(Arbitrary, Debug, Clone)]
 struct FuzzCreateTokenInput {
     // Random bytes for name and symbol - bounded to avoid extremely long strings
-    #[arbitrary(size_hint = 1..=100)]
     name_bytes: Vec<u8>,
-    #[arbitrary(size_hint = 1..=50)]
     symbol_bytes: Vec<u8>,
     decimals: u32,
-    initial_supply: i128,
+    // i128 has full Arbitrary support; we reinterpret its bit pattern as u128
+    // below to cover the high-end values that the contract's u128 parameter
+    // accepts.  This means values ≥ 0 map to [0, i128::MAX] and negative
+    // values map to (i128::MAX, u128::MAX], which is exactly the overflow
+    // region guarded by the fix for issue #909.
+    initial_supply_bits: i128,
     fee_payment: i128,
 }
 
 fuzz_target!(|input: FuzzCreateTokenInput| {
     // Test string validation and creation with random UTF-8 data
-    
+
     // Convert random bytes to valid UTF-8 strings
     let name_str = match String::from_utf8(input.name_bytes) {
         Ok(s) if !s.is_empty() => s,
         _ => "DefaultToken".to_string(),
     };
-    
+
     let symbol_str = match String::from_utf8(input.symbol_bytes) {
         Ok(s) if !s.is_empty() => s,
         _ => "DTK".to_string(),
@@ -35,18 +38,74 @@ fuzz_target!(|input: FuzzCreateTokenInput| {
 
     // Test bounded arithmetic - should not panic on overflow
     let decimals_bounded = input.decimals % 256;
-    let initial_supply_bounded = input.initial_supply.saturating_mul(1);
     let fee_bounded = input.fee_payment.saturating_abs();
 
     // Verify invariants
     assert!(decimals_bounded < 256);
     assert!(fee_bounded >= 0);
-    
+
+    // ── Supply boundary checks (issue #909) ───────────────────────────────
+    // Reinterpret the fuzz-provided i128 as a u128 (same bits, different type)
+    // so that the full u128 domain — including values above i128::MAX — is
+    // reachable by the fuzzer with an Arbitrary-compatible input type.
+    let initial_supply = input.initial_supply_bits as u128;
+
+    // Validate that the supply guard logic never panics and always produces
+    // the correct accept/reject decision without silent wraparound.
+    //
+    // The fix rejects any u128 value > i128::MAX with InvalidParameters.
+    // Here we replicate that exact predicate and confirm it is consistent
+    // with a safe cast, covering the four critical boundary values that
+    // libFuzzer is unlikely to find on its own:
+    //   • i128::MAX - 1  (just below the limit — valid)
+    //   • i128::MAX      (exactly at the limit — valid)
+    //   • i128::MAX + 1  (one above the limit — must be rejected)
+    //   • u128::MAX      (largest possible value — must be rejected)
+    let boundary_cases: [u128; 4] = [
+        (i128::MAX as u128).saturating_sub(1), // i128::MAX - 1
+        i128::MAX as u128,                     // i128::MAX
+        (i128::MAX as u128).saturating_add(1), // i128::MAX + 1
+        u128::MAX,                             // u128::MAX
+    ];
+
+    for &supply in &boundary_cases {
+        if supply > i128::MAX as u128 {
+            // Values above i128::MAX must be rejected — simulating the guard.
+            // A cast here would produce a negative i128; assert we never
+            // reach the cast path without the guard.
+            let would_be_negative = supply as i128; // intentional: validate sign
+            assert!(
+                would_be_negative < 0,
+                "supply {supply} above i128::MAX must cast to a negative i128 \
+                 (confirming the guard is necessary)"
+            );
+        } else {
+            // Values at or below i128::MAX must cast safely and stay non-negative.
+            let safe_supply = supply as i128;
+            assert!(
+                safe_supply >= 0,
+                "supply {supply} ≤ i128::MAX must produce a non-negative i128, got {safe_supply}"
+            );
+        }
+    }
+
+    // Also run the same check for the fuzz-provided supply value so every
+    // input exercises the guard predicate.
+    if initial_supply <= i128::MAX as u128 {
+        let safe = initial_supply as i128;
+        assert!(
+            safe >= 0,
+            "supply {} ≤ i128::MAX must produce a non-negative i128, got {}",
+            initial_supply,
+            safe
+        );
+    }
+    // (Values above i128::MAX would be rejected by the contract; no cast is
+    //  performed on that code path, so no assertion needed here.)
+
     // Test saturation arithmetic doesn't panic
-    let _total = initial_supply_bounded.saturating_add(fee_bounded);
+    let _total = fee_bounded.saturating_add(i64::MAX as i128);
     let _product = fee_bounded.saturating_mul(i128::from(decimals_bounded));
-    
+
     // Fuzz test passes if no panic occurs
 });
-
-

--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -180,6 +180,9 @@ impl TokenFactory {
         {
             let mut distributed: i128 = 0;
             for (recipient, bps) in splits.iter() {
+                // Safe: `bps` is a fee basis-points value validated by
+                // `set_fee_split` to sum to exactly 10_000 (≤ i16::MAX),
+                // so the cast to i128 is always lossless.
                 let share = amount
                     .checked_mul(bps as i128)
                     .ok_or(Error::ArithmeticOverflow)?
@@ -322,6 +325,14 @@ impl TokenFactory {
             state.locked = false;
             return Err(Error::ArithmeticOverflow);
         }
+        // Guard: u128 values above i128::MAX would wrap silently to a negative
+        // number when cast to i128, allowing a negative mint.  Reject them
+        // with InvalidParameters before the cast so the invariant
+        // "minted supply ≥ 0" is always upheld.
+        if initial_supply > i128::MAX as u128 {
+            state.locked = false;
+            return Err(Error::InvalidParameters);
+        }
 
         // Transfer fee from creator to treasury using the dedicated fee_token
         Self::distribute_fee(env, state, &creator, fee_payment)?;
@@ -334,6 +345,7 @@ impl TokenFactory {
         TokenInitClient::new(env, &token_address).initialize(&creator, &decimals, &name, &symbol);
 
         if initial_supply > 0 {
+            // Safe: value is guaranteed ≤ i128::MAX by the guard above.
             token::StellarAssetClient::new(env, &token_address)
                 .mint(&creator, &(initial_supply as i128));
         }
@@ -487,6 +499,9 @@ impl TokenFactory {
             return Err(Error::Reentrancy);
         }
 
+        // Safe: Soroban `Vec::len()` returns a `u32` (at most u32::MAX ≈ 4 × 10⁹),
+        // which is well within i128's positive range.  The empty-batch check
+        // below immediately rejects the count == 0 case.
         let count = tokens.len() as i128;
         if count == 0 {
             return Err(Error::InvalidParameters);

--- a/contracts/token-factory/src/test.rs
+++ b/contracts/token-factory/src/test.rs
@@ -160,6 +160,90 @@ fn test_initialize_already_initialized() {
     assert_eq!(result, Err(Ok(Error::AlreadyInitialized)));
 }
 
+// ── supply boundary tests (issue #909) ───────────────────────────────────────
+
+/// u128 value just above i128::MAX wraps to a negative i128 without a guard.
+/// The fix must reject this with InvalidParameters before any mint occurs.
+#[test]
+fn test_create_token_supply_above_i128_max_rejected() {
+    let s = Setup::new();
+    let creator = Address::generate(&s.env);
+    s.fund(&creator, 1_000);
+    let overflow_supply: u128 = (i128::MAX as u128).saturating_add(1); // i128::MAX + 1
+    let result = s.client.try_create_token(
+        &creator,
+        &s.salt(0),
+        &String::from_str(&s.env, "MyToken"),
+        &String::from_str(&s.env, "MTK"),
+        &7,
+        &overflow_supply,
+        &1_000,
+    );
+    assert_eq!(result, Err(Ok(Error::InvalidParameters)));
+}
+
+/// u128::MAX is the largest possible overflow value — must also be rejected.
+#[test]
+fn test_create_token_supply_u128_max_rejected() {
+    let s = Setup::new();
+    let creator = Address::generate(&s.env);
+    s.fund(&creator, 1_000);
+    let result = s.client.try_create_token(
+        &creator,
+        &s.salt(0),
+        &String::from_str(&s.env, "MyToken"),
+        &String::from_str(&s.env, "MTK"),
+        &7,
+        &u128::MAX,
+        &1_000,
+    );
+    assert_eq!(result, Err(Ok(Error::InvalidParameters)));
+}
+
+/// i128::MAX is the largest value that fits exactly — must pass validation.
+/// The test will reach the deploy step and fail there because the hash is a
+/// dummy, but the error must NOT be InvalidParameters (supply is valid).
+#[test]
+fn test_create_token_supply_i128_max_passes_validation() {
+    let s = Setup::new();
+    let creator = Address::generate(&s.env);
+    s.fund(&creator, 1_000);
+    let max_valid: u128 = i128::MAX as u128;
+    let result = s.client.try_create_token(
+        &creator,
+        &s.salt(0),
+        &String::from_str(&s.env, "MyToken"),
+        &String::from_str(&s.env, "MTK"),
+        &7,
+        &max_valid,
+        &1_000,
+    );
+    // Supply is valid, so we must not get InvalidParameters.
+    // The call may fail for other reasons (dummy wasm hash), but not supply.
+    assert_ne!(result, Err(Ok(Error::InvalidParameters)));
+}
+
+/// Zero supply is explicitly allowed — token is created without minting.
+/// The call will fail at the deploy step (dummy hash) but not at supply
+/// validation, confirming zero is accepted.
+#[test]
+fn test_create_token_supply_zero_passes_validation() {
+    let s = Setup::new();
+    let creator = Address::generate(&s.env);
+    s.fund(&creator, 1_000);
+    let result = s.client.try_create_token(
+        &creator,
+        &s.salt(0),
+        &String::from_str(&s.env, "MyToken"),
+        &String::from_str(&s.env, "MTK"),
+        &7,
+        &0_u128,
+        &1_000,
+    );
+    // Must not be rejected for supply reasons.
+    assert_ne!(result, Err(Ok(Error::InvalidParameters)));
+}
+
 // ── create_token (error paths only — deploy requires real wasm) ───────────────
 
 #[test]


### PR DESCRIPTION
Closes #909