### PR TITLE
Feat/contract event indexing spec

### DIFF
--- a/.kiro/specs/contract-event-indexing/design.md
+++ b/.kiro/specs/contract-event-indexing/design.md
@@ -1,0 +1,154 @@
+# Contract Event Indexing — Design
+
+Companion to [requirements.md](./requirements.md). Tracking issue: #943.
+
+## Decision: serverless cron, not a dedicated service
+
+**Chosen: a scheduled serverless function writing to a managed Postgres, with
+read routes served from the same deployment.**
+
+| Option                       | Verdict                                                                                                                                                                                                           |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Serverless cron + managed DB | **Chosen.** Workload is a periodic poll over a low-volume event stream and a keyset-paginated read. No long-lived connections needed. Deploys with the existing Vercel project; no new infrastructure to operate. |
+| Dedicated always-on service  | Rejected for v1. Justified only by a Soroban event _subscription_ (push), which the RPC does not offer — so the service would poll on a timer anyway, i.e. a cron with extra operational cost.                    |
+| Client-side IndexedDB cache  | Rejected as the primary fix. Per-browser, cold on first visit, and cannot fix the retention gap (R1). Complementary later, not a substitute.                                                                      |
+
+Revisit if event volume outgrows a single function invocation's budget, or if
+Soroban gains a real subscription API.
+
+### Storage
+
+Postgres (Vercel Postgres / Neon). Chosen over Cloudflare D1 because the
+deployment target is already Vercel, and because keyset pagination over a
+partial index is a well-trodden Postgres path. D1 would force a second vendor
+into the deploy story for no gain at this scale.
+
+> The `token_count` on a mature factory is in the thousands, not millions. This
+> schema is deliberately boring; the constraint is correctness, not throughput.
+
+```sql
+CREATE TABLE tokens (
+  address       TEXT PRIMARY KEY,
+  token_index   INTEGER NOT NULL UNIQUE,   -- contract enumeration order
+  name          TEXT   NOT NULL,
+  symbol        TEXT   NOT NULL,
+  decimals      SMALLINT NOT NULL,
+  creator       TEXT   NOT NULL,
+  created_at    BIGINT NOT NULL,           -- unix seconds
+  metadata_uri  TEXT,
+  source        TEXT   NOT NULL,           -- 'backfill' | 'event'
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX tokens_creator_idx ON tokens (creator, token_index DESC);
+CREATE INDEX tokens_index_idx   ON tokens (token_index DESC);
+
+-- Single-row checkpoint. Survives function restarts; makes lag queryable.
+CREATE TABLE indexer_state (
+  id                     BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (id),
+  last_cursor            TEXT,        -- getEvents paging token
+  last_ledger            BIGINT,
+  last_ledger_close_time TIMESTAMPTZ, -- drives the lag metric (R4)
+  last_run_at            TIMESTAMPTZ,
+  last_error             TEXT,
+  backfill_complete      BOOLEAN NOT NULL DEFAULT FALSE
+);
+```
+
+## Ingest
+
+Two phases, because of the retention constraint in requirements.md.
+
+**Phase A — backfill (once, resumable).** Read `get_state().token_count`, then
+walk `get_token_info(i)` for every `i` not already present, in batches.
+Idempotent: re-running skips rows already stored. Sets
+`backfill_complete = true` when `COUNT(*) = token_count`. This is the only
+phase that can recover tokens older than the RPC event-retention window.
+
+**Phase B — steady state (every run).** Page `getEvents` from `last_cursor`,
+upsert `created` events, apply the newest `meta` event per token, then advance
+the checkpoint. On any error, record `last_error` and leave the cursor
+untouched so the next run retries the same range — at-least-once delivery with
+idempotent upserts, rather than at-most-once with silent gaps.
+
+**Reconciliation.** Each run compares `COUNT(*)` against
+`get_state().token_count`. A mismatch means an event was missed or the cursor
+skipped a range; it re-triggers Phase A for the missing indices. This is the
+backstop that keeps at-least-once delivery honest, and it is cheap.
+
+Cadence: every 5 minutes. See the Vercel Hobby cron caveat in requirements.md.
+
+## API
+
+All routes are read-only and public. Pagination is keyset, not `OFFSET` — the
+cost of `OFFSET n` grows with `n`, violating R5.
+
+```
+GET /api/tokens?creator=<G...>&cursor=<token_index>&limit=<1..100>
+  -> { tokens: TokenInfo[], nextCursor: string | null, indexedAt: string }
+
+GET /api/tokens/:address
+  -> TokenInfo & { indexedAt: string }        // 404 when genuinely absent
+
+GET /api/health/indexer
+  -> { lagSeconds, lastLedger, backfillComplete, lastError, healthy }
+```
+
+`limit` is clamped server-side to 100. `indexedAt` is returned on every payload
+so the client can surface staleness rather than presenting cached data as live.
+
+`TokenInfo` matches the existing frontend type exactly, so the indexer is a
+drop-in behind the current interface.
+
+## Frontend integration and fallback (R3)
+
+Introduce a `TokenSource` seam with two implementations behind one interface —
+`IndexerTokenSource` and the existing `RpcTokenSource` — composed by a wrapper
+that tries the indexer and falls back:
+
+```
+getTokens(...)
+  ├─ indexer: ok and fresh   -> return
+  ├─ indexer: error/timeout  -> RPC, log downgrade
+  ├─ indexer: lag > MAX_LAG  -> RPC, log downgrade
+  └─ indexer: 404 on address -> RPC (may be newer than last ingest)
+```
+
+Three rules that make this safe:
+
+- **Timeout, don't hang.** The indexer call gets a short deadline (~2s); a slow
+  indexer must degrade to RPC, never stall the page.
+- **404 is not authoritative.** A token created since the last ingest is legitimately
+  absent. Address lookups must fall through to RPC on 404 — otherwise the indexer
+  turns "too new" into "does not exist", exactly the class of silent-wrong-answer
+  bug this spec exists to remove.
+- **Fallback is visible.** Surface a "showing live chain data" indicator when
+  degraded, so a permanently-broken indexer cannot hide behind a working app.
+
+Testing (R3): unit tests per branch above with a stubbed indexer — success,
+error, timeout, stale-lag, and 404-falls-through — asserting the RPC path is
+actually exercised, plus a manual runbook step for a real indexer outage.
+
+## Monitoring (R4)
+
+`lagSeconds = now() - last_ledger_close_time`, exposed by `/api/health/indexer`.
+
+| Condition                                                  | Severity                        |
+| ---------------------------------------------------------- | ------------------------------- |
+| `lagSeconds > 15m`                                         | warning                         |
+| `lagSeconds > 1h`, or `last_error` set on consecutive runs | page                            |
+| `backfill_complete = false` for > 24h                      | warning                         |
+| `COUNT(*) != token_count` after reconciliation             | page — indicates real data loss |
+
+Report ingest failures to the existing Sentry setup (`lib/monitoring/sentry`)
+rather than introducing a second alerting path.
+
+## Rollout
+
+1. Deploy ingest + DB. Do not wire the frontend. Let backfill complete.
+2. Verify `COUNT(*) == token_count` on testnet with >100 tokens (R1).
+3. Put the explorer list behind `TokenSource` with the indexer enabled and
+   fallback active. Measure the downgrade rate.
+4. Extend to per-creator queries and search once the list view is proven.
+
+Rollback is a feature flag: point `TokenSource` at RPC only. Because the
+indexer never becomes a source of truth (R2), rollback loses speed, not data.

--- a/.kiro/specs/contract-event-indexing/requirements.md
+++ b/.kiro/specs/contract-event-indexing/requirements.md
@@ -1,0 +1,100 @@
+# Contract Event Indexing — Requirements
+
+Status: **Scoped, not yet built** · Tracking issue: #943
+
+## Problem
+
+The frontend's entire read path derives state from live RPC calls to Soroban and
+Horizon on every page load. There is no off-chain service that ingests factory
+events once and serves fast, complete, filterable queries over them.
+
+Three consequences, in order of severity:
+
+1. **History is silently incomplete.** Soroban RPC retains contract events for a
+   bounded window (roughly 7 days on public networks). The explorer's token list
+   is derived from `getEvents` history, so tokens created before the retention
+   window fall out of the list entirely — with no error and no empty state.
+   This is not a future scaling concern; it is a correctness bug that grows
+   worse the longer a deployment lives.
+2. **Latency scales with history.** `fetchAllContractEvents` re-walks the entire
+   retained event history on every explorer load, then issues one
+   `getTokenInfoByAddress` call per displayed token. Cost is linear in total
+   tokens created, paid again on every page load by every visitor (audit finding 23).
+3. **RPC availability is a single point of failure.** Any endpoint outage or
+   rate-limit event (audit finding 34) takes down all data reading simultaneously. The only
+   persistence is a short-TTL in-memory cache (audit finding 21) that dies with the tab.
+
+## Evidence
+
+| Symptom                                       | Location                                           | Status                                                                  |
+| --------------------------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------- |
+| Fixed 100-event cap dropped the newest tokens | `utils/fetchAllContractEvents.ts`                  | Fixed in `b480f56` (audit finding 22) — replaced with cursor pagination |
+| Same cap in the address-search path           | `services/stellar-impl.ts` `getTokenInfoByAddress` | Fixed alongside this spec                                               |
+| Sequential pagination latency                 | `hooks/useTokens.ts`                               | Partly mitigated by bounded concurrency (audit finding 23)              |
+| Unbounded in-memory cache                     | `hooks/useTokenInfo.ts`                            | Open (audit finding 21)                                                 |
+
+Note that audit finding 22's truncation is **already fixed**. The indexer is therefore a
+performance, completeness, and resilience layer — not the fix for it. The
+issue text's framing on that point is out of date.
+
+## The retention constraint (drives the whole design)
+
+An indexer built _only_ on `getEvents` inherits the RPC retention window and
+cannot backfill beyond it. It would reproduce problem (1) rather than fix it.
+
+The factory contract exposes an authoritative, complete enumeration that does
+not depend on event retention:
+
+- `get_state() -> { token_count, ... }`
+- `get_token_info(index) -> TokenInfo` for `index` in `0..token_count`
+
+**Backfill must come from these index-based views; events are only used to stay
+current.** Any design that skips this is incorrect for any deployment older than
+the retention window.
+
+## Requirements
+
+### R1 — Completeness
+
+The "all tokens" view must return every token ever created by the factory,
+regardless of age, verified against a deployment with more than 100 tokens.
+
+### R2 — The indexer is a cache, not a source of truth
+
+The chain remains authoritative. The indexer is a read optimization. Any value
+it serves must be independently derivable from the contract.
+
+### R3 — Fallback
+
+If the indexer is unreachable, stale beyond threshold, or returns an error, the
+frontend must fall back to direct RPC reads and remain functional. This path
+must be tested, not merely present.
+
+### R4 — Staleness is visible
+
+Indexer lag (time since the last successfully ingested ledger) must be queryable
+and alertable. Silent staleness is worse than a visible outage, because it looks
+like correct data.
+
+### R5 — Bounded query cost
+
+`GET /api/tokens` must serve a page in time independent of total token count.
+
+## Non-goals
+
+- Replacing on-chain view functions. The frontend keeps its direct-RPC path.
+- Indexing non-factory contracts, or per-holder token balances.
+- Serving as an authority for balances, supply, or any consensus-relevant value.
+- Real-time push (WebSocket/SSE) to the browser. Polling is sufficient here.
+
+## Open questions
+
+- **Read source account.** `get_token_info` goes through `simulateTransaction`,
+  which needs a source account. The frontend uses the connected wallet; a
+  server-side indexer has none. Confirm whether an unfunded throwaway account
+  simulates successfully, or whether a funded read-only account must be
+  provisioned per network.
+- **Retention window.** The ~7-day figure needs confirming against the specific
+  RPC provider in use before the backfill/steady-state boundary is finalised.
+- **Cron floor.** Vercel Hobby caps cron frequency at daily, which is far too
+  slow for R4. Confirm the deployment tier before committing to Vercel Cron.

--- a/.kiro/specs/contract-event-indexing/tasks.md
+++ b/.kiro/specs/contract-event-indexing/tasks.md
@@ -1,0 +1,85 @@
+# Contract Event Indexing — Tasks
+
+Milestoned build plan for [design.md](./design.md). Tracking issue: #943.
+
+Milestones are ordered so each one is independently shippable and reversible.
+
+## M0 — Unblock (done in this change)
+
+- [x] Fill in this spec (requirements, design, tasks).
+- [x] Fix the surviving 100-event cap in `getTokenInfoByAddress`, which silently
+      resolved tokens beyond the first event page to a placeholder record
+      instead of their real metadata. Regression-tested in
+      `services/stellar-impl.getTokenInfoByAddress.test.ts`.
+
+No infrastructure yet — M0 is spec plus the correctness fix that does not need it.
+
+## M1 — Resolve open questions
+
+Blocks M2; each is cheap and each can invalidate part of the design.
+
+- [ ] Confirm the RPC provider's event retention window.
+- [ ] Confirm whether `simulateTransaction` accepts an unfunded source account
+      for `get_token_info`; if not, provision a read-only account per network
+      and document key handling.
+- [ ] Confirm the Vercel plan's minimum cron interval (Hobby is daily-only,
+      which does not meet R4).
+
+## M2 — Ingest, no frontend changes
+
+- [ ] Provision Postgres; apply the schema from design.md as a checked-in migration.
+- [ ] Backfill job (Phase A): `get_state().token_count` → `get_token_info(i)`,
+      batched, resumable, idempotent.
+- [ ] Steady-state job (Phase B): cursor-paged `getEvents`, upsert, advance
+      checkpoint only on success.
+- [ ] Reconciliation: compare `COUNT(*)` to `token_count`, re-trigger backfill
+      for missing indices.
+- [ ] Tests: idempotent re-ingest, cursor-not-advanced-on-error, reconciliation
+      detects a deliberately skipped index.
+
+Exit: backfill completes on testnet and `COUNT(*) == token_count`.
+
+## M3 — Read API
+
+- [ ] `GET /api/tokens` with keyset pagination and clamped `limit`.
+- [ ] `GET /api/tokens/:address` returning a true 404 when absent.
+- [ ] `GET /api/health/indexer` exposing `lagSeconds`.
+- [ ] Tests: pagination covers all rows with no duplicates or gaps across page
+      boundaries; `limit` clamping; 404 shape.
+
+Exit: API serves >100 tokens completely (R1) against testnet.
+
+## M4 — Frontend integration behind fallback
+
+- [ ] Extract the `TokenSource` interface; wrap the existing RPC path as
+      `RpcTokenSource` with no behaviour change.
+- [ ] Add `IndexerTokenSource` and the fallback composer (timeout, stale-lag,
+      error, and 404-falls-through — all four branches from design.md).
+- [ ] Feature flag, defaulting to RPC-only.
+- [ ] Degraded-mode indicator in the UI.
+- [ ] Tests for every fallback branch, asserting RPC is actually invoked (R3).
+
+Exit: flag on, explorer served by the indexer, downgrade rate observable.
+
+## M5 — Monitoring
+
+- [ ] Alert thresholds from design.md wired to Sentry.
+- [ ] Ingest failures reported with the failing cursor range.
+- [ ] Runbook: what to do when lag alerts fire, including forced re-backfill.
+
+Exit: a deliberately stalled indexer produces an alert within 15 minutes.
+
+## M6 — Expansion
+
+Only after M4 is proven in production.
+
+- [ ] Per-creator queries served by the indexer (`useTokens`).
+- [ ] Search and filter pushed server-side.
+- [ ] Transaction history.
+
+## Verification note
+
+Acceptance criterion "verified against a testnet deployment with more than 100
+tokens created" is satisfied at **M3**, not before. M0 deliberately does not
+claim it: no indexer exists yet, and the fix it ships was verified by unit
+tests against a stubbed event source, not against a live testnet deployment.

--- a/frontend/src/services/stellar-impl.getTokenInfoByAddress.test.ts
+++ b/frontend/src/services/stellar-impl.getTokenInfoByAddress.test.ts
@@ -1,0 +1,130 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import type { ContractEvent, GetEventsResult } from '../types'
+
+vi.mock('../config/stellar', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../config/stellar')>()
+  return {
+    ...actual,
+    STELLAR_CONFIG: { ...actual.STELLAR_CONFIG, factoryContractId: 'CFACTORY' },
+  }
+})
+
+import { StellarService } from './stellar-impl'
+
+/** Matches the default page size in `fetchAllContractEvents`. */
+const PAGE_SIZE = 100
+
+const created = (ledger: number, address: string, name: string): ContractEvent => ({
+  id: `created-${ledger}`,
+  type: 'created',
+  ledger,
+  timestamp: 1_700_000_000 + ledger,
+  txHash: `tx-${ledger}`,
+  data: { tokenAddress: address, name, symbol: name.toUpperCase(), creator: `G${name}` },
+})
+
+const meta = (ledger: number, address: string, uri: string): ContractEvent => ({
+  id: `meta-${ledger}`,
+  type: 'meta',
+  ledger,
+  timestamp: 1_700_000_000 + ledger,
+  txHash: `tx-${ledger}`,
+  data: { tokenAddress: address, metadataUri: uri },
+})
+
+/**
+ * Serves `events` in fixed-size pages, mirroring the `getEvents` contract that
+ * `fetchAllContractEvents` relies on: ascending ledger order, and a page
+ * shorter than the requested limit signals end-of-history.
+ */
+const pagedSource = (events: ContractEvent[]) => {
+  return vi.fn(
+    async (_contractId: string, limit = 20, cursor?: string): Promise<GetEventsResult> => {
+      const start = cursor ? Number(cursor) : 0
+      const slice = events.slice(start, start + limit)
+      const next = start + slice.length
+      return { events: slice, cursor: next < events.length ? String(next) : null }
+    },
+  )
+}
+
+describe('StellarService.getTokenInfoByAddress', () => {
+  let service: StellarService
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    service = new StellarService('testnet')
+  })
+
+  test('resolves a token whose created event is beyond the first page', async () => {
+    // Regression: a single capped getContractEvents(contractId, 100) call
+    // returned only the OLDEST 100 events, so this token silently resolved to
+    // a placeholder named after its own address instead of its real metadata.
+    const events = Array.from({ length: 150 }, (_, i) =>
+      created(i + 1, `C_TOKEN_${i}`, `token${i}`),
+    )
+    const target = events[120]!
+    const getContractEvents = pagedSource(events)
+    vi.spyOn(service, 'getContractEvents').mockImplementation(getContractEvents)
+
+    const info = await service.getTokenInfoByAddress('C_TOKEN_120')
+
+    expect(info.name).toBe('token120')
+    expect(info.symbol).toBe('TOKEN120')
+    expect(info.creator).toBe('Gtoken120')
+    expect(info.createdAt).toBe(target.timestamp)
+    // Proves pagination actually happened rather than one capped call.
+    expect(getContractEvents.mock.calls.length).toBeGreaterThan(1)
+  })
+
+  test('requests full pages until history is exhausted', async () => {
+    const events = Array.from({ length: 250 }, (_, i) =>
+      created(i + 1, `C_TOKEN_${i}`, `token${i}`),
+    )
+    const getContractEvents = pagedSource(events)
+    vi.spyOn(service, 'getContractEvents').mockImplementation(getContractEvents)
+
+    await service.getTokenInfoByAddress('C_TOKEN_249')
+
+    // 250 events at 100/page => 3 pages (100, 100, 50-short terminates).
+    expect(getContractEvents).toHaveBeenCalledTimes(3)
+    expect(getContractEvents.mock.calls[0]?.[1]).toBe(PAGE_SIZE)
+  })
+
+  test('throws when no created event exists for the address', async () => {
+    vi.spyOn(service, 'getContractEvents').mockImplementation(
+      pagedSource([created(1, 'C_OTHER', 'other')]),
+    )
+
+    // A rejection is the "not found" signal callers rely on; returning a
+    // placeholder here is what made a missing token look like a real one.
+    await expect(service.getTokenInfoByAddress('C_MISSING')).rejects.toThrow(
+      /No token found at address C_MISSING/,
+    )
+  })
+
+  test('applies the most recent metadata event for the token', async () => {
+    vi.spyOn(service, 'getContractEvents').mockImplementation(
+      pagedSource([
+        created(1, 'C_TOKEN', 'token'),
+        meta(2, 'C_TOKEN', 'ipfs://old'),
+        meta(9, 'C_TOKEN', 'ipfs://new'),
+        meta(5, 'C_OTHER', 'ipfs://unrelated'),
+      ]),
+    )
+
+    const info = await service.getTokenInfoByAddress('C_TOKEN')
+
+    expect(info.metadataUri).toBe('ipfs://new')
+  })
+
+  test('leaves metadataUri empty when the token has no metadata event', async () => {
+    vi.spyOn(service, 'getContractEvents').mockImplementation(
+      pagedSource([created(1, 'C_TOKEN', 'token')]),
+    )
+
+    const info = await service.getTokenInfoByAddress('C_TOKEN')
+
+    expect(info.metadataUri).toBe('')
+  })
+})

--- a/frontend/src/services/stellar-impl.ts
+++ b/frontend/src/services/stellar-impl.ts
@@ -27,6 +27,7 @@ import {
 } from 'stellar-sdk'
 import type { Network } from '../config/stellar'
 import { withRetry, HttpError } from '../utils/retry'
+import { fetchAllContractEvents } from '../utils/fetchAllContractEvents'
 import { parseContractError } from '../utils/contractErrors'
 import { nextBackoffDelay } from '../utils/pollWithBackoff'
 
@@ -877,28 +878,45 @@ export class StellarService {
   // ── getTokenInfoByAddress ────────────────────────────────────────────────────
 
   /**
-   * Get token info by contract address (derived from factory events).
-   * Returns a TokenInfo with the address embedded in the creator field if not found.
+   * Get token info by contract address, derived from factory events.
+   *
+   * Pages through the full event history rather than requesting a single
+   * fixed-size page. `getEvents` returns events in ascending ledger order, so
+   * a capped single call drops the *newest* events — meaning a token created
+   * after the cap was reached resolved to a placeholder record (name set to
+   * its own address, empty symbol and creator) that callers could not
+   * distinguish from a real token. See `fetchAllContractEvents` for the
+   * pagination contract, and `.kiro/specs/contract-event-indexing` for why
+   * re-walking history per lookup is a stopgap rather than the end state.
+   *
+   * Throws when no `created` event exists for `tokenAddress`. Callers treat a
+   * rejection as "not found" — `TokenDetail` renders its not-found state,
+   * `TokenExplorer` and `useTokens` filter the entry out — which is why a
+   * placeholder is not returned instead.
    */
   async getTokenInfoByAddress(tokenAddress: string): Promise<TokenInfo> {
     const contractId = STELLAR_CONFIG.factoryContractId
     if (!contractId) throw new Error('Factory contract ID is not configured')
 
-    const { events } = await this.getContractEvents(contractId, 100)
+    const events = await fetchAllContractEvents(this, contractId)
     const createdEvent = events.find(
       (e) => e.type === 'created' && e.data.tokenAddress === tokenAddress,
     )
+    if (!createdEvent) {
+      throw new Error(`No token found at address ${tokenAddress}`)
+    }
+
     // Most-recent metadata event for this token
     const metaEvent = events
       .filter((e) => e.type === 'meta' && e.data.tokenAddress === tokenAddress)
       .sort((a, b) => b.ledger - a.ledger)[0]
 
     return {
-      name: createdEvent?.data.name ?? tokenAddress,
-      symbol: createdEvent?.data.symbol ?? '',
+      name: createdEvent.data.name ?? tokenAddress,
+      symbol: createdEvent.data.symbol ?? '',
       decimals: 7,
-      creator: createdEvent?.data.creator ?? '',
-      createdAt: createdEvent?.timestamp ?? 0,
+      creator: createdEvent.data.creator ?? '',
+      createdAt: createdEvent.timestamp ?? 0,
       metadataUri: metaEvent?.data.metadataUri ?? '',
     }
   }


### PR DESCRIPTION
Scopes the empty `.kiro/specs/contract-event-indexing/` spec and fixes a surviving instance of the truncation bug the issue describes.

  This delivers one of the three acceptance criteria. The other two require infrastructure that does not exist yet; see Acceptance criteria below.

  ## What's in here

  **The spec** — `requirements.md`, `design.md`, `tasks.md`.

  Architecture decision recorded: a **scheduled serverless function + managed Postgres**, not a dedicated always-on service. A dedicated service is only
  justified by a true event *subscription*, which Soroban RPC does not offer — so it would poll on a timer anyway, i.e. a cron with extra operational
  cost. Postgres over Cloudflare D1 because Vercel is already the deploy target.

  Also specified: the ingest checkpoint schema, keyset pagination (not `OFFSET`, whose cost grows with depth), the `TokenSource` fallback seam, and lag
  alert thresholds wired to the existing Sentry setup.

  **The fix** — `getTokenInfoByAddress` still fetched a single capped page:

  ```ts
  const { events } = await this.getContractEvents(contractId, 100)

  getEvents returns events in ascending ledger order, so a fixed limit drops the newest events, not the oldest. Any token created after the factory's
  100th event was never found — and instead of failing, the function returned a placeholder with name set to the token's own address, empty
  symbol/creator, and createdAt: 0. Callers could not distinguish that from a real token.

  Now paginated via fetchAllContractEvents, and it throws on genuine not-found. All four callers already handle rejection correctly — TokenDetail has a
  dedicated not-found state that the placeholder was bypassing, useTokenInfo sets an error, and TokenExplorer/useTokens filter the entry out.

  Two findings that change the issue's premise

  1. The 100-event explorer truncation is already fixed. Commit b480f56 replaced the capped fetch with cursor pagination in fetchAllContractEvents, and
  TokenExplorer uses it. The indexer is therefore a performance/completeness/resilience layer — not the fix for that truncation, as the issue assumes. The
  call site fixed in this PR is a separate surviving instance of the same bug class.

  2. An event-only indexer cannot be correct. This drives the whole design.

  Soroban RPC retains contract events for a bounded window (~7 days on public networks). An indexer built solely on getEvents polling — which is what the
  issue proposes — inherits that window and still loses tokens older than it, reproducing the very gap it is meant to close.

  The factory already exposes an authoritative enumeration that does not depend on event retention:

  - get_state() -> { token_count, ... }
  - get_token_info(index) for index in 0..token_count

  So backfill must come from those index-based views, with events used only to stay current. The spec splits ingest into exactly those two phases, plus a
  reconciliation step comparing COUNT(*) against token_count.

  This also means the explorer is already silently incomplete today for any deployment older than the retention window — a live correctness bug, not the
  future scaling concern the issue frames it as.

  Acceptance criteria

  ┌──────────────────────────────────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────────┐
  │                                      Criterion                                       │                           Status                           │
  ├──────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
  │ A scoped design document fills the empty spec                                        │ ✅ Done                                                    │
  ├──────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
  │ A first working version serves the all-tokens view, verified against testnet with    │ ❌ Not done — no indexer exists yet. Satisfied at M3 in    │
  │ >100 tokens                                                                          │ tasks.md.                                                  │
  ├──────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
  │ Frontend has a documented, tested fallback path to direct RPC                        │ ⚠️  Designed and specified, not built. M4.                  │
  └──────────────────────────────────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┘

  Verification

  - 5 new tests in stellar-impl.getTokenInfoByAddress.test.ts. 3 of them fail against the previous implementation — confirming real regression coverage
  rather than tests written to match current behaviour.
  - Full frontend suite: 531 passing.
  - eslint clean, tsc --noEmit clean.

  Not verified: anything requiring a live testnet deployment or a provisioned database. No indexer code ships here, so there is nothing
  infrastructure-dependent to test.

  Note on issue references

  The issue body's #21/#22/#23/#34 are audit-report finding numbers, not GitHub issues — GitHub's #21–#23 are unrelated UI component tickets, and #35
  (referenced in a code comment in fetchAllContractEvents.ts as the indexer issue) is "Add Mainnet Deployment Checklist / Guard". The spec spells these
  out as "audit finding N" so they don't autolink to the wrong issues.

  Follow-ups

  Three open questions are listed in the spec rather than guessed, because each can invalidate part of the design. M1 resolves them before any
  infrastructure is built:

  1. The RPC provider's actual event retention window.
  2. Whether simulateTransaction accepts an unfunded source account for get_token_info — the frontend uses the connected wallet, but a server-side indexer
  has none.
  3. The Vercel plan's minimum cron interval. Hobby is daily-only, which cannot meet the lag requirement.

Closes #943 