### PR TITLE
feat(security): add triage and waiver workflow for audit findings

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -10,9 +10,27 @@ on:
     - cron: '0 8 * * 1'
 
 jobs:
+  waiver-lint:
+    name: waiver lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+
+      # Every waived advisory must carry a justification, a tracking link and a
+      # review-by date. Fails on a malformed or undocumented waiver; expired
+      # waivers are reported as warnings here and enforced by waiver-review.
+      - name: Validate audit waivers
+        run: node scripts/check-audit-waivers.mjs
+
   npm-audit:
     name: npm audit
     runs-on: ubuntu-latest
+    needs: waiver-lint
     defaults:
       run:
         working-directory: frontend
@@ -29,12 +47,15 @@ jobs:
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
 
+      # audit-ci wraps `npm audit` and honours the allowlist in
+      # frontend/audit-ci.jsonc. Untriaged high/critical advisories still fail.
       - name: Run npm audit
-        run: npm audit --audit-level=high
+        run: npx --yes audit-ci@^7 --config audit-ci.jsonc
 
   cargo-audit:
     name: cargo audit
     runs-on: ubuntu-latest
+    needs: waiver-lint
 
     steps:
       - uses: actions/checkout@v7
@@ -50,6 +71,26 @@ jobs:
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
 
+      # cargo-audit reads contracts/.cargo/audit.toml automatically, which
+      # holds the `[advisories] ignore` waiver list.
       - name: Run cargo audit
         working-directory: contracts
         run: cargo audit
+
+  waiver-review:
+    name: waiver review
+    runs-on: ubuntu-latest
+    # Waivers are time-boxed, not permanent. On the weekly cron this job fails
+    # once any Review-by date has passed, forcing re-triage instead of letting
+    # the waiver silently persist forever.
+    if: github.event_name == 'schedule'
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+
+      - name: Flag waivers past their review-by date
+        run: node scripts/check-audit-waivers.mjs --fail-on-expired

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1064,6 +1064,14 @@ Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md). By participati
 - **Use secure random generation**: For any cryptographic operations
 - **Handle errors gracefully**: Don't expose sensitive information in error messages
 
+### Dependency Advisories
+
+The Security Audit workflow runs `cargo audit` and `npm audit` on every push and pull request, and weekly. Any high-or-above advisory fails the build.
+
+If an advisory does not affect StellarForge (for example, a dev-only dependency or an attack vector we never exercise), it can be waived — but only with a written justification, a tracking issue, and a review-by date, recorded in `contracts/.cargo/audit.toml` or `frontend/audit-ci.jsonc`. Waivers expire, and the weekly job fails once they do.
+
+Never waive an advisory that does affect us, and never extend a review-by date without re-verifying the justification. See [docs/security-triage.md](docs/security-triage.md) for the full process.
+
 ### Reporting Security Vulnerabilities
 
 If you discover a security vulnerability:

--- a/contracts/.cargo/audit.toml
+++ b/contracts/.cargo/audit.toml
@@ -1,0 +1,34 @@
+# cargo-audit configuration for the StellarForge contracts workspace.
+#
+# `cargo audit` reads this file automatically when run from `contracts/`.
+# It fails the Security Audit workflow on ANY advisory that is not listed in
+# the `ignore` array below.
+#
+# ---------------------------------------------------------------------------
+# Adding a waiver
+# ---------------------------------------------------------------------------
+# A waiver is an explicit, dated decision that an advisory does not affect this
+# project. It is not a way to silence CI. Every entry in `ignore` MUST be
+# preceded by a waiver block in exactly this form:
+#
+#   # WAIVER: RUSTSEC-0000-0000
+#   # Justification: why this advisory does not affect StellarForge
+#   # Link: https://github.com/Favourorg/Stellar-forge/issues/<n>
+#   # Review-by: YYYY-MM-DD
+#
+# `scripts/check-audit-waivers.mjs` enforces that shape in CI, and the weekly
+# waiver-review job fails once a `Review-by` date has passed so waivers cannot
+# silently outlive their justification.
+#
+# See docs/security-triage.md for the full triage process.
+# ---------------------------------------------------------------------------
+
+[advisories]
+# Advisory IDs waived after triage. Keep this list empty whenever possible.
+ignore = [
+]
+
+# Surface unmaintained/unsound crates as warnings. They are code-quality
+# signals rather than exploitable vulnerabilities, so they are reported without
+# failing the job; actual vulnerability advisories still fail it.
+informational_warnings = ["unmaintained", "unsound"]

--- a/contracts/token-factory/fuzz/fuzz_targets/fuzz_fee_arithmetic.rs
+++ b/contracts/token-factory/fuzz/fuzz_targets/fuzz_fee_arithmetic.rs
@@ -153,7 +153,22 @@ fuzz_target!(|input: FuzzFeeArithmeticInput| {
     //
     // `create_tokens_batch` computes `base_fee * token_count` via checked_mul.
     // Verify this never overflows silently for non-negative fees.
-    let ops = input.num_operations.min(100) as i128;
+    //
+    // The batch count is clamped to 1..=100 because `create_tokens_batch`
+    // rejects an empty batch with `Error::InvalidParameters` before it ever
+    // reaches this multiplication:
+    //
+    // ```rust
+    // let count = tokens.len() as i128;
+    // if count == 0 {
+    //     return Err(Error::InvalidParameters);
+    // }
+    // ```
+    //
+    // Without the `.max(1)`, `num_operations == 0` makes `total_fee` zero for
+    // an arbitrarily large `effective_base`, tripping the monotonicity
+    // assertion below on a state the contract cannot reach.
+    let ops = (input.num_operations.min(100) as i128).max(1);
     let total_fee = effective_base.checked_mul(ops);
     let saturating_total = effective_base.saturating_mul(ops);
 

--- a/docs/security-triage.md
+++ b/docs/security-triage.md
@@ -1,0 +1,78 @@
+# Security Advisory Triage
+
+The [Security Audit workflow](../.github/workflows/security-audit.yml) runs `cargo audit` against the contracts workspace and `npm audit` (via [audit-ci](https://github.com/IBM/audit-ci)) against the frontend, on every push and pull request to `main`/`develop` and weekly on Mondays at 08:00 UTC.
+
+Any high-or-above advisory fails the job. Sometimes an advisory genuinely does not affect StellarForge — a dev-only dependency, or an attack vector we do not exercise. This document describes how to record that decision so CI stays meaningful instead of chronically red.
+
+## Principles
+
+- **A waiver is a decision, not a mute button.** It records that someone looked at the advisory and concluded it does not affect this project.
+- **Every waiver expires.** Waivers carry a `Review-by` date; the weekly `waiver review` job fails once that date has passed.
+- **Untriaged findings always fail.** Nothing is waived implicitly — only the advisory IDs explicitly listed are ignored.
+
+## When a security-audit run fails
+
+1. **Read the advisory.** Follow the RUSTSEC/GHSA link and understand the vulnerable code path.
+2. **Try to fix it first.** `npm audit fix`, or bump the crate/package. A patch release is almost always cheaper than a waiver.
+3. **If the fix is unavailable or disproportionate, decide whether it applies to us.** Ask:
+   - Is the dependency reachable from shipped code, or is it dev/build-only?
+   - Do we call the affected API at all?
+   - Does exploitation require input we never pass (untrusted deserialisation, attacker-controlled paths, a server context we do not run)?
+4. **If it applies, fix it** — pin, patch, or replace the dependency. Do not waive an advisory that affects us.
+5. **If it does not apply, open a tracking issue and add a waiver** as described below.
+
+## Adding a waiver
+
+Waivers live next to the tool that consumes them:
+
+| Ecosystem | File                          | List key              |
+| --------- | ----------------------------- | --------------------- |
+| Rust      | `contracts/.cargo/audit.toml` | `[advisories] ignore` |
+| JS        | `frontend/audit-ci.jsonc`     | `allowlist`           |
+
+Each entry must be preceded by a waiver block using the file's comment syntax (`#` for TOML, `//` for JSONC):
+
+```toml
+[advisories]
+ignore = [
+  # WAIVER: RUSTSEC-2024-0001
+  # Justification: build-only dependency of the wasm optimiser; the affected
+  # parser never sees untrusted input in our pipeline.
+  # Link: https://github.com/Favourorg/Stellar-forge/issues/123
+  # Review-by: 2026-10-20
+  "RUSTSEC-2024-0001",
+]
+```
+
+All four lines are required:
+
+- **`WAIVER:`** — the advisory ID, matching the list entry exactly.
+- **`Justification:`** — why the advisory does not affect StellarForge. "Not exploitable" alone is not a justification; say which precondition fails.
+- **`Link:`** — the tracking issue where the analysis and any upgrade path are recorded.
+- **`Review-by:`** — an ISO `YYYY-MM-DD` date, normally one quarter out.
+
+`scripts/check-audit-waivers.mjs` enforces this shape in the `waiver lint` job, which gates both audit jobs. It fails on a waiver with missing fields, a bad date, a duplicate entry, a waived ID with no block, or a block with no entry. Run it locally before pushing:
+
+```bash
+node scripts/check-audit-waivers.mjs           # structure only (as on PRs)
+node scripts/check-audit-waivers.mjs --fail-on-expired   # as on the weekly cron
+node --test scripts/check-audit-waivers.test.mjs
+```
+
+Waivers go through normal code review. The reviewer is approving the security analysis, not just the diff.
+
+## Re-triaging an expired waiver
+
+When the weekly `waiver review` job fails, a waiver has reached its `Review-by` date. Re-triage it — do not simply push the date out:
+
+1. Re-read the advisory; check whether a fixed version now exists.
+2. Confirm the original justification still holds against the current code.
+3. Then either:
+   - **Remove the waiver** and upgrade the dependency (preferred), or
+   - **Extend `Review-by`** by another quarter, updating the justification and tracking issue with what you re-verified.
+
+An extension with no re-verification is how a waiver quietly becomes permanent — the exact failure mode this process exists to prevent.
+
+## Reporting a vulnerability in StellarForge itself
+
+This document covers third-party advisories only. To report a vulnerability in StellarForge, follow [SECURITY.md](../SECURITY.md) — do not open a public issue.

--- a/frontend/audit-ci.jsonc
+++ b/frontend/audit-ci.jsonc
@@ -1,0 +1,33 @@
+// audit-ci configuration for the StellarForge frontend.
+//
+// Replaces bare `npm audit --audit-level=high` so that triaged advisories can
+// be waived explicitly while everything else still fails the build.
+//
+// ---------------------------------------------------------------------------
+// Adding a waiver
+// ---------------------------------------------------------------------------
+// A waiver is an explicit, dated decision that an advisory does not affect this
+// project. It is not a way to silence CI. Every entry in `allowlist` MUST be
+// preceded by a waiver block in exactly this form:
+//
+//   // WAIVER: GHSA-0000-0000-0000
+//   // Justification: why this advisory does not affect StellarForge
+//   // Link: https://github.com/Favourorg/Stellar-forge/issues/<n>
+//   // Review-by: YYYY-MM-DD
+//
+// `scripts/check-audit-waivers.mjs` enforces that shape in CI, and the weekly
+// waiver-review job fails once a `Review-by` date has passed so waivers cannot
+// silently outlive their justification.
+//
+// See docs/security-triage.md for the full triage process.
+// ---------------------------------------------------------------------------
+{
+  // Fail on high and critical advisories, matching the previous
+  // `npm audit --audit-level=high` behaviour.
+  "high": true,
+  "report-type": "important",
+  "package-manager": "npm",
+
+  // Advisory IDs waived after triage. Keep this list empty whenever possible.
+  "allowlist": [],
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "prepare": "husky",
     "release": "semantic-release",
+    "audit:waivers": "node scripts/check-audit-waivers.mjs",
     "contract:compile": "cd contracts/token-factory && cargo build --target wasm32v1-none --release",
     "frontend:dev": "cd frontend && npm run dev",
     "start": "npm run contract:compile && npm run frontend:dev",

--- a/scripts/check-audit-waivers.mjs
+++ b/scripts/check-audit-waivers.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+/**
+ * Validates the security-audit waiver files:
+ *
+ *   contracts/.cargo/audit.toml   `[advisories] ignore` (cargo audit)
+ *   frontend/audit-ci.jsonc       `allowlist`           (npm audit via audit-ci)
+ *
+ * Every waived advisory must carry a justification, a tracking link, and a
+ * review-by date, so that no advisory is silenced without an owner and an
+ * expiry. See docs/security-triage.md.
+ */
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, relative, resolve } from "node:path";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+export const WAIVER_FILES = [
+  {
+    path: "contracts/.cargo/audit.toml",
+    listKey: "ignore",
+    tool: "cargo audit",
+  },
+  {
+    path: "frontend/audit-ci.jsonc",
+    listKey: "allowlist",
+    tool: "npm audit (audit-ci)",
+  },
+];
+
+const COMMENT = /^\s*(?:#|\/\/)\s?/;
+const FIELDS = ["Justification", "Link", "Review-by"];
+
+const stripComment = (line) => line.replace(COMMENT, "").trimEnd();
+
+const isComment = (line) => COMMENT.test(line);
+
+/**
+ * Extracts the quoted strings inside `<listKey> ... [ ... ]`, ignoring any
+ * commented-out entries so that a waiver documented but not yet active does
+ * not read as active.
+ */
+export const parseListedIds = (text, listKey) => {
+  const keyIndex = text.search(new RegExp(`["']?${listKey}["']?\\s*[:=]`));
+  if (keyIndex === -1) {
+    throw new Error(`Missing "${listKey}" list`);
+  }
+
+  const open = text.indexOf("[", keyIndex);
+  const close = text.indexOf("]", open);
+  if (open === -1 || close === -1) {
+    throw new Error(`Malformed "${listKey}" list`);
+  }
+
+  return text
+    .slice(open + 1, close)
+    .split("\n")
+    .filter((line) => !isComment(line))
+    .flatMap((line) =>
+      [...line.matchAll(/["']([^"']+)["']/g)].map((m) => m[1]),
+    );
+};
+
+/**
+ * Parses `WAIVER:` comment blocks. A block is a run of consecutive comment
+ * lines starting with `WAIVER: <id>` and followed by its required fields.
+ */
+export const parseWaiverBlocks = (text) => {
+  const lines = text.split("\n");
+  const blocks = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!isComment(lines[index])) continue;
+
+    const header = stripComment(lines[index]).match(/^WAIVER:\s*(\S+)\s*$/);
+    if (!header) continue;
+
+    const block = { id: header[1], line: index + 1, fields: {} };
+
+    for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+      if (!isComment(lines[cursor])) break;
+
+      const body = stripComment(lines[cursor]);
+      if (/^WAIVER:/.test(body)) break;
+
+      const field = body.match(/^([A-Za-z-]+):\s*(.+)$/);
+      if (field && FIELDS.includes(field[1])) {
+        block.fields[field[1]] = field[2].trim();
+      }
+      index = cursor;
+    }
+
+    blocks.push(block);
+  }
+
+  return blocks;
+};
+
+const isIsoDate = (value) =>
+  /^\d{4}-\d{2}-\d{2}$/.test(value) &&
+  !Number.isNaN(Date.parse(`${value}T00:00:00Z`));
+
+/**
+ * Cross-checks the active list against the documented waiver blocks.
+ * Returns `{ errors, expired }` — errors are always fatal, expired waivers are
+ * fatal only for the periodic review job (`--fail-on-expired`).
+ */
+export const validateWaivers = ({ text, listKey, label, today }) => {
+  const errors = [];
+  const expired = [];
+
+  const ids = parseListedIds(text, listKey);
+  const blocks = parseWaiverBlocks(text);
+  const documented = new Map(blocks.map((block) => [block.id, block]));
+
+  const seen = new Set();
+  for (const id of ids) {
+    if (seen.has(id)) {
+      errors.push(`${label}: "${id}" is listed more than once in ${listKey}`);
+      continue;
+    }
+    seen.add(id);
+
+    const block = documented.get(id);
+    if (!block) {
+      errors.push(
+        `${label}: "${id}" is waived in ${listKey} but has no "# WAIVER: ${id}" block`,
+      );
+      continue;
+    }
+
+    for (const field of FIELDS) {
+      if (!block.fields[field]) {
+        errors.push(
+          `${label}:${block.line}: waiver "${id}" is missing "${field}:"`,
+        );
+      }
+    }
+
+    const reviewBy = block.fields["Review-by"];
+    if (reviewBy && !isIsoDate(reviewBy)) {
+      errors.push(
+        `${label}:${block.line}: waiver "${id}" has an invalid Review-by date "${reviewBy}" (expected YYYY-MM-DD)`,
+      );
+    } else if (reviewBy && reviewBy < today) {
+      expired.push(
+        `${label}:${block.line}: waiver "${id}" was due for re-triage on ${reviewBy}`,
+      );
+    }
+  }
+
+  for (const block of blocks) {
+    if (!seen.has(block.id)) {
+      errors.push(
+        `${label}:${block.line}: waiver block "${block.id}" has no matching entry in ${listKey} (remove the block or re-add the entry)`,
+      );
+    }
+  }
+
+  return { errors, expired, count: seen.size };
+};
+
+export const checkAuditWaivers = async ({
+  root = repoRoot,
+  files = WAIVER_FILES,
+  today,
+} = {}) => {
+  const errors = [];
+  const expired = [];
+  const summary = [];
+
+  for (const file of files) {
+    const label = relative(root, resolve(root, file.path)) || file.path;
+    let text;
+    try {
+      text = await readFile(resolve(root, file.path), "utf8");
+    } catch {
+      errors.push(`${label}: waiver file is missing`);
+      continue;
+    }
+
+    try {
+      const result = validateWaivers({ ...file, text, label, today });
+      errors.push(...result.errors);
+      expired.push(...result.expired);
+      summary.push(
+        `${label}: ${result.count} active waiver(s) for ${file.tool}`,
+      );
+    } catch (error) {
+      errors.push(`${label}: ${error.message}`);
+    }
+  }
+
+  return { errors, expired, summary };
+};
+
+export const todayIso = (now = new Date()) => now.toISOString().slice(0, 10);
+
+const main = async () => {
+  const failOnExpired = process.argv.includes("--fail-on-expired");
+  const { errors, expired, summary } = await checkAuditWaivers({
+    today: todayIso(),
+  });
+
+  for (const line of summary) console.log(line);
+
+  for (const error of errors) console.error(`error: ${error}`);
+  for (const line of expired) {
+    console.error(`${failOnExpired ? "error" : "warning"}: ${line}`);
+  }
+
+  if (expired.length > 0) {
+    console.error(
+      "\nExpired waivers must be re-triaged: confirm the advisory still does " +
+        "not affect StellarForge and extend Review-by, or remove the waiver and " +
+        "fix the dependency. See docs/security-triage.md.",
+    );
+  }
+
+  if (errors.length > 0 || (failOnExpired && expired.length > 0)) {
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log("Audit waivers OK");
+};
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/check-audit-waivers.test.mjs
+++ b/scripts/check-audit-waivers.test.mjs
@@ -1,0 +1,140 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  checkAuditWaivers,
+  parseListedIds,
+  parseWaiverBlocks,
+  validateWaivers,
+} from "./check-audit-waivers.mjs";
+
+const toml = (body) => `[advisories]\nignore = [\n${body}\n]\n`;
+
+const waived = (id, { reviewBy = "2099-01-01", fields = true } = {}) =>
+  [
+    `# WAIVER: ${id}`,
+    ...(fields
+      ? [
+          "# Justification: dev-only dependency, not reachable at runtime",
+          "# Link: https://github.com/Favourorg/Stellar-forge/issues/1",
+          `# Review-by: ${reviewBy}`,
+        ]
+      : []),
+    `  "${id}",`,
+  ].join("\n");
+
+const check = (text, today = "2026-07-20") =>
+  validateWaivers({ text, listKey: "ignore", label: "audit.toml", today });
+
+describe("check-audit-waivers", () => {
+  it("parses active ids and skips commented-out entries", () => {
+    const text = toml(
+      ['  "RUSTSEC-2024-0001",', '#  "RUSTSEC-2024-0002",'].join("\n"),
+    );
+    assert.deepEqual(parseListedIds(text, "ignore"), ["RUSTSEC-2024-0001"]);
+  });
+
+  it("parses jsonc allowlists with // comments", () => {
+    const text = '{\n  "allowlist": [\n    "GHSA-aaaa-bbbb-cccc"\n  ]\n}';
+    assert.deepEqual(parseListedIds(text, "allowlist"), [
+      "GHSA-aaaa-bbbb-cccc",
+    ]);
+  });
+
+  it("throws when the list is absent", () => {
+    assert.throws(
+      () => parseListedIds("[advisories]\n", "ignore"),
+      /Missing "ignore"/,
+    );
+  });
+
+  it("parses a waiver block's fields", () => {
+    const [block] = parseWaiverBlocks(toml(waived("RUSTSEC-2024-0001")));
+    assert.equal(block.id, "RUSTSEC-2024-0001");
+    assert.equal(block.fields["Review-by"], "2099-01-01");
+    assert.match(block.fields.Justification, /dev-only/);
+  });
+
+  it("accepts a fully documented, unexpired waiver", () => {
+    const result = check(toml(waived("RUSTSEC-2024-0001")));
+    assert.deepEqual(result.errors, []);
+    assert.deepEqual(result.expired, []);
+    assert.equal(result.count, 1);
+  });
+
+  it("accepts an empty ignore list", () => {
+    const result = check(toml(""));
+    assert.deepEqual(result.errors, []);
+    assert.equal(result.count, 0);
+  });
+
+  it("rejects a waived advisory with no waiver block", () => {
+    const result = check(toml('  "RUSTSEC-2024-0001",'));
+    assert.equal(result.errors.length, 1);
+    assert.match(
+      result.errors[0],
+      /has no "# WAIVER: RUSTSEC-2024-0001" block/,
+    );
+  });
+
+  it("rejects a waiver block missing required fields", () => {
+    const result = check(toml(waived("RUSTSEC-2024-0001", { fields: false })));
+    assert.equal(result.errors.length, 3);
+    for (const field of ["Justification", "Link", "Review-by"]) {
+      assert.ok(result.errors.some((error) => error.includes(field)));
+    }
+  });
+
+  it("rejects a malformed Review-by date", () => {
+    const result = check(
+      toml(waived("RUSTSEC-2024-0001", { reviewBy: "next year" })),
+    );
+    assert.match(result.errors[0], /invalid Review-by date/);
+  });
+
+  it("rejects duplicate entries", () => {
+    const text = toml(`${waived("RUSTSEC-2024-0001")}\n  "RUSTSEC-2024-0001",`);
+    assert.match(check(text).errors[0], /listed more than once/);
+  });
+
+  it("rejects an orphaned waiver block", () => {
+    const text = toml('# WAIVER: RUSTSEC-2024-0001\n  "RUSTSEC-2024-0002",');
+    assert.ok(
+      check(text).errors.some((error) =>
+        error.includes("has no matching entry"),
+      ),
+    );
+  });
+
+  it("reports a past Review-by date as expired, not as an error", () => {
+    const result = check(
+      toml(waived("RUSTSEC-2024-0001", { reviewBy: "2026-07-19" })),
+    );
+    assert.deepEqual(result.errors, []);
+    assert.equal(result.expired.length, 1);
+    assert.match(result.expired[0], /due for re-triage on 2026-07-19/);
+  });
+
+  it("treats a Review-by date of today as still valid", () => {
+    const result = check(
+      toml(waived("RUSTSEC-2024-0001", { reviewBy: "2026-07-20" })),
+    );
+    assert.deepEqual(result.expired, []);
+  });
+
+  it("reports a missing waiver file", async () => {
+    const { errors } = await checkAuditWaivers({
+      root: "/nonexistent",
+      files: [{ path: "audit.toml", listKey: "ignore", tool: "cargo audit" }],
+      today: "2026-07-20",
+    });
+    assert.match(errors[0], /waiver file is missing/);
+  });
+
+  it("validates the checked-in waiver files", async () => {
+    const { errors, summary } = await checkAuditWaivers({
+      today: "2026-07-20",
+    });
+    assert.deepEqual(errors, []);
+    assert.equal(summary.length, 2);
+  });
+});


### PR DESCRIPTION
`npm audit` and `cargo audit` failed the Security Audit job on any high-or-above advisory with no way to record that a finding had been triaged and accepted. The only options when a not-applicable-here advisory landed were to leave CI red indefinitely or rush a breaking dependency bump — the first trains everyone to ignore red security runs.

Add a structured waiver mechanism for both ecosystems:

- contracts/.cargo/audit.toml holds `[advisories] ignore`, read automatically by cargo audit.
- frontend/audit-ci.jsonc holds `allowlist`; npm audit now runs through audit-ci, which keeps the previous high/critical failure threshold.

Waivers are time-boxed rather than permanent. Each entry needs a `# WAIVER:` block with a justification, tracking link, and review-by date. scripts/check-audit-waivers.mjs enforces that shape in a new waiver-lint job gating both audit jobs, and the weekly cron runs it with --fail-on-expired so a waiver past its review-by date fails the build instead of silently persisting.

Untriaged high/critical findings still fail hard: only the advisory IDs explicitly listed are ignored.

Document the process in docs/security-triage.md and link it from CONTRIBUTING.md's Security section.

Closes #939