### PR TITLE
fix(frontend): close network-mismatch signing window with a fresh pre-sign check

### DIFF
--- a/frontend/src/hooks/useNetworkMismatch.ts
+++ b/frontend/src/hooks/useNetworkMismatch.ts
@@ -12,7 +12,19 @@ export interface NetworkMismatchState {
   refresh: () => void
 }
 
-const POLL_INTERVAL_MS = 5_000
+// @stellar/freighter-api has no event/subscription mechanism for network
+// changes — the only thing close, WatchWalletChanges, is itself a poller
+// under the hood (fetchInfo on a setTimeout loop, default 3s). So this UI
+// state is inherently poll-based and can be stale by up to one interval.
+//
+// 2s (down from 5s) is a stopgap that shrinks the *visible* staleness
+// window for the banner, traded against 2.5x more requestNetworkDetails()
+// calls to the extension. It is NOT what prevents a stale-network
+// transaction from being signed — that gate is a synchronous, un-cached
+// getNetworkDetails() check in WalletService.signTransaction (wallet.ts),
+// which runs fresh immediately before every sign call regardless of this
+// poll's cadence. See #927.
+const POLL_INTERVAL_MS = 2_000
 
 export function useNetworkMismatch(network: Network): NetworkMismatchState {
   const [freighterNetwork, setFreighterNetwork] = useState<string | null>(null)

--- a/frontend/src/services/wallet.test.ts
+++ b/frontend/src/services/wallet.test.ts
@@ -1,0 +1,83 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { WalletService } from './wallet'
+import {
+  isConnected,
+  getAddress,
+  getNetworkDetails,
+  signTransaction as freighterSignTransaction,
+} from '@stellar/freighter-api'
+
+vi.mock('@stellar/freighter-api', () => ({
+  isConnected: vi.fn(),
+  getAddress: vi.fn(),
+  getNetworkDetails: vi.fn(),
+  signTransaction: vi.fn(),
+}))
+
+describe('WalletService.signTransaction', () => {
+  let wallet: WalletService
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    wallet = new WalletService()
+    vi.mocked(isConnected).mockResolvedValue({ isConnected: true })
+    vi.mocked(getAddress).mockResolvedValue({ address: 'GABC123' })
+    await wallet.connect()
+  })
+
+  test('signs when Freighter is already on the expected network', async () => {
+    vi.mocked(getNetworkDetails).mockResolvedValue({
+      network: 'TESTNET',
+      networkUrl: 'https://horizon-testnet.stellar.org',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+    })
+    vi.mocked(freighterSignTransaction).mockResolvedValue({
+      signedTxXdr: 'signed-xdr',
+      signerAddress: 'GABC123',
+    })
+
+    const result = await wallet.signTransaction('unsigned-xdr', 'testnet')
+
+    expect(result).toBe('signed-xdr')
+    expect(freighterSignTransaction).toHaveBeenCalled()
+  })
+
+  // Regression test for #927: a network switch that happens *between* the
+  // background poll ticks in useNetworkMismatch (every 5s) but *before* a
+  // submit action must still block signing. This asserts the block comes
+  // from a fresh getNetworkDetails() check at sign time, not from any
+  // cached/stale mismatch state.
+  test('blocks signing when Freighter switched networks since the last poll tick', async () => {
+    vi.mocked(getNetworkDetails).mockResolvedValue({
+      network: 'PUBLIC',
+      networkUrl: 'https://horizon.stellar.org',
+      networkPassphrase: 'Public Global Stellar Network ; September 2015',
+    })
+    vi.mocked(freighterSignTransaction).mockResolvedValue({
+      signedTxXdr: 'signed-xdr',
+      signerAddress: 'GABC123',
+    })
+
+    await expect(wallet.signTransaction('unsigned-xdr', 'testnet')).rejects.toThrow(
+      'Network mismatch: Please switch Freighter to testnet',
+    )
+    expect(freighterSignTransaction).not.toHaveBeenCalled()
+  })
+
+  test('does not block when getNetworkDetails errors (falls through to Freighter, which surfaces its own error)', async () => {
+    vi.mocked(getNetworkDetails).mockResolvedValue({
+      network: '',
+      networkUrl: '',
+      networkPassphrase: '',
+      error: 'not available',
+    })
+    vi.mocked(freighterSignTransaction).mockResolvedValue({
+      signedTxXdr: 'signed-xdr',
+      signerAddress: 'GABC123',
+    })
+
+    const result = await wallet.signTransaction('unsigned-xdr', 'testnet')
+
+    expect(result).toBe('signed-xdr')
+  })
+})

--- a/frontend/src/services/wallet.ts
+++ b/frontend/src/services/wallet.ts
@@ -1,6 +1,7 @@
 import {
   isConnected,
   getAddress,
+  getNetworkDetails,
   signTransaction as freighterSignTransaction,
 } from '@stellar/freighter-api'
 import { NETWORK_CONFIGS, type Network } from '../config/stellar'
@@ -96,9 +97,19 @@ export class WalletService {
       throw new Error('Wallet not connected. Please connect first.')
     }
 
-    try {
-      const networkPassphrase = NETWORK_CONFIGS[network].networkPassphrase
+    const networkPassphrase = NETWORK_CONFIGS[network].networkPassphrase
 
+    // Freighter's active network isn't push-notified to the page — useNetworkMismatch
+    // only polls every few seconds, so its cached state can be stale by the time the
+    // user hits submit. Re-check fresh, right before dispatching the sign request, so
+    // the actual gate that matters (can *this* transaction be signed) never relies on
+    // a value that's up to one poll interval old.
+    const freshDetails = await getNetworkDetails()
+    if (!freshDetails.error && freshDetails.networkPassphrase !== networkPassphrase) {
+      throw new Error(`Network mismatch: Please switch Freighter to ${network}`)
+    }
+
+    try {
       const signedResult = await freighterSignTransaction(xdr, {
         networkPassphrase,
         address: this.connectedAddress,


### PR DESCRIPTION
Closes #927

## Summary

`useNetworkMismatch` polls Freighter's `getNetworkDetails()` every `POLL_INTERVAL_MS` (previously 5s) to drive the write-blocking mismatch banner. Because it's a poll and not an event subscription, there's up to one poll interval after a user switches Freighter's active network where `isMismatch` still reflects the *previous* state. If a user has a form open, switches Freighter's network for an unrelated reason, and submits within that window, the app could let a transaction reach the signer before the UI gate catches up — undermining the guarantee the mismatch banner (`f6e88f3`, `901021f`) was specifically built to provide.

## Investigation: is there a push mechanism?

Checked `@stellar/freighter-api` (v6.0.1) for an event/subscription API. The closest thing is `WatchWalletChanges`, but its implementation (`node_modules/@stellar/freighter-api/src/watchWalletChanges.ts`) is itself a poller under the hood — `fetchInfo` re-runs on a `setTimeout` loop with a default 3s timeout. There is no true push notification for network changes from the extension to the page. So the staleness window can't be closed by swapping polling primitives — it has to be closed at the point that actually matters: the moment a transaction is about to be signed.

## Fix

- **`wallet.ts`**: `WalletService.signTransaction` now calls `getNetworkDetails()` fresh, immediately before every sign dispatch, and throws `Network mismatch: Please switch Freighter to {network}` if the live passphrase doesn't match the expected one — independent of `useNetworkMismatch`'s cached/polled state. This is the single choke point every write path (mint, burn, admin, metadata, fee bump) already funnels through, via `simulateAndSubmit` / `submitFeeBumpTransaction` in `stellar-impl.ts`. No transaction can be signed while a genuine mismatch exists, no matter how stale the banner is.
- **`useNetworkMismatch.ts`**: reduced `POLL_INTERVAL_MS` from 5s to 2s as a stopgap that shrinks the banner's *visible* staleness window, with a comment documenting the tradeoff (2.5x more `getNetworkDetails()` calls) and making clear this is not what prevents signing — that's the check above, which no longer depends on poll cadence at all.

## Tests

- `wallet.test.ts` (new): exercises `WalletService.signTransaction` directly against a mocked `@stellar/freighter-api`.
  - Signs normally when Freighter is already on the expected network.
  - **Regression test for #927**: simulates a network switch that happened *between* poll ticks (mocks `getNetworkDetails` to return a mismatched passphrase, independent of any polling hook) and asserts `signTransaction` rejects *before* Freighter's own `signTransaction` is ever called — proving the block doesn't rely on waiting for the poll's natural cadence.
  - Falls through to Freighter's own signing (and its error surface) when `getNetworkDetails()` itself errors, so an unrelated Freighter hiccup doesn't block otherwise-valid signing.

## Test plan

- [x] `npx vitest run` — all 47 test files / 464 tests pass.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on changed files — clean.