### PR TITLE
feat(hooks): add LRU eviction to useTokens module-level cache   

### DIFF
--- a/frontend/src/hooks/useTokens.test.tsx
+++ b/frontend/src/hooks/useTokens.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook, waitFor, act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { useTokens, _clearCache } from './useTokens'
+import { useTokens, _clearCache, CACHE_MAX_SIZE } from './useTokens'
 import { stellarService } from '../services/stellar'
 
 vi.mock('../services/stellar', () => ({
@@ -159,5 +159,110 @@ describe('useTokens', () => {
     })
     expect(result.current.tokens).toHaveLength(5)
     expect(result.current.page).toBe(2)
+  })
+})
+
+// ── LRU eviction tests ────────────────────────────────────────────────────────
+
+describe('useTokens LRU cache eviction', () => {
+  it('CACHE_MAX_SIZE is 50', () => {
+    expect(CACHE_MAX_SIZE).toBe(50)
+  })
+
+  it('never stores more than CACHE_MAX_SIZE entries regardless of how many creators are queried', async () => {
+    // Populate the cache with CACHE_MAX_SIZE + 10 distinct creator addresses
+    // by rendering the hook once per creator and waiting for it to settle.
+    const total = CACHE_MAX_SIZE + 10
+
+    for (let i = 0; i < total; i++) {
+      const creator = `GCREATOR${i.toString().padStart(4, '0')}`
+      vi.mocked(stellarService.getTokensByCreator).mockResolvedValue([
+        { name: `Token${i}`, symbol: `TK${i}`, decimals: 7, creator, createdAt: i },
+      ])
+      const { result, unmount } = renderHook(() => useTokens(creator))
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+      unmount()
+    }
+
+    // Import the internal cache size via a fresh render using a sentinel key
+    // that is guaranteed to already be in the cache (the last written entry).
+    // We verify the cap indirectly by checking that a cache hit still occurs
+    // for the most-recently-used entry and that a cache miss occurs for the
+    // oldest entry — which proves the LRU bound is enforced.
+
+    // The last-written creator should be a cache hit (no extra RPC call).
+    const lastCreator = `GCREATOR${(total - 1).toString().padStart(4, '0')}`
+    vi.mocked(stellarService.getTokensByCreator).mockClear()
+    const { result: lastResult, unmount: unmountLast } = renderHook(() => useTokens(lastCreator))
+    await waitFor(() => expect(lastResult.current.isLoading).toBe(false))
+    // No new RPC call — served from cache
+    expect(stellarService.getTokensByCreator).not.toHaveBeenCalled()
+    unmountLast()
+
+    // The very first creator should have been evicted (LRU) — a new RPC call
+    // is required to serve it.
+    const firstCreator = 'GCREATOR0000'
+    vi.mocked(stellarService.getTokensByCreator).mockResolvedValue([TOKEN_A])
+    vi.mocked(stellarService.getTokensByCreator).mockClear()
+    const { result: firstResult, unmount: unmountFirst } = renderHook(() =>
+      useTokens(firstCreator),
+    )
+    await waitFor(() => expect(firstResult.current.isLoading).toBe(false))
+    // Cache miss — RPC was called
+    expect(stellarService.getTokensByCreator).toHaveBeenCalledWith(firstCreator, 0, expect.any(Number))
+    unmountFirst()
+  })
+
+  it('promotes a re-read entry to MRU so it is not evicted before newer entries', async () => {
+    // Fill the cache up to the cap with creators 0..CACHE_MAX_SIZE-1.
+    for (let i = 0; i < CACHE_MAX_SIZE; i++) {
+      const creator = `GREREAD${i.toString().padStart(4, '0')}`
+      vi.mocked(stellarService.getTokensByCreator).mockResolvedValue([
+        { name: `Token${i}`, symbol: `TK${i}`, decimals: 7, creator, createdAt: i },
+      ])
+      const { result, unmount } = renderHook(() => useTokens(creator))
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+      unmount()
+    }
+
+    // Re-read the very first entry (GREREAD0000) to promote it to MRU.
+    const promotedCreator = 'GREREAD0000'
+    vi.mocked(stellarService.getTokensByCreator).mockClear()
+    const { result: promoResult, unmount: unmountPromo } = renderHook(() =>
+      useTokens(promotedCreator),
+    )
+    await waitFor(() => expect(promoResult.current.isLoading).toBe(false))
+    // Should be a cache hit since TTL has not elapsed.
+    expect(stellarService.getTokensByCreator).not.toHaveBeenCalled()
+    unmountPromo()
+
+    // Now add one more creator to push the cap over by 1.
+    const overflowCreator = `GREREAD${CACHE_MAX_SIZE.toString().padStart(4, '0')}`
+    vi.mocked(stellarService.getTokensByCreator).mockResolvedValue([TOKEN_B])
+    const { result: overResult, unmount: unmountOver } = renderHook(() =>
+      useTokens(overflowCreator),
+    )
+    await waitFor(() => expect(overResult.current.isLoading).toBe(false))
+    unmountOver()
+
+    // The promoted entry should still be cached (it was MRU, not LRU).
+    vi.mocked(stellarService.getTokensByCreator).mockClear()
+    const { result: stillCached, unmount: unmountStill } = renderHook(() =>
+      useTokens(promotedCreator),
+    )
+    await waitFor(() => expect(stillCached.current.isLoading).toBe(false))
+    expect(stellarService.getTokensByCreator).not.toHaveBeenCalled()
+    unmountStill()
+
+    // GREREAD0001 (the LRU after promotion) should have been evicted.
+    const evictedCreator = 'GREREAD0001'
+    vi.mocked(stellarService.getTokensByCreator).mockResolvedValue([TOKEN_A])
+    vi.mocked(stellarService.getTokensByCreator).mockClear()
+    const { result: evictedResult, unmount: unmountEvicted } = renderHook(() =>
+      useTokens(evictedCreator),
+    )
+    await waitFor(() => expect(evictedResult.current.isLoading).toBe(false))
+    expect(stellarService.getTokensByCreator).toHaveBeenCalledWith(evictedCreator, 0, expect.any(Number))
+    unmountEvicted()
   })
 })

--- a/frontend/src/hooks/useTokens.ts
+++ b/frontend/src/hooks/useTokens.ts
@@ -6,8 +6,17 @@ import type { TokenInfo } from '../types'
 // ── Module-level cache keyed by creator address ('' = all tokens) ─────────────
 // Shared across all hook instances — any component mounting within the TTL
 // window reuses the same result without an extra network round-trip.
+//
+// LRU eviction: JavaScript's Map preserves insertion order, so we implement
+// LRU by deleting and re-inserting a key on every read or write (moving it
+// to the "most-recently-used" tail). When the map exceeds CACHE_MAX_SIZE the
+// first (oldest / least-recently-used) entry is evicted. This caps memory
+// use regardless of how many distinct creator addresses are queried in a
+// long-lived session (e.g. the Token Explorer browsing hundreds of creators).
 
 const CACHE_TTL_MS = 30_000
+/** Maximum number of creator-keyed entries kept in memory at one time. */
+export const CACHE_MAX_SIZE = 50
 
 interface CacheEntry {
   tokens: TokenInfo[]
@@ -15,6 +24,36 @@ interface CacheEntry {
 }
 
 const cache = new Map<string, CacheEntry>()
+
+/**
+ * Read an entry and promote it to most-recently-used.
+ * Returns undefined on a cache miss.
+ */
+function cacheGet(key: string): CacheEntry | undefined {
+  const entry = cache.get(key)
+  if (entry === undefined) return undefined
+  // Re-insert to move to tail (most-recently-used position).
+  cache.delete(key)
+  cache.set(key, entry)
+  return entry
+}
+
+/**
+ * Write an entry, promote it to MRU, and evict the LRU entry when the cap
+ * is exceeded.
+ */
+function cacheSet(key: string, entry: CacheEntry): void {
+  // Delete first so a re-write moves the key to the tail.
+  cache.delete(key)
+  cache.set(key, entry)
+  if (cache.size > CACHE_MAX_SIZE) {
+    // The first key in iteration order is the least-recently-used one.
+    const lruKey = cache.keys().next().value
+    if (lruKey !== undefined) {
+      cache.delete(lruKey)
+    }
+  }
+}
 
 /** Exposed for testing only */
 export function _clearCache() {
@@ -83,7 +122,7 @@ export interface UseTokensResult {
 export function useTokens(creator?: string): UseTokensResult {
   const cacheKey = creator ?? ''
 
-  const [tokens, setTokens] = useState<TokenInfo[]>(() => cache.get(cacheKey)?.tokens ?? [])
+  const [tokens, setTokens] = useState<TokenInfo[]>(() => cacheGet(cacheKey)?.tokens ?? [])
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<Error | null>(null)
   const [page, setPageRaw] = useState(1)
@@ -95,7 +134,7 @@ export function useTokens(creator?: string): UseTokensResult {
   const load = useCallback(
     async (bypassCache: boolean) => {
       const now = Date.now()
-      const hit = cache.get(cacheKey)
+      const hit = cacheGet(cacheKey)
 
       if (!bypassCache && hit && now - hit.fetchedAt < CACHE_TTL_MS) {
         setTokens(hit.tokens)
@@ -115,7 +154,7 @@ export function useTokens(creator?: string): UseTokensResult {
         } else {
           result = await fetchAllTokens()
         }
-        cache.set(cacheKey, { tokens: result, fetchedAt: Date.now() })
+        cacheSet(cacheKey, { tokens: result, fetchedAt: Date.now() })
         setTokens(result)
         // Reset to first page whenever data is refreshed
         setPageRaw(1)


### PR DESCRIPTION
 Summary
  
  The module-level Map cache in useTokens.ts was unbounded — entries were added on every new
  creator address lookup but never removed. In a long-lived session (e.g. the Token Explorer, an
  admin auditing many accounts), this caused monotonic memory growth proportional to the number
  of distinct creators browsed, with no upper limit.
  
  This PR fixes that by implementing a proper LRU (Least-Recently-Used) eviction policy capped at
  50 entries.
  

  Problem
  
  const cache = new Map<string, CacheEntry>()
  // cache.set() called on every load — nothing ever calls cache.delete()
  
  - Every distinct creator address (or '' for the all-tokens view) inserted a new entry that
  lived for the entire page lifetime.
  - _clearCache() wiped everything (test-only), and TTL was only checked lazily on read — neither
  provided a memory bound.
  - In a typical explorer session touching hundreds of creators, each entry holds a full
  TokenInfo[] array (name, symbol, decimals, creator, timestamp, flags per token), making the
  cumulative footprint significant.

  Solution
  
  JavaScript's Map preserves insertion order. This property makes it a zero-dependency LRU
  structure:
  
  - On read (cacheGet) — delete the key and re-insert it. The entry moves to the tail
  (most-recently-used position).
  - On write (cacheSet) — same re-insert trick, then if map.size > CACHE_MAX_SIZE, delete
  map.keys().next().value (the head — least-recently-used). Both operations are O(1).
  
  export const CACHE_MAX_SIZE = 50
  
  function cacheGet(key: string): CacheEntry | undefined {
    const entry = cache.get(key)
    if (entry === undefined) return undefined
    cache.delete(key)
    cache.set(key, entry)   // promote to MRU tail
    return entry
  }
  
  function cacheSet(key: string, entry: CacheEntry): void {
    cache.delete(key)
    cache.set(key, entry)   // promote to MRU tail
    if (cache.size > CACHE_MAX_SIZE) {
      const lruKey = cache.keys().next().value
      if (lruKey !== undefined) cache.delete(lruKey)
    }
  }
  
  The cap of 50 covers all realistic use cases (a user browsing creators in a session) while
  keeping peak memory negligible. No third-party library introduced.
  
  
  Tests
  
  Three new tests added under describe('useTokens LRU cache eviction'):
  
  ┌────────────────────────────┬─────────────────────────────────────────────────────────────┐
  │ Test                       │ What it verifies                                            │
  ├────────────────────────────┼─────────────────────────────────────────────────────────────┤
  │ CACHE_MAX_SIZE is 50       │ Exported constant is the expected value — prevents silent   │
  │                            │ regressions if someone changes it                           │
  ├────────────────────────────┼─────────────────────────────────────────────────────────────┤
  │ never stores more than     │ Populates 60 distinct creator keys; asserts the             │
  │ CACHE_MAX_SIZE entries     │ most-recently-written key is a cache hit (no RPC call) and  │
  │                            │ the first-written key was evicted (RPC call required)       │
  ├────────────────────────────┼─────────────────────────────────────────────────────────────┤
  │ promotes a re-read entry   │ Fills to the cap, re-reads entry #0 to promote it, adds one │
  │ to MRU so it is not        │ overflow entry; asserts #0 survives and entry #1 (true LRU  │
  │ evicted before newer       │ after the promotion) is evicted                             │
  │ entries                    │                                                             │
  └────────────────────────────┴─────────────────────────────────────────────────────────────┘
  
  All 10 tests pass (7 pre-existing + 3 new).
 
  
  Files Changed
  
  ┌───────────────────────────────────────┬───────────────────────────────────────────────────┐
  │ File                                  │ Change                                            │
  ├───────────────────────────────────────┼───────────────────────────────────────────────────┤
  │ frontend/src/hooks/useTokens.ts       │ Added CACHE_MAX_SIZE, cacheGet, cacheSet;         │
  │                                       │ replaced 3 bare cache.get/set call-sites          │
  ├───────────────────────────────────────┼───────────────────────────────────────────────────┤
  │ frontend/src/hooks/useTokens.test.tsx │ Added 3 LRU eviction tests                        │
  └───────────────────────────────────────┴───────────────────────────────────────────────────┘
  
  ───────────────────────────────────────────────────────────────────────────────────────────────
  
  Follow-up (out of scope for this PR)
  
  The fetchingRef de-duplication logic and hand-rolled TTL semantics are a subset of what
  TanStack Query provides out of the box. Migrating to TanStack Query would eliminate this cache
  entirely and replace it with a well-tested, feature-complete solution (TTL, LRU, request
  de-duplication, background revalidation). Recommended as a follow-up discussion.
  
  closes #929 

