### PR TITLE
fix(analytics): add opt-out tests, CI bypass check, and compliance ADR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,9 @@ jobs:
       - name: i18n Parity Check
         run: node scripts/check-i18n-parity.mjs
 
+      - name: Analytics Bypass Check
+        run: npm run check:analytics-bypass
+
       - name: Typecheck
         run: npm run typecheck
 

--- a/docs/adr/ADR-005-analytics-privacy-consent.md
+++ b/docs/adr/ADR-005-analytics-privacy-consent.md
@@ -1,0 +1,102 @@
+# ADR-005: Analytics Privacy and Consent (Plausible + Opt-Out)
+
+**Status:** Accepted  
+**Date:** 2026-07-17  
+**Relates to:** [Issue #948](https://github.com/Favourorg/Stellar-forge/issues/948)
+
+---
+
+## Context
+
+StellarForge includes a lightweight analytics integration using
+[Plausible](https://plausible.io) — a privacy-first, cookieless analytics
+provider.  Plausible collects no PII, sets no cookies, and is GDPR-compliant
+by design.
+
+Nonetheless, the app includes an explicit opt-out mechanism
+(`AnalyticsOptOut.tsx`) because:
+
+1. **GDPR (EU)** — Art. 6(1)(f) legitimate interest only applies where the
+   user's interests do not override the controller's.  Providing an easy
+   opt-out is a common mitigation and aligns with the spirit of data
+   minimisation.
+2. **CCPA (California)** — Users have the right to opt out of the "sale" or
+   "sharing" of personal information.  Even though Plausible collects
+   aggregate data that is not personal information, offering an opt-out
+   satisfies the broadest reasonable reading of the CCPA requirement.
+3. **User trust** — Explicit opt-out UI signals transparency and builds trust
+   with the developer community that uses this dApp.
+
+---
+
+## Decision
+
+### Provider: Plausible
+
+Plausible was chosen for analytics because:
+
+- No cookies, no cross-site tracking, no fingerprinting.
+- Aggregated statistics only — no individual user profiles.
+- Self-hostable; the `VITE_PLAUSIBLE_DOMAIN` env var gates the entire
+  analytics subsystem.  If the var is unset (e.g., in development, tests,
+  or a self-hosted deployment that opts out entirely), **zero** analytics
+  calls are made.
+
+### Opt-out mechanism
+
+The opt-out preference is stored in `localStorage` under the key
+`analytics_opt_out`.  The analytics service (`src/services/analytics.ts`)
+reads this key on **every** tracking call via `isOptedOut()`:
+
+```
+isEnabled() → !isOptedOut() && VITE_PLAUSIBLE_DOMAIN configured
+```
+
+This means opt-out takes effect **immediately in the current session** —
+no page reload is required.  A user who toggles the opt-out checkbox
+mid-session will have all subsequent analytics calls suppressed within
+the same page load.
+
+### What is tracked
+
+Only two categories of events are tracked:
+
+| Event | Call site | Contains PII? |
+|-------|-----------|---------------|
+| `pageview` | `App.tsx` `useEffect` on route change | No — path only (e.g. `/create`) |
+| Custom events (`token_created`, `mint_tokens`, etc.) | `trackEvent()` callers | No — event name + optional non-PII props |
+
+**Wallet addresses are never included in analytics events.** This is
+enforced by code review and by the `trackEvent` type signature which
+accepts only `string | number | boolean` props (no complex objects that
+could accidentally include addresses).
+
+---
+
+## Regulatory compliance analysis
+
+| Requirement | Satisfied? | How |
+|-------------|-----------|-----|
+| No PII collected | ✅ | Plausible design + prop type constraint |
+| No cookies | ✅ | Plausible is cookieless by default |
+| Opt-out available | ✅ | `AnalyticsOptOut` component in app footer |
+| Opt-out persisted | ✅ | `localStorage` (survives reload) |
+| Opt-out takes effect immediately | ✅ | `isOptedOut()` read on every call |
+| Opt-out backed by tests | ✅ | `analytics.test.ts`, `useAnalytics.test.ts`, `AnalyticsOptOut.test.tsx` |
+| New bypass call sites detected | ✅ | `scripts/check-analytics-bypass.mjs` (CI-enforced) |
+| Analytics disabled when unconfigured | ✅ | `VITE_PLAUSIBLE_DOMAIN` guard |
+
+---
+
+## Consequences
+
+- Any new tracking call site **must** go through `trackEvent()` or
+  `trackPageView()` from `src/services/analytics.ts`.  Direct use of
+  `window.plausible` bypasses the consent check and is blocked by the
+  CI lint rule (`npm run check:analytics-bypass`).
+- To add a new allowed caller that imports from `services/analytics`
+  directly (as `App.tsx` does for page-view tracking), add it to
+  `ALLOWED_PATHS` in `scripts/check-analytics-bypass.mjs` with a comment
+  justifying the exception.
+- Removing or weakening the opt-out check in `isEnabled()` / `isOptedOut()`
+  requires updating this ADR and the test suite.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "format": "prettier --write \"src/**/*.{ts,tsx}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx}\"",
     "preview": "vite preview",
+    "check:analytics-bypass": "node scripts/check-analytics-bypass.mjs",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",

--- a/frontend/scripts/check-analytics-bypass.mjs
+++ b/frontend/scripts/check-analytics-bypass.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+
+/**
+ * Analytics Bypass Check — issue #948
+ *
+ * Scans the source tree for files that import directly from
+ * `services/analytics` and use the raw trackEvent / trackPageView /
+ * window.plausible APIs outside of:
+ *   - the analytics service itself  (src/services/analytics.ts)
+ *   - test files                    (*.test.ts / *.test.tsx)
+ *   - the useAnalytics hook         (src/hooks/useAnalytics.ts)
+ *
+ * WHY THIS MATTERS (GDPR / CCPA consent):
+ *   The opt-out consent check lives in `analytics.ts` (isOptedOut()).
+ *   Every call site that reaches window.plausible *through* trackEvent /
+ *   trackPageView inherits the consent check automatically.  A call site that
+ *   bypasses these functions and invokes window.plausible directly would
+ *   silently ignore the user's recorded opt-out preference.
+ *
+ *   This script ensures no such bypass accidentally enters the codebase.
+ *
+ * Usage:
+ *   node scripts/check-analytics-bypass.mjs
+ *
+ * Exit codes:
+ *   0 – no violations found
+ *   1 – one or more violations found (CI-blocking)
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, resolve, extname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { dirname } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const SRC_DIR = resolve(__dirname, '..', 'src')
+
+// ----------------------------------------------------------------------------
+// Allowed files — these are permitted to reference analytics.ts directly
+// ----------------------------------------------------------------------------
+const ALLOWED_PATHS = [
+  // The service module itself
+  'services/analytics.ts',
+  // The hook that wraps the service (only uses isOptedOut / setOptOut, not tracking fns)
+  'hooks/useAnalytics.ts',
+  // App.tsx calls trackPageView() inside a useEffect to record SPA route changes.
+  // This is safe because trackPageView() internally calls isEnabled() which calls
+  // isOptedOut() on every invocation — the consent check is enforced inside the
+  // service, not in the caller.  Prefer this explicit allowance over silently
+  // passing; review if new tracking call sites are added to App.tsx.
+  'App.tsx',
+]
+
+// Allowed to contain tracking function names only in test files
+const TEST_FILE_PATTERN = /\.test\.(ts|tsx)$/
+
+// ----------------------------------------------------------------------------
+// Patterns that indicate a bypass of the consent-aware API
+// ----------------------------------------------------------------------------
+
+/** Import that pulls trackEvent or trackPageView directly from analytics.ts */
+const DIRECT_IMPORT_RE =
+  /from\s+['"][^'"]*services\/analytics['"]/
+
+/** Direct call to window.plausible (bypasses isEnabled check entirely) */
+const WINDOW_PLAUSIBLE_RE = /window\.plausible\s*\??\s*\(/
+
+// ----------------------------------------------------------------------------
+// File traversal
+// ----------------------------------------------------------------------------
+
+/**
+ * Recursively enumerate .ts / .tsx files under `dir`.
+ * @param {string} dir
+ * @returns {string[]}
+ */
+function walkTs(dir) {
+  const results = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    const stat = statSync(full)
+    if (stat.isDirectory()) {
+      if (entry === 'node_modules' || entry === '__tests__' && full.includes('node_modules')) continue
+      results.push(...walkTs(full))
+    } else if (['.ts', '.tsx'].includes(extname(full))) {
+      results.push(full)
+    }
+  }
+  return results
+}
+
+// ----------------------------------------------------------------------------
+// Main check
+// ----------------------------------------------------------------------------
+
+/**
+ * @typedef {{ file: string; line: number; text: string; reason: string }} Violation
+ */
+
+function main() {
+  const files = walkTs(SRC_DIR)
+  /** @type {Violation[]} */
+  const violations = []
+
+  for (const absPath of files) {
+    const relPath = relative(SRC_DIR, absPath).replace(/\\/g, '/')
+
+    // Skip allowed files
+    if (ALLOWED_PATHS.some((p) => relPath.endsWith(p))) continue
+
+    // Skip test files (they intentionally import trackEvent to assert behaviour)
+    if (TEST_FILE_PATTERN.test(relPath)) continue
+
+    const lines = readFileSync(absPath, 'utf-8').split('\n')
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]
+
+      if (DIRECT_IMPORT_RE.test(line)) {
+        violations.push({
+          file: relPath,
+          line: i + 1,
+          text: line.trim(),
+          reason:
+            'Direct import from services/analytics bypasses the useAnalytics hook. ' +
+            'Use the useAnalytics hook in components, or call trackEvent/trackPageView from ' +
+            'within a service layer that is itself guarded by the analytics module.',
+        })
+      }
+
+      if (WINDOW_PLAUSIBLE_RE.test(line)) {
+        violations.push({
+          file: relPath,
+          line: i + 1,
+          text: line.trim(),
+          reason:
+            'Direct call to window.plausible bypasses isOptedOut() consent check. ' +
+            'Use trackEvent() or trackPageView() from services/analytics instead.',
+        })
+      }
+    }
+  }
+
+  if (violations.length === 0) {
+    console.log('\n✅ Analytics bypass check passed — no violations found.\n')
+    process.exit(0)
+  }
+
+  console.error(`\n❌ Analytics bypass check FAILED — ${violations.length} violation(s) found:\n`)
+
+  for (const v of violations) {
+    console.error(`  📄 src/${v.file}:${v.line}`)
+    console.error(`     Code:   ${v.text}`)
+    console.error(`     Reason: ${v.reason}`)
+    console.error()
+  }
+
+  console.error(
+    '  To fix: replace direct service/plausible usage with the useAnalytics hook\n' +
+    '  or route the call through trackEvent() / trackPageView() which enforce consent.\n' +
+    '  If the usage is intentional (e.g., a new allowed file), add it to ALLOWED_PATHS\n' +
+    '  in scripts/check-analytics-bypass.mjs with a comment explaining the exception.\n',
+  )
+
+  process.exit(1)
+}
+
+main()

--- a/frontend/src/components/AnalyticsOptOut.test.tsx
+++ b/frontend/src/components/AnalyticsOptOut.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * AnalyticsOptOut component tests — issue #948
+ *
+ * Verifies that the opt-out checkbox:
+ *  - Renders only when VITE_PLAUSIBLE_DOMAIN is configured.
+ *  - Correctly reflects the current opt-out state.
+ *  - Toggles opt-out on change and suppresses events immediately.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { AnalyticsOptOut } from './AnalyticsOptOut'
+import { isOptedOut, trackEvent } from '../services/analytics'
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.stubEnv('VITE_PLAUSIBLE_DOMAIN', 'example.com')
+})
+
+afterEach(() => {
+  localStorage.clear()
+  // @ts-expect-error — plausible is an optional global typed in vite-env.d.ts
+  delete window.plausible
+  vi.unstubAllEnvs()
+})
+
+describe('AnalyticsOptOut component', () => {
+  it('renders the opt-out checkbox when VITE_PLAUSIBLE_DOMAIN is set', () => {
+    render(<AnalyticsOptOut />)
+    expect(screen.getByRole('checkbox', { name: /opt out of analytics/i })).toBeInTheDocument()
+  })
+
+  it('renders nothing when VITE_PLAUSIBLE_DOMAIN is not configured', () => {
+    vi.stubEnv('VITE_PLAUSIBLE_DOMAIN', '')
+    const { container } = render(<AnalyticsOptOut />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('checkbox is unchecked when user has NOT opted out', () => {
+    render(<AnalyticsOptOut />)
+    const checkbox = screen.getByRole('checkbox', { name: /opt out of analytics/i })
+    expect(checkbox).not.toBeChecked()
+  })
+
+  it('checkbox is checked when user HAS opted out (persisted in localStorage)', () => {
+    localStorage.setItem('analytics_opt_out', 'true')
+    render(<AnalyticsOptOut />)
+    const checkbox = screen.getByRole('checkbox', { name: /opt out of analytics/i })
+    expect(checkbox).toBeChecked()
+  })
+
+  it('checking the checkbox opts the user out immediately (persisted + service updated)', () => {
+    render(<AnalyticsOptOut />)
+    const checkbox = screen.getByRole('checkbox', { name: /opt out of analytics/i })
+
+    fireEvent.click(checkbox)
+
+    expect(checkbox).toBeChecked()
+    expect(isOptedOut()).toBe(true)
+    expect(localStorage.getItem('analytics_opt_out')).toBe('true')
+  })
+
+  it('un-checking the checkbox opts the user back in immediately', () => {
+    localStorage.setItem('analytics_opt_out', 'true')
+    render(<AnalyticsOptOut />)
+    const checkbox = screen.getByRole('checkbox', { name: /opt out of analytics/i })
+
+    fireEvent.click(checkbox)
+
+    expect(checkbox).not.toBeChecked()
+    expect(isOptedOut()).toBe(false)
+    expect(localStorage.getItem('analytics_opt_out')).toBeNull()
+  })
+
+  it('analytics events are suppressed immediately after checking the opt-out box — no reload required', () => {
+    const plausible = vi.fn()
+    // @ts-expect-error — plausible is an optional global typed in vite-env.d.ts
+    window.plausible = plausible
+
+    render(<AnalyticsOptOut />)
+    const checkbox = screen.getByRole('checkbox', { name: /opt out of analytics/i })
+
+    // Opt out via UI
+    fireEvent.click(checkbox)
+
+    // Any tracking call fired in the same session is suppressed
+    trackEvent('should_be_suppressed')
+    expect(plausible).not.toHaveBeenCalled()
+  })
+
+  it('analytics events fire again after un-checking the opt-out box', () => {
+    localStorage.setItem('analytics_opt_out', 'true')
+    const plausible = vi.fn()
+    // @ts-expect-error — plausible is an optional global typed in vite-env.d.ts
+    window.plausible = plausible
+
+    render(<AnalyticsOptOut />)
+    const checkbox = screen.getByRole('checkbox', { name: /opt out of analytics/i })
+
+    // Opt back in via UI
+    fireEvent.click(checkbox)
+
+    trackEvent('should_fire')
+    expect(plausible).toHaveBeenCalledOnce()
+  })
+
+  it('has an accessible aria-label on the checkbox', () => {
+    render(<AnalyticsOptOut />)
+    const checkbox = screen.getByRole('checkbox', { name: /opt out of analytics/i })
+    expect(checkbox).toHaveAttribute('aria-label', 'Opt out of analytics')
+  })
+})

--- a/frontend/src/hooks/useAnalytics.test.ts
+++ b/frontend/src/hooks/useAnalytics.test.ts
@@ -1,0 +1,120 @@
+/**
+ * useAnalytics hook tests — issue #948
+ *
+ * Verifies that the React hook correctly reflects and toggles the opt-out
+ * state and that the change propagates synchronously to the analytics service
+ * (i.e. takes effect in-session without a reload).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useAnalytics } from './useAnalytics'
+import { isOptedOut, trackEvent } from '../services/analytics'
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.stubEnv('VITE_PLAUSIBLE_DOMAIN', 'example.com')
+})
+
+afterEach(() => {
+  localStorage.clear()
+  vi.unstubAllEnvs()
+})
+
+describe('useAnalytics', () => {
+  it('initialises with optedOut = false when localStorage is empty', () => {
+    const { result } = renderHook(() => useAnalytics())
+    expect(result.current.optedOut).toBe(false)
+  })
+
+  it('initialises with optedOut = true when opt-out flag is already set', () => {
+    localStorage.setItem('analytics_opt_out', 'true')
+    const { result } = renderHook(() => useAnalytics())
+    expect(result.current.optedOut).toBe(true)
+  })
+
+  it('toggleOptOut sets opt-out to true and persists to localStorage', () => {
+    const { result } = renderHook(() => useAnalytics())
+
+    act(() => {
+      result.current.toggleOptOut()
+    })
+
+    expect(result.current.optedOut).toBe(true)
+    expect(localStorage.getItem('analytics_opt_out')).toBe('true')
+  })
+
+  it('toggleOptOut sets opt-out back to false and clears localStorage', () => {
+    localStorage.setItem('analytics_opt_out', 'true')
+    const { result } = renderHook(() => useAnalytics())
+    expect(result.current.optedOut).toBe(true)
+
+    act(() => {
+      result.current.toggleOptOut()
+    })
+
+    expect(result.current.optedOut).toBe(false)
+    expect(localStorage.getItem('analytics_opt_out')).toBeNull()
+  })
+
+  it('opt-out takes effect IMMEDIATELY in the same session — analytics service is updated synchronously', () => {
+    const plausible = vi.fn()
+    // @ts-expect-error — plausible is an optional global typed in vite-env.d.ts
+    window.plausible = plausible
+
+    const { result } = renderHook(() => useAnalytics())
+    expect(result.current.optedOut).toBe(false)
+
+    // Trigger opt-out
+    act(() => {
+      result.current.toggleOptOut()
+    })
+
+    // The analytics service should now report opted-out without any reload
+    expect(isOptedOut()).toBe(true)
+
+    // Any tracking call fired after the toggle must be suppressed
+    trackEvent('should_be_suppressed')
+    expect(plausible).not.toHaveBeenCalled()
+
+    // @ts-expect-error — plausible is an optional global typed in vite-env.d.ts
+    delete window.plausible
+  })
+
+  it('re-enabling tracking via toggleOptOut allows events to fire again', () => {
+    localStorage.setItem('analytics_opt_out', 'true')
+    const plausible = vi.fn()
+    // @ts-expect-error — plausible is an optional global typed in vite-env.d.ts
+    window.plausible = plausible
+
+    const { result } = renderHook(() => useAnalytics())
+
+    // Opt back in
+    act(() => {
+      result.current.toggleOptOut()
+    })
+
+    expect(result.current.optedOut).toBe(false)
+    expect(isOptedOut()).toBe(false)
+
+    trackEvent('should_fire')
+    expect(plausible).toHaveBeenCalledOnce()
+
+    // @ts-expect-error — plausible is an optional global typed in vite-env.d.ts
+    delete window.plausible
+  })
+
+  it('isOptedOut service state matches hook state after toggle', () => {
+    const { result } = renderHook(() => useAnalytics())
+
+    act(() => {
+      result.current.toggleOptOut()
+    })
+    expect(isOptedOut()).toBe(result.current.optedOut)
+
+    act(() => {
+      result.current.toggleOptOut()
+    })
+    expect(isOptedOut()).toBe(result.current.optedOut)
+  })
+})

--- a/frontend/src/services/analytics.test.ts
+++ b/frontend/src/services/analytics.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Analytics opt-out tests — issue #948
+ *
+ * These tests prove that:
+ *  1. When opt-out is set, ZERO analytics events are dispatched.
+ *  2. Opt-out takes effect IMMEDIATELY (in-session, no reload required).
+ *  3. Opt-in restores normal event dispatching.
+ *  4. Missing VITE_PLAUSIBLE_DOMAIN also suppresses all events.
+ *  5. Every public tracking call site (trackEvent, trackPageView) is covered.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  isOptedOut,
+  setOptOut,
+  trackEvent,
+  trackPageView,
+} from './analytics'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Install a spy on window.plausible and return it. */
+function stubPlausible() {
+  const spy = vi.fn()
+  // @ts-expect-error — plausible is an optional global typed in vite-env.d.ts
+  window.plausible = spy
+  return spy
+}
+
+/** Remove window.plausible so "not configured" tests work cleanly. */
+function removePlausible() {
+  // @ts-expect-error — plausible is an optional global typed in vite-env.d.ts
+  delete window.plausible
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  localStorage.clear()
+  // Default: plausible domain IS configured so tests can focus on opt-out logic.
+  vi.stubEnv('VITE_PLAUSIBLE_DOMAIN', 'example.com')
+})
+
+afterEach(() => {
+  localStorage.clear()
+  removePlausible()
+  vi.unstubAllEnvs()
+})
+
+// ---------------------------------------------------------------------------
+// isOptedOut / setOptOut
+// ---------------------------------------------------------------------------
+
+describe('isOptedOut', () => {
+  it('returns false when localStorage is empty', () => {
+    expect(isOptedOut()).toBe(false)
+  })
+
+  it('returns true when opt-out flag is set to "true"', () => {
+    localStorage.setItem('analytics_opt_out', 'true')
+    expect(isOptedOut()).toBe(true)
+  })
+
+  it('returns false when opt-out flag has any other value', () => {
+    localStorage.setItem('analytics_opt_out', '1')
+    expect(isOptedOut()).toBe(false)
+  })
+})
+
+describe('setOptOut', () => {
+  it('sets opt-out flag in localStorage when called with true', () => {
+    setOptOut(true)
+    expect(localStorage.getItem('analytics_opt_out')).toBe('true')
+    expect(isOptedOut()).toBe(true)
+  })
+
+  it('removes opt-out flag from localStorage when called with false', () => {
+    localStorage.setItem('analytics_opt_out', 'true')
+    setOptOut(false)
+    expect(localStorage.getItem('analytics_opt_out')).toBeNull()
+    expect(isOptedOut()).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// trackEvent — opt-out suppression
+// ---------------------------------------------------------------------------
+
+describe('trackEvent', () => {
+  it('fires window.plausible when analytics is enabled and user has NOT opted out', () => {
+    const plausible = stubPlausible()
+    trackEvent('token_created', { symbol: 'TEST' })
+    expect(plausible).toHaveBeenCalledOnce()
+    expect(plausible).toHaveBeenCalledWith('token_created', { props: { symbol: 'TEST' } })
+  })
+
+  it('does NOT fire window.plausible when user opts out BEFORE the call', () => {
+    const plausible = stubPlausible()
+    setOptOut(true)
+    trackEvent('token_created')
+    expect(plausible).not.toHaveBeenCalled()
+  })
+
+  it('suppresses events IMMEDIATELY after opt-out — no reload required', () => {
+    const plausible = stubPlausible()
+
+    // First call fires normally
+    trackEvent('page_view')
+    expect(plausible).toHaveBeenCalledTimes(1)
+
+    // Opt-out mid-session
+    setOptOut(true)
+
+    // Subsequent calls in the same session are suppressed instantly
+    trackEvent('token_created')
+    trackEvent('mint_tokens')
+    expect(plausible).toHaveBeenCalledTimes(1) // no additional calls
+  })
+
+  it('resumes firing after user opts back in — immediate in-session effect', () => {
+    const plausible = stubPlausible()
+
+    setOptOut(true)
+    trackEvent('page_view')
+    expect(plausible).toHaveBeenCalledTimes(0)
+
+    // Opt back in during the same session
+    setOptOut(false)
+    trackEvent('token_created')
+    expect(plausible).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT fire when VITE_PLAUSIBLE_DOMAIN is not set', () => {
+    vi.stubEnv('VITE_PLAUSIBLE_DOMAIN', '')
+    const plausible = stubPlausible()
+    trackEvent('token_created')
+    expect(plausible).not.toHaveBeenCalled()
+  })
+
+  it('passes event props correctly to plausible', () => {
+    const plausible = stubPlausible()
+    trackEvent('mint', { amount: 1000, symbol: 'XLM', success: true })
+    expect(plausible).toHaveBeenCalledWith('mint', {
+      props: { amount: 1000, symbol: 'XLM', success: true },
+    })
+  })
+
+  it('calls plausible with no second argument when props is omitted', () => {
+    const plausible = stubPlausible()
+    trackEvent('wallet_connect')
+    expect(plausible).toHaveBeenCalledWith('wallet_connect', undefined)
+  })
+
+  it('does not throw when window.plausible is undefined', () => {
+    removePlausible()
+    expect(() => trackEvent('token_created')).not.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// trackPageView — opt-out suppression
+// ---------------------------------------------------------------------------
+
+describe('trackPageView', () => {
+  it('fires window.plausible when user has NOT opted out', () => {
+    const plausible = stubPlausible()
+    trackPageView('/create')
+    expect(plausible).toHaveBeenCalledOnce()
+    expect(plausible).toHaveBeenCalledWith('pageview', {
+      u: `${window.location.origin}/create`,
+    })
+  })
+
+  it('does NOT fire window.plausible when user opts out BEFORE the call', () => {
+    const plausible = stubPlausible()
+    setOptOut(true)
+    trackPageView('/create')
+    expect(plausible).not.toHaveBeenCalled()
+  })
+
+  it('suppresses page-view events IMMEDIATELY after opt-out — no reload required', () => {
+    const plausible = stubPlausible()
+
+    trackPageView('/')
+    expect(plausible).toHaveBeenCalledTimes(1)
+
+    // Opt-out mid-session
+    setOptOut(true)
+
+    trackPageView('/create')
+    trackPageView('/tokens')
+    expect(plausible).toHaveBeenCalledTimes(1) // no new calls
+  })
+
+  it('does NOT fire when VITE_PLAUSIBLE_DOMAIN is not set', () => {
+    vi.stubEnv('VITE_PLAUSIBLE_DOMAIN', '')
+    const plausible = stubPlausible()
+    trackPageView('/create')
+    expect(plausible).not.toHaveBeenCalled()
+  })
+
+  it('does not throw when window.plausible is undefined', () => {
+    removePlausible()
+    expect(() => trackPageView('/create')).not.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Full session simulation: every tracking call site suppressed after opt-out
+// ---------------------------------------------------------------------------
+
+describe('opt-out suppresses ALL tracking call sites for the remainder of the session', () => {
+  it('zero analytics events dispatched after opt-out across every call site', () => {
+    const plausible = stubPlausible()
+
+    // --- Phase 1: analytics active, events fire normally ---
+    trackPageView('/')
+    trackEvent('wallet_connect')
+    trackEvent('token_created', { symbol: 'ABC' })
+    trackPageView('/tokens')
+    trackEvent('mint_tokens', { amount: 500 })
+
+    const callsBeforeOptOut = plausible.mock.calls.length
+    expect(callsBeforeOptOut).toBe(5)
+
+    // --- Phase 2: user opts out (mid-session) ---
+    setOptOut(true)
+
+    // --- Phase 3: every call site fires — none should reach plausible ---
+    trackPageView('/create')      // App.tsx call site
+    trackEvent('token_created')   // generic trackEvent
+    trackPageView('/mint')        // another page view
+    trackEvent('burn_tokens')     // generic trackEvent
+    trackEvent('metadata_set')    // generic trackEvent
+
+    // Plausible call count must NOT have increased
+    expect(plausible.mock.calls.length).toBe(callsBeforeOptOut)
+  })
+})

--- a/frontend/src/services/analytics.ts
+++ b/frontend/src/services/analytics.ts
@@ -5,6 +5,15 @@
  * - No PII, no wallet addresses, no personal data is ever sent.
  * - All tracking is skipped when the user has opted out.
  * - All tracking is skipped when VITE_PLAUSIBLE_DOMAIN is not configured.
+ *
+ * Opt-out semantics (regulatory compliance — GDPR/CCPA):
+ * - isOptedOut() reads localStorage on every call, so opt-out takes effect
+ *   IMMEDIATELY within the current session — no page reload is required.
+ * - This satisfies the requirement that a user who opts out mid-session must
+ *   have their preference honoured instantly, not deferred to the next load.
+ * - All code that needs to fire analytics events MUST call trackEvent() or
+ *   trackPageView() from this module — direct use of window.plausible bypasses
+ *   the consent check and is flagged by the CI lint rule (scripts/check-analytics-bypass.mjs).
  */
 
 const OPT_OUT_KEY = 'analytics_opt_out'


### PR DESCRIPTION
## Summary

Fixes the analytics opt-out regression risk identified in #948: no automated test was asserting that toggling opt-out actually suppresses analytics events.

## Changes

### Tests (35 new tests across 3 files)
- `src/services/analytics.test.ts` — unit tests for `isOptedOut`, `setOptOut`, `trackEvent`, `trackPageView`, and a full session simulation proving zero events dispatched after opt-out across every call site.
- `src/hooks/useAnalytics.test.ts` — hook tests verifying state initialization, toggle persistence, and immediate in-session effect.
- `src/components/AnalyticsOptOut.test.tsx` — component tests verifying render conditions, checkbox state, UI toggle suppressing events immediately, and accessibility.

### Immediate opt-out (no reload required) — verified
`isOptedOut()` is called on every `trackEvent` / `trackPageView` invocation, so setting the flag suppresses events synchronously without a page reload. Added inline documentation to `analytics.ts` making this guarantee explicit.

### CI bypass check
- `frontend/scripts/check-analytics-bypass.mjs` — walks `src/` and fails CI if any file outside the allowed list imports directly from `services/analytics` or calls `window.plausible()` directly (both bypass the consent check).
- Added `npm run check:analytics-bypass` to `package.json`.
- Wired into `.github/workflows/ci.yml` after the i18n parity check.

### Compliance ADR
- `docs/adr/ADR-005-analytics-privacy-consent.md` — documents the Plausible provider choice, opt-out semantics, what is tracked (no PII), and a GDPR/CCPA compliance table.

## Test results

```
Test Files  51 passed (51)
     Tests  503 passed (503)
```

Lint: clean. Analytics bypass check: passes.

Closes #948