### PR TITLE
fix(frontend): paginate factory event fetch instead of silently capping the token explorer

### DIFF
--- a/frontend/src/components/TokenExplorer.tsx
+++ b/frontend/src/components/TokenExplorer.tsx
@@ -12,6 +12,7 @@ import { Card, Button, Input, Spinner } from './UI'
 import { CopyButton } from './CopyButton'
 import { PaginationControls } from './UI/PaginationControls'
 import { useDebounce } from '../hooks/useDebounce'
+import { fetchAllContractEvents } from '../utils/fetchAllContractEvents'
 
 interface TokenWithMetadata extends TokenInfo {
   address: string
@@ -80,10 +81,12 @@ export const TokenExplorer: React.FC = () => {
     const startIndex = (currentPage - 1) * tokensPerPage
     const endIndex = Math.min(startIndex + tokensPerPage, totalTokens)
 
-    // Get all token_created events to map indices to addresses
-    stellarService
-      .getContractEvents(STELLAR_CONFIG.factoryContractId || '', 1000)
-      .then(({ events }) => {
+    // Get all token_created events to map indices to addresses. Paginated
+    // via fetchAllContractEvents rather than a single capped
+    // getContractEvents() call — see that helper for why a fixed limit
+    // would silently drop the newest tokens once history exceeds one page.
+    fetchAllContractEvents(stellarService, STELLAR_CONFIG.factoryContractId || '')
+      .then((events) => {
         const tokenCreatedEvents = events
           .filter((e) => e.type === 'created')
           .sort((a, b) => a.ledger - b.ledger) // Sort by creation order
@@ -137,9 +140,9 @@ export const TokenExplorer: React.FC = () => {
         }
 
         // Get token address from events
-        const { events } = await stellarService.getContractEvents(
+        const events = await fetchAllContractEvents(
+          stellarService,
           STELLAR_CONFIG.factoryContractId || '',
-          1000,
         )
         const tokenCreatedEvents = events
           .filter((e) => e.type === 'created')

--- a/frontend/src/hooks/useTokens.test.tsx
+++ b/frontend/src/hooks/useTokens.test.tsx
@@ -110,6 +110,44 @@ describe('useTokens', () => {
     expect(stellarService.getTokenInfoByAddress).toHaveBeenCalledTimes(2)
   })
 
+  // Regression test: a single fixed-size getContractEvents() call silently
+  // drops any `created` events beyond the page limit. This asserts the "all
+  // tokens" path pages through the full event history via the returned
+  // cursor instead, so every token is still found once the factory has
+  // emitted more than one page's worth of events.
+  it('pages through the full event history when there are more than one page of created events', async () => {
+    const makeEvent = (i: number) => ({
+      id: String(i),
+      type: 'created' as const,
+      ledger: i,
+      timestamp: i,
+      txHash: `tx${i}`,
+      data: { tokenAddress: `CADDR${i}` },
+    })
+    const page1 = Array.from({ length: 100 }, (_, i) => makeEvent(i))
+    const page2 = Array.from({ length: 20 }, (_, i) => makeEvent(100 + i))
+
+    vi.mocked(stellarService.getContractEvents)
+      .mockResolvedValueOnce({ events: page1, cursor: 'cursor-1' })
+      .mockResolvedValueOnce({ events: page2, cursor: 'cursor-2' })
+    vi.mocked(stellarService.getTokenInfoByAddress).mockImplementation((addr: string) =>
+      Promise.resolve({ ...TOKEN_A, name: addr }),
+    )
+
+    const { result } = renderHook(() => useTokens())
+
+    await waitFor(() => expect(result.current.totalCount).toBe(120))
+    expect(stellarService.getContractEvents).toHaveBeenCalledTimes(2)
+    expect(stellarService.getContractEvents).toHaveBeenNthCalledWith(1, 'CFACTORY123', 100, undefined)
+    expect(stellarService.getContractEvents).toHaveBeenNthCalledWith(
+      2,
+      'CFACTORY123',
+      100,
+      'cursor-1',
+    )
+    expect(stellarService.getTokenInfoByAddress).toHaveBeenCalledTimes(120)
+  })
+
   it('populates error on RPC failure', async () => {
     vi.mocked(stellarService.getTokensByCreator).mockRejectedValue(new Error('RPC down'))
 

--- a/frontend/src/hooks/useTokens.ts
+++ b/frontend/src/hooks/useTokens.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { stellarService } from '../services/stellar'
 import { STELLAR_CONFIG } from '../config/stellar'
+import { fetchAllContractEvents } from '../utils/fetchAllContractEvents'
 import type { TokenInfo } from '../types'
 
 // ── Module-level cache keyed by creator address ('' = all tokens) ─────────────
@@ -172,12 +173,18 @@ export function useTokens(creator?: string): UseTokensResult {
 }
 
 // ── Fallback "all tokens" fetcher (kept from the original hook) ──────────────
+//
+// There's no `get_all_tokens` contract view (only the per-creator, paginated
+// `get_tokens_by_creator`), so the global explorer has to derive the token
+// list from factory `created` events instead. See fetchAllContractEvents for
+// why a single fixed-size getContractEvents() call is not safe here — it
+// silently drops the newest tokens once event history exceeds one page.
 
 async function fetchAllTokens(): Promise<TokenInfo[]> {
   const contractId = STELLAR_CONFIG.factoryContractId
   if (!contractId) throw new Error('VITE_FACTORY_CONTRACT_ID is not configured')
 
-  const { events } = await stellarService.getContractEvents(contractId, 100)
+  const events = await fetchAllContractEvents(stellarService, contractId)
   const addresses = [
     ...new Set(
       events

--- a/frontend/src/utils/fetchAllContractEvents.test.ts
+++ b/frontend/src/utils/fetchAllContractEvents.test.ts
@@ -1,0 +1,74 @@
+import { describe, test, expect, vi } from 'vitest'
+import { fetchAllContractEvents, type ContractEventSource } from './fetchAllContractEvents'
+import type { ContractEvent } from '../types'
+
+function makeEvent(ledger: number): ContractEvent {
+  return {
+    id: String(ledger),
+    type: 'created',
+    ledger,
+    timestamp: ledger,
+    txHash: `tx${ledger}`,
+    data: { tokenAddress: `CADDR${ledger}` },
+  }
+}
+
+describe('fetchAllContractEvents', () => {
+  test('returns all events from a single short page without pagination', async () => {
+    const events = [makeEvent(1), makeEvent(2)]
+    const source: ContractEventSource = {
+      getContractEvents: vi.fn().mockResolvedValue({ events, cursor: 'c1' }),
+    }
+
+    const result = await fetchAllContractEvents(source, 'CFACTORY', 100)
+
+    expect(result).toEqual(events)
+    expect(source.getContractEvents).toHaveBeenCalledTimes(1)
+  })
+
+  // This is the exact scenario that caused the "all tokens" explorer to
+  // silently drop newly-created tokens: a factory with more created events
+  // than fit in one page. A single fixed-size call would only see the first
+  // page; pagination via the cursor must walk forward to collect the rest.
+  test('pages through the cursor until a short page signals end-of-data', async () => {
+    const page1 = Array.from({ length: 100 }, (_, i) => makeEvent(i))
+    const page2 = Array.from({ length: 100 }, (_, i) => makeEvent(100 + i))
+    const page3 = Array.from({ length: 30 }, (_, i) => makeEvent(200 + i))
+
+    const getContractEvents = vi
+      .fn()
+      .mockResolvedValueOnce({ events: page1, cursor: 'c1' })
+      .mockResolvedValueOnce({ events: page2, cursor: 'c2' })
+      .mockResolvedValueOnce({ events: page3, cursor: 'c3' })
+    const source: ContractEventSource = { getContractEvents }
+
+    const result = await fetchAllContractEvents(source, 'CFACTORY', 100)
+
+    expect(result).toHaveLength(230)
+    expect(getContractEvents).toHaveBeenCalledTimes(3)
+    expect(getContractEvents).toHaveBeenNthCalledWith(1, 'CFACTORY', 100, undefined)
+    expect(getContractEvents).toHaveBeenNthCalledWith(2, 'CFACTORY', 100, 'c1')
+    expect(getContractEvents).toHaveBeenNthCalledWith(3, 'CFACTORY', 100, 'c2')
+  })
+
+  test('stops when the cursor comes back null even on a full page', async () => {
+    const page = Array.from({ length: 100 }, (_, i) => makeEvent(i))
+    const getContractEvents = vi.fn().mockResolvedValueOnce({ events: page, cursor: null })
+    const source: ContractEventSource = { getContractEvents }
+
+    const result = await fetchAllContractEvents(source, 'CFACTORY', 100)
+
+    expect(result).toHaveLength(100)
+    expect(getContractEvents).toHaveBeenCalledTimes(1)
+  })
+
+  test('returns an empty list when there are no events', async () => {
+    const source: ContractEventSource = {
+      getContractEvents: vi.fn().mockResolvedValue({ events: [], cursor: null }),
+    }
+
+    const result = await fetchAllContractEvents(source, 'CFACTORY', 100)
+
+    expect(result).toEqual([])
+  })
+})

--- a/frontend/src/utils/fetchAllContractEvents.ts
+++ b/frontend/src/utils/fetchAllContractEvents.ts
@@ -1,0 +1,54 @@
+import type { ContractEvent, GetEventsResult } from '../types'
+
+export interface ContractEventSource {
+  getContractEvents(contractId: string, limit?: number, cursor?: string): Promise<GetEventsResult>
+}
+
+const DEFAULT_PAGE_SIZE = 100
+// Defensive only — getContractEvents guarantees a short page once the
+// cursor reaches the end of history, so this bounds runaway loops rather
+// than reflecting a real expected page count.
+const MAX_PAGES = 10_000
+
+/**
+ * Soroban's `getEvents` RPC returns events in ascending ledger order (oldest
+ * first) starting from the earliest retained ledger when no cursor is given.
+ * A single capped `getContractEvents(contractId, limit)` call therefore
+ * silently truncates the *newest* events once the contract's event history
+ * exceeds one page — e.g. a token created after the page limit was already
+ * reached would never appear in an "all tokens" view built on one fixed-size
+ * call, while older tokens keep showing up. This is the opposite of the
+ * usual "stale/missing old data" assumption, so it's easy to miss in review.
+ *
+ * Page through with the cursor `getContractEvents` already returns (the same
+ * end-of-data signal `fetchAllTokensByCreator` uses for the contract's
+ * paginated view call: a page shorter than requested means no more data) so
+ * callers see the complete event history instead of a silently truncated
+ * slice.
+ *
+ * This re-walks the full event history on every call — acceptable at
+ * today's scale, but the right long-term fix for an all-tokens view is an
+ * off-chain indexer (#35) rather than the frontend re-deriving state from
+ * raw contract events on each load.
+ */
+export async function fetchAllContractEvents(
+  source: ContractEventSource,
+  contractId: string,
+  pageSize: number = DEFAULT_PAGE_SIZE,
+): Promise<ContractEvent[]> {
+  const collected: ContractEvent[] = []
+  let cursor: string | undefined
+
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const { events, cursor: nextCursor } = await source.getContractEvents(
+      contractId,
+      pageSize,
+      cursor,
+    )
+    collected.push(...events)
+    if (events.length < pageSize || !nextCursor) break
+    cursor = nextCursor
+  }
+
+  return collected
+}


### PR DESCRIPTION
Closes #930

## Summary

`fetchAllTokens()` in `useTokens.ts` (the no-creator path intended for the global token explorer) called `stellarService.getContractEvents(contractId, 100)` once and filtered for `created` events — a hardcoded, undocumented cap on the entire explorer's dataset, with no pagination and no indication to the user that results could be partial.

## Investigation: what actually gets dropped?

Traced `getContractEvents`'s implementation in `stellar-impl.ts`: it calls Soroban's `getEvents` RPC, which returns events in **ascending ledger order (oldest first)** starting from the earliest retained ledger when no cursor is supplied. A single capped call therefore drops the **newest** events once the factory's event history exceeds one page — the opposite of the usual "old data goes missing" assumption. Concretely: once the factory has emitted more than 100 `created` events, **brand-new tokens silently stop appearing in "All Tokens"** while old ones keep showing up, with no pagination control and no way to reach the missing tokens through this code path. This is documented at the call site now (`fetchAllContractEvents.ts`).

`getContractEvents` already supports cursor-based pagination (it's used this way by `getTokenEvents`), so full pagination to fetch the complete history was feasible — no need to fall back to an honest-but-partial UI indicator.

## Fix

- Added `frontend/src/utils/fetchAllContractEvents.ts`: pages through `getContractEvents`'s cursor until a short page signals end-of-data, mirroring the exact end-of-data pattern `fetchAllTokensByCreator` already uses for the contract's paginated `get_tokens_by_creator` view call.
- `useTokens.ts`'s `fetchAllTokens()` now uses this helper instead of one fixed-size call.
- **Discovered while investigating**: `TokenExplorer.tsx` — the component actually rendered as the Token Explorer page — has its own, entirely independent duplicate of this same bug class (`getContractEvents(contractId, 1000)`, same silent-cap failure mode, just a higher ceiling, used in both its "browse all tokens" effect and its "search by index" handler). Since the acceptance criteria is about what the explorer view actually shows, not just this one hook, I switched both of `TokenExplorer.tsx`'s call sites to the same `fetchAllContractEvents` helper — one implementation of "fetch the complete factory event history" instead of two that could independently drift, and the page users actually see now shows the complete set.

## Scaling note (per the issue)

This re-walks the full factory event history on every load, which won't scale indefinitely as the platform grows. Per the issue's own framing, the durable long-term fix is an off-chain indexer (#35) rather than the frontend re-deriving state from raw contract events on each request — noted as a comment in `fetchAllContractEvents.ts` so this doesn't get relitigated from scratch later.

## Tests

- `fetchAllContractEvents.test.ts` (new): single short page (no pagination needed), multi-page pagination across 3 pages (230 events), a full-page-with-null-cursor edge case, and the empty-history case.
- `useTokens.test.tsx`: added a regression test with 120 mocked `created` events split across two pages (100 + 20), asserting all 120 resolve to `TokenInfo` — not just the first 100 — and that the second `getContractEvents` call is made with the cursor returned by the first.

## Test plan

- [x] `npx vitest run` — all 47 test files / 466 tests pass.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on changed files — clean.