### PR TITLE
fix(frontend): unify transaction poll backoff into shared utility

### DIFF
--- a/frontend/src/components/TransactionStatus.test.tsx
+++ b/frontend/src/components/TransactionStatus.test.tsx
@@ -100,4 +100,30 @@ describe('TransactionStatus Component', () => {
 
     expect(onError).toHaveBeenCalledWith('Timeout')
   })
+
+  test('grows the poll interval instead of polling at a fixed cadence', async () => {
+    ;(stellarService.getTransaction as Mock).mockResolvedValue({ status: 'pending' })
+    const setTimeoutSpy = vi.spyOn(global, 'setTimeout')
+
+    render(<TransactionStatus txHash="test-hash" />)
+
+    // Let several poll/schedule cycles run.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20000)
+    })
+
+    // Delays passed to setTimeout for the poll chain (excludes the initial
+    // synchronous call and the fixed 60s overall timeout).
+    const scheduledDelays = setTimeoutSpy.mock.calls
+      .map((call) => call[1] as number)
+      .filter((delay): delay is number => typeof delay === 'number' && delay > 0 && delay !== 60000)
+
+    expect(scheduledDelays.length).toBeGreaterThan(1)
+    // Fixed-cadence polling (the regression this guards against) would mean
+    // every scheduled delay is identical; backoff means they are not.
+    const allEqual = scheduledDelays.every((d) => d === scheduledDelays[0])
+    expect(allEqual).toBe(false)
+
+    setTimeoutSpy.mockRestore()
+  })
 })

--- a/frontend/src/hooks/useTransaction.ts
+++ b/frontend/src/hooks/useTransaction.ts
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect } from 'react'
 import { stellarService } from '../services/stellar'
 import { captureTransactionError } from '../lib/monitoring/sentry'
 import { STELLAR_CONFIG } from '../config/stellar'
+import { nextBackoffDelay } from '../utils/pollWithBackoff'
 
 /*
  * ┌──────────────────────────────────────────────────────────────────┐
@@ -118,12 +119,16 @@ export interface UseTransactionPollingResult {
   sentryEventId?: string
 }
 
-const POLL_INTERVAL_MS = 250
+const INITIAL_DELAY_MS = 500
+const MAX_DELAY_MS = 4000
 const TIMEOUT_MS = 60000
 
 /**
  * Polls stellarService.getTransaction(txHash) until it resolves to a
- * terminal status (success/error) or TIMEOUT_MS elapses.
+ * terminal status (success/error) or TIMEOUT_MS elapses. Uses the same
+ * exponential-backoff-with-jitter schedule (via nextBackoffDelay) as
+ * stellar-impl.ts's pollTransaction, so there is one growth curve for
+ * "poll a transaction hash until terminal status" across the codebase.
  *
  * Thin, justified wrapper: TransactionStatus.tsx needs to poll an
  * *already-submitted* transaction by hash independently of the builder
@@ -144,6 +149,8 @@ export function useTransactionPolling(txHash: string): UseTransactionPollingResu
     setSentryEventId(undefined)
 
     let settled = false
+    let attempt = 0
+    let pollTimeoutId: ReturnType<typeof setTimeout> | undefined
 
     const poll = async () => {
       try {
@@ -152,11 +159,11 @@ export function useTransactionPolling(txHash: string): UseTransactionPollingResu
 
         if (result.status === 'success') {
           settled = true
-          clearInterval(intervalId)
+          clearTimeout(pollTimeoutId)
           setStatus('success')
         } else if (result.status === 'error' || result.status === 'failed') {
           settled = true
-          clearInterval(intervalId)
+          clearTimeout(pollTimeoutId)
           setStatus('failed')
           const errorMessage =
             typeof result.error === 'string' ? result.error : 'Transaction failed'
@@ -173,12 +180,19 @@ export function useTransactionPolling(txHash: string): UseTransactionPollingResu
             },
           )
           if (eventId) setSentryEventId(eventId)
+        } else {
+          // status === 'pending' — schedule the next attempt with backoff
+          const delay = nextBackoffDelay(attempt, {
+            initialDelayMs: INITIAL_DELAY_MS,
+            maxDelayMs: MAX_DELAY_MS,
+          })
+          attempt += 1
+          pollTimeoutId = setTimeout(poll, delay)
         }
-        // status === 'pending' — keep polling
       } catch (err) {
         if (settled) return
         settled = true
-        clearInterval(intervalId)
+        clearTimeout(pollTimeoutId)
         setStatus('failed')
         const errorMessage = err instanceof Error ? err.message : 'Transaction failed'
         setError(errorMessage)
@@ -197,13 +211,12 @@ export function useTransactionPolling(txHash: string): UseTransactionPollingResu
       }
     }
 
-    const intervalId = setInterval(poll, POLL_INTERVAL_MS)
     void poll()
 
     const timeoutId = setTimeout(() => {
       if (settled) return
       settled = true
-      clearInterval(intervalId)
+      clearTimeout(pollTimeoutId)
       setStatus('failed')
       const errorMessage = 'Timeout'
       setError(errorMessage)
@@ -218,7 +231,7 @@ export function useTransactionPolling(txHash: string): UseTransactionPollingResu
 
     return () => {
       settled = true
-      clearInterval(intervalId)
+      clearTimeout(pollTimeoutId)
       clearTimeout(timeoutId)
     }
   }, [txHash])

--- a/frontend/src/services/stellar-impl.ts
+++ b/frontend/src/services/stellar-impl.ts
@@ -28,6 +28,7 @@ import {
 import type { Network } from '../config/stellar'
 import { withRetry, HttpError } from '../utils/retry'
 import { parseContractError } from '../utils/contractErrors'
+import { nextBackoffDelay } from '../utils/pollWithBackoff'
 
 export type { FactoryState } from '../types'
 
@@ -122,11 +123,8 @@ async function pollTransaction(
     if (result.status === rpc.Api.GetTransactionStatus.FAILED) {
       throw parseContractError(new Error(`Transaction failed: ${hash}`))
     }
-    // Exponential backoff capped at maxDelayMs, with ±10% jitter to avoid
-    // thundering-herd bursts when many transactions confirm around the same time.
-    const base = Math.min(initialDelayMs * Math.pow(2, i), maxDelayMs)
-    const jitter = Math.floor(Math.random() * 0.2 * base) - Math.floor(0.1 * base)
-    await new Promise((r) => setTimeout(r, base + jitter))
+    const delay = nextBackoffDelay(i, { initialDelayMs, maxDelayMs })
+    await new Promise((r) => setTimeout(r, delay))
   }
   throw new Error(`Transaction ${hash} timed out after ${maxAttempts} attempts`)
 } // ── Fee Bump Transactions ─────────────────────────────────────────────────────

--- a/frontend/src/utils/pollWithBackoff.test.ts
+++ b/frontend/src/utils/pollWithBackoff.test.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect, vi, afterEach } from 'vitest'
+import { nextBackoffDelay } from './pollWithBackoff'
+
+describe('nextBackoffDelay', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('grows with each attempt instead of using a fixed cadence', () => {
+    // Pin jitter to 0 so the growth trend isn't masked by randomness.
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+
+    const options = { initialDelayMs: 500, maxDelayMs: 4000 }
+    const delays = [0, 1, 2, 3].map((attempt) => nextBackoffDelay(attempt, options))
+
+    for (let i = 1; i < delays.length; i++) {
+      expect(delays[i]).toBeGreaterThan(delays[i - 1]!)
+    }
+  })
+
+  test('caps the delay at maxDelayMs once exponential growth exceeds it', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+
+    const options = { initialDelayMs: 500, maxDelayMs: 4000 }
+    const delay = nextBackoffDelay(10, options)
+
+    expect(delay).toBeLessThanOrEqual(4000)
+  })
+
+  test('applies jitter within +/-10% of the base delay by default', () => {
+    const options = { initialDelayMs: 1000, maxDelayMs: 4000 }
+    for (let i = 0; i < 50; i++) {
+      const delay = nextBackoffDelay(0, options)
+      expect(delay).toBeGreaterThanOrEqual(900)
+      expect(delay).toBeLessThanOrEqual(1100)
+    }
+  })
+})

--- a/frontend/src/utils/pollWithBackoff.ts
+++ b/frontend/src/utils/pollWithBackoff.ts
@@ -1,0 +1,23 @@
+// Shared exponential backoff math for polling loops that wait on transaction
+// confirmation. Centralised so every poller (RPC-based in stellar-impl.ts,
+// Horizon-based in useTransactionPolling.ts) grows its interval the same way
+// instead of drifting into a fixed-cadence implementation.
+
+export interface BackoffOptions {
+  initialDelayMs: number
+  maxDelayMs: number
+  /** Jitter as a fraction of the base delay, applied symmetrically. Default ±10%. */
+  jitterRatio?: number
+}
+
+/**
+ * Computes the delay (ms) before the next poll attempt: exponential backoff
+ * capped at maxDelayMs, with jitter to avoid thundering-herd bursts when many
+ * transactions confirm around the same time.
+ */
+export function nextBackoffDelay(attempt: number, options: BackoffOptions): number {
+  const { initialDelayMs, maxDelayMs, jitterRatio = 0.2 } = options
+  const base = Math.min(initialDelayMs * Math.pow(2, attempt), maxDelayMs)
+  const jitter = Math.floor(Math.random() * jitterRatio * base) - Math.floor((jitterRatio / 2) * base)
+  return base + jitter
+}


### PR DESCRIPTION
## Summary

`useTransactionPolling.ts` (consumed by `TransactionStatus.tsx`) had its own independent polling loop: a hardcoded `POLL_INTERVAL_MS = 250` with a plain `setInterval`, no backoff, no jitter. This is a separate code path from `pollTransaction` in `stellar-impl.ts` (consumed by `useTransaction.ts` → `MintForm.tsx`, `AdminPanel.tsx`, `BurnForm.tsx`), which already has exponential backoff with ±10% jitter, restored in a recent fix for audit issue #852.

Because the fix only touched `pollTransaction`, the second implementation kept its fixed 250ms cadence — up to 240 RPC calls to `stellarService.getTransaction` per pending transaction over the 60s timeout window, reintroducing the exact thundering-herd pattern the earlier fix eliminated.

## Changes

- Added `frontend/src/utils/pollWithBackoff.ts`: a single `nextBackoffDelay(attempt, { initialDelayMs, maxDelayMs, jitterRatio? })` utility implementing the exponential-backoff-with-jitter math that previously lived only inline in `pollTransaction`.
- `stellar-impl.ts`'s `pollTransaction` now calls `nextBackoffDelay` instead of inlining the calculation.
- `useTransactionPolling.ts` now uses `setTimeout`-chained polling via `nextBackoffDelay` (500ms initial, 4000ms cap) instead of a fixed-interval `setInterval(poll, 250)`.
- Both hooks remain separate — they serve different concerns (`useTransaction.ts` orchestrates simulate/sign/submit/poll for write transactions with a reconciliation policy; `useTransactionPolling.ts` just polls an existing tx hash for status) — but now share one implementation of the backoff curve instead of two that can independently drift.
- Added tests:
  - `pollWithBackoff.test.ts`: asserts delay grows across attempts, caps at `maxDelayMs`, and stays within the configured jitter band.
  - `TransactionStatus.test.tsx`: asserts the `setTimeout` delays scheduled during a real poll sequence are not a fixed cadence (regression guard for this exact bug class).
- Grepped `frontend/src` for other ad hoc `setInterval` polling of transaction/RPC state. Found `useTransactionHistory.ts`, `useXlmPrice.ts`, `useNetworkMismatch.ts` — these are periodic background-refresh loops (refetch a list / price / network check on a fixed cadence), not "poll a single pending transaction until terminal status" loops, so they don't have the same RPC-storm characteristics and are out of scope for this fix.

## Test plan

- [x] `npx vitest run` — all previously-passing tests still pass; the 5 pre-existing `CreateToken.test.tsx` timeout failures are present unchanged on `main` before this change (unrelated to this PR).
- [x] New tests in `pollWithBackoff.test.ts` and `TransactionStatus.test.tsx` pass.
- [x] `TransactionStatus.tsx` pending/success/failed rendering behavior verified unchanged via existing component tests.

closes #924 