### PR TITLE
feat(frontend): verify deployed token WASM hash against factory state

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ credentials never reach the browser. Set these as **server-side** environment
 variables in your Vercel project settings (or a local `.env` at the repo
 root when running `vercel dev`) - never prefix them with `VITE_`, or they'll
 be inlined into the client bundle and shipped to every visitor:
+
 ```env
 PINATA_API_KEY=<pinata-api-key>
 PINATA_API_SECRET=<pinata-api-secret>
@@ -237,19 +238,23 @@ npm run lint         # Lint code
 The authoritative, field-by-field reference — including parameter tables, every error code, and every emitted event — lives in [`docs/contract-abi.md`](./docs/contract-abi.md). This section is a quick-scan summary of the same `#[contractimpl]` surface in `contracts/token-factory/src/lib.rs`.
 
 ### Initialization
+
 - `initialize(admin, treasury, fee_token, token_wasm_hash, base_fee, metadata_fee)`: One-time factory setup. Fails with `AlreadyInitialized` on retry.
 
 ### Token Lifecycle
+
 - `create_token(creator, salt, name, symbol, decimals, initial_supply, fee_payment)`: Deploy a single new token contract at a deterministic `(creator, salt)` address; optionally mint `initial_supply` to `creator`.
 - `create_tokens_batch(creator, tokens, fee_payment)`: Atomically deploy a `Vec<BatchTokenParams>` (each with its own name/symbol/decimals/initial_supply and optional `max_supply` cap) in one transaction. `fee_payment` must cover `base_fee * tokens.len()`; a failure partway through the batch aborts the whole call.
 - `mint_tokens(token_address, admin, to, amount, fee_payment)`: Mint additional supply. Only the token's original creator may call this. Rejected with `MaxSupplyExceeded` if the token was created with a `max_supply` cap that minting would exceed.
 - `burn(token_address, from, amount)`: Burn `amount` from the caller's own balance. Honors the token's `burn_enabled` flag; ignores the factory-wide pause.
 
 ### Metadata
+
 - `set_metadata(token_address, admin, metadata_uri, fee_payment)`: Attach an `ipfs://` (or `https://`) metadata URI to a token. One-shot — a second call returns `MetadataAlreadySet`.
 - `set_burn_enabled(token_address, admin, enabled)`: Toggle whether a specific token can be burned. Caller must be the token's creator.
 
 ### Admin & Governance
+
 - `update_fees(admin, base_fee?, metadata_fee?)`: Adjust either fee; `None` leaves it unchanged.
 - `set_fee_split(admin, splits)` / `get_fee_split()`: Configure or read a `Map<Address, u32>` of basis-point fee recipients (must sum to `10_000`, or be empty to clear the split and fall back to `treasury`).
 - `pause(admin)` / `unpause(admin)`: Halt or resume `create_token`, `create_tokens_batch`, `mint_tokens`, and `set_metadata` factory-wide.
@@ -259,6 +264,7 @@ The authoritative, field-by-field reference — including parameter tables, ever
 - `migrate(admin)`: Idempotently bring on-chain state up to `CURRENT_SCHEMA_VERSION` after an upgrade.
 
 ### View Functions
+
 - `get_state()`: Full `FactoryState` (admin, treasury, fee_token, fees, pause flag, token count, schema version).
 - `get_base_fee()` / `get_metadata_fee()`: Current fee values.
 - `get_token_info(index)`: Look up a token by its 1-based factory index.
@@ -414,6 +420,7 @@ stellar contract invoke \
 ```
 
 **Parameters explained:**
+
 - `admin`: Address that can update fees, pause the factory, manage the whitelist and fee split, rotate the admin, and upgrade the contract
 - `treasury`: Default address that receives fees from token creation (overridden per-recipient if a fee split is configured)
 - `fee_token`: Contract address for the SEP-41 token used to pay all fees (use native XLM contract: `CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC`)
@@ -442,6 +449,19 @@ VITE_TOKEN_WASM_HASH=<your-token-wasm-hash>
 VITE_IPFS_API_KEY=<your-pinata-api-key>
 VITE_IPFS_API_SECRET=<your-pinata-api-secret>
 ```
+
+> **Keep `VITE_TOKEN_WASM_HASH` in sync with the factory.** This value must equal the
+> factory's on-chain `token_wasm_hash` — the WASM the factory actually deploys tokens
+> from. That field is set at `initialize` time and can only change through a contract
+> upgrade + migrate, so the realistic way they drift apart is a factory upgrade that
+> ships without a matching frontend redeploy.
+>
+> On startup (and every 5 minutes thereafter) the app reads `get_state()` and compares
+> the on-chain hash against this variable, showing a red warning banner if they differ.
+> Treat that banner as a deployment bug: it is a **safety net for detecting drift, not a
+> substitute for updating both in lockstep**. If the check cannot be completed — the RPC
+> read fails, or the variable is unset — the app stays silent rather than warning, so a
+> missing banner is not by itself proof that the hashes match.
 
 **Getting Pinata credentials:**
 

--- a/docs/mainnet-deployment-checklist.md
+++ b/docs/mainnet-deployment-checklist.md
@@ -34,6 +34,7 @@ Every mainnet deployment **must** be accompanied by a signed, annotated git tag 
 
 - [ ] Set `VITE_NETWORK=mainnet` and confirm no testnet network passphrase, RPC URL, or Friendbot reference remains.
 - [ ] Verify `VITE_FACTORY_CONTRACT_ID`, `VITE_TOKEN_WASM_HASH`, and Pinata/IPFS configuration point to production values.
+- [ ] Confirm `VITE_TOKEN_WASM_HASH` equals the factory's on-chain `token_wasm_hash` (`stellar contract invoke --id <factory> -- get_state`). If the factory is being upgraded in this release, the frontend must be redeployed with the new hash in the same release window.
 - [ ] Confirm Content Security Policy headers allow only the required Stellar, Pinata, and application origins.
 - [ ] Review deployment hosting settings, environment variables, redirects, and security headers before publishing.
 
@@ -44,6 +45,7 @@ Every mainnet deployment **must** be accompanied by a signed, annotated git tag 
 - [ ] Prepare a rollback plan that names the last known-good frontend deployment, contract IDs, owner, and rollback command.
 - [ ] Save deployment transaction hashes, contract IDs, WASM hashes, and release notes in the deployment log.
 - [ ] After mainnet deployment, verify contract state, transaction history, and frontend reads against Stellar Explorer.
+- [ ] Load the deployed frontend against mainnet and confirm **no token-contract mismatch banner** appears. The app compares the factory's on-chain `token_wasm_hash` against `VITE_TOKEN_WASM_HASH` at startup; a red banner means the frontend build and the factory disagree about which token contract is being deployed. The check stays silent when it cannot complete (RPC read failure, or the variable unset), so pair this with the config verification above rather than relying on the absent banner alone.
 - [ ] Run the [WASM Hash Verification workflow](https://github.com/Favourorg/Stellar-forge/actions/workflows/wasm-verify.yml) as the final post-deployment check, using the deployment tag as `git_ref` and the new factory contract ID. The job must pass before the deployment is considered complete.
 - [ ] Monitor application errors, failed transactions, fee spikes, and user-reported issues during the release window.
 
@@ -59,4 +61,3 @@ These items must be verified before the factory is accessible to end users on ma
 - [ ] Tabletop exercise (runbook section 10) has been completed and dated in the deployment log.
 
 > See [SECURITY.md](../SECURITY.md) for the responsible disclosure policy and further security context.
-

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -11,6 +11,8 @@ VITE_FACTORY_CONTRACT_ID=CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 # Token WASM Hash (REQUIRED)
 # The WASM hash of the token contract used for token creation
 # Get this from `stellar contract install` command (64 hex characters)
+# MUST match the factory's on-chain `token_wasm_hash` (see `get_state`). The app
+# compares the two at startup and shows a warning banner if they drift apart.
 VITE_TOKEN_WASM_HASH=0000000000000000000000000000000000000000000000000000000000000000
 
 # Pinata IPFS Credentials (REQUIRED for token metadata uploads)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2396,9 +2396,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2494,9 +2494,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5191,16 +5191,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.0.tgz",
-      "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.58.0",
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/typescript-estree": "8.58.0",
-        "@typescript-eslint/visitor-keys": "8.58.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -5216,14 +5216,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.0.tgz",
-      "integrity": "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.0",
-        "@typescript-eslint/types": "^8.58.0",
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -5238,14 +5238,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.0.tgz",
-      "integrity": "sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/visitor-keys": "8.58.0"
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5256,9 +5256,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.0.tgz",
-      "integrity": "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5423,9 +5423,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.0.tgz",
-      "integrity": "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5437,16 +5437,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.0.tgz",
-      "integrity": "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.0",
-        "@typescript-eslint/tsconfig-utils": "8.58.0",
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/visitor-keys": "8.58.0",
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -5465,9 +5465,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5645,13 +5645,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.0.tgz",
-      "integrity": "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/types": "8.65.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -5732,42 +5732,42 @@
         }
       }
     },
-    "node_modules/@vitest/coverage-v8/node_modules/@vitest/pretty-format": {
+    "node_modules/@vitest/expect": {
       "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
-      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/coverage-v8/node_modules/@vitest/utils": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
-      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+    "node_modules/@vitest/expect/node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.3.tgz",
-      "integrity": "sha512-XN3TrycitDQSzGRnec/YWgoofkYRhouyVQj4YNsJ5r/STCUFqMrP4+oxEv3e7ZbLi4og5kIHrZwekDJgw6hcjw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.3",
+        "@vitest/spy": "4.1.10",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -5787,16 +5787,6 @@
         }
       }
     },
-    "node_modules/@vitest/mocker/node_modules/@vitest/spy": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.3.tgz",
-      "integrity": "sha512-ujj5Uwxagg4XUIfAUyRQxAg631BP6e9joRiN99mr48Bg9fRs+5mdUElhOoZ6rP5mBr8Bs3lmrREnkrQWkrsTCw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/@vitest/mocker/node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -5807,57 +5797,42 @@
         "@types/estree": "^1.0.0"
       }
     },
-    "node_modules/@vitest/runner": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.3.tgz",
-      "integrity": "sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA==",
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.3",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
         "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.3.tgz",
-      "integrity": "sha512-hYqqwuMbpkkBodpRh4k4cQSOELxXky1NfMmQvOfKvV8zQHz8x8Dla+2wzElkMkBvSAJX5TRGHJAQvK0TcOafwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/runner/node_modules/@vitest/utils": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.3.tgz",
-      "integrity": "sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.3",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.3.tgz",
-      "integrity": "sha512-9l+k/J9KG5wPJDX9BcFFzhhwNjwkRb8RsnYhaT1vPY7OufxmQFc9sZzScRCPTiETzl37mrIWVY9zxzmdVeJwDQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.3",
-        "@vitest/utils": "4.1.3",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -5865,42 +5840,24 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.3.tgz",
-      "integrity": "sha512-hYqqwuMbpkkBodpRh4k4cQSOELxXky1NfMmQvOfKvV8zQHz8x8Dla+2wzElkMkBvSAJX5TRGHJAQvK0TcOafwg==",
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/snapshot/node_modules/@vitest/utils": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.3.tgz",
-      "integrity": "sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.3",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
-      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.3.tgz",
-      "integrity": "sha512-xBPy+43o1fgMLUDlufUXh7tlT/Es8uS5eiyBY2PyPfFYSGpApZskLw65DROoDz+rgYkPuAmb20Mv9Z9g1WQE7w==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.10.tgz",
+      "integrity": "sha512-EOUqfXHTXtpSHsyLHH40ts3Ue+hRhSGwzwzMlK0dTEOLSDYyOXLyr5JDGmHQWhN2DYI30gw6dVx3cdgM9FZl+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.3",
+        "@vitest/utils": "4.1.10",
         "fflate": "^0.8.2",
         "flatted": "^3.4.2",
         "pathe": "^2.0.3",
@@ -5912,30 +5869,17 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "4.1.3"
+        "vitest": "4.1.10"
       }
     },
-    "node_modules/@vitest/ui/node_modules/@vitest/pretty-format": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.3.tgz",
-      "integrity": "sha512-hYqqwuMbpkkBodpRh4k4cQSOELxXky1NfMmQvOfKvV8zQHz8x8Dla+2wzElkMkBvSAJX5TRGHJAQvK0TcOafwg==",
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/ui/node_modules/@vitest/utils": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.3.tgz",
-      "integrity": "sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.3",
+        "@vitest/pretty-format": "4.1.10",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -6431,9 +6375,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7631,9 +7575,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7773,9 +7717,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9394,9 +9338,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -12533,7 +12477,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -12823,19 +12767,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.3.tgz",
-      "integrity": "sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.3",
-        "@vitest/mocker": "4.1.3",
-        "@vitest/pretty-format": "4.1.3",
-        "@vitest/runner": "4.1.3",
-        "@vitest/snapshot": "4.1.3",
-        "@vitest/spy": "4.1.3",
-        "@vitest/utils": "4.1.3",
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -12863,12 +12807,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.3",
-        "@vitest/browser-preview": "4.1.3",
-        "@vitest/browser-webdriverio": "4.1.3",
-        "@vitest/coverage-istanbul": "4.1.3",
-        "@vitest/coverage-v8": "4.1.3",
-        "@vitest/ui": "4.1.3",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -12910,72 +12854,6 @@
         "vite": {
           "optional": false
         }
-      }
-    },
-    "node_modules/vitest/node_modules/@vitest/expect": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.3.tgz",
-      "integrity": "sha512-CW8Q9KMtXDGHj0vCsqui0M5KqRsu0zm0GNDW7Gd3U7nZ2RFpPKSCpeCXoT+/+5zr1TNlsoQRDEz+LzZUyq6gnQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.3",
-        "@vitest/utils": "4.1.3",
-        "chai": "^6.2.2",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vitest/node_modules/@vitest/pretty-format": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.3.tgz",
-      "integrity": "sha512-hYqqwuMbpkkBodpRh4k4cQSOELxXky1NfMmQvOfKvV8zQHz8x8Dla+2wzElkMkBvSAJX5TRGHJAQvK0TcOafwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vitest/node_modules/@vitest/spy": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.3.tgz",
-      "integrity": "sha512-ujj5Uwxagg4XUIfAUyRQxAg631BP6e9joRiN99mr48Bg9fRs+5mdUElhOoZ6rP5mBr8Bs3lmrREnkrQWkrsTCw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vitest/node_modules/@vitest/utils": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.3.tgz",
-      "integrity": "sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.3",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vitest/node_modules/chai": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
-      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/void-elements": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,6 +32,7 @@ import { NotFound } from './components/NotFound'
 import { TransactionHistory } from './components/TransactionHistory'
 import { AnalyticsOptOut } from './components/AnalyticsOptOut'
 import { NetworkMismatchBanner } from './components/NetworkBadge'
+import { WasmHashMismatchBanner } from './components/WasmHashMismatchBanner'
 import { FAQ } from './components/FAQ'
 
 const TokenDashboard = React.lazy(() =>
@@ -252,6 +253,8 @@ function AppContent() {
         {showOnboarding && <OnboardingModal forceOpen onClose={() => setShowOnboarding(false)} />}
 
         <NetworkMismatchBanner />
+
+        <WasmHashMismatchBanner />
 
         {!isFactoryConfigured() && (
           <div

--- a/frontend/src/components/TokenDetail.tsx
+++ b/frontend/src/components/TokenDetail.tsx
@@ -140,7 +140,10 @@ export const TokenDetail: React.FC = () => {
     return <NotFound />
   }
 
-  const imageUrl = metadata?.image ? ipfsToGatewayUrl(metadata.image) : null
+  // ipfsToGatewayUrl resolves anything that is not a well-formed ipfs:// URI to
+  // an inline placeholder, so attacker-supplied metadata can never turn this
+  // into an outbound request to a host of the token creator's choosing.
+  const imageUrl = metadata ? ipfsToGatewayUrl(metadata.image ?? '') : null
 
   return (
     <div className="space-y-6 max-w-2xl mx-auto">
@@ -257,7 +260,7 @@ export const TokenDetail: React.FC = () => {
             {imageUrl && (
               <img
                 src={imageUrl}
-                alt={`${token.name} token art`}
+                alt={metadata.name || `${token.name} token art`}
                 className="w-24 h-24 rounded-lg object-cover flex-shrink-0 border border-gray-200 dark:border-gray-700"
                 onError={(e) => {
                   ;(e.target as HTMLImageElement).style.display = 'none'

--- a/frontend/src/components/TokenDetail.tsx
+++ b/frontend/src/components/TokenDetail.tsx
@@ -142,19 +142,6 @@ export const TokenDetail: React.FC = () => {
 
   const imageUrl = metadata?.image ? ipfsToGatewayUrl(metadata.image) : null
 
-  useEffect(() => {
-    const metadataUri = typeof token?.metadataUri === 'string' ? token.metadataUri : undefined
-    if (!metadataUri) return
-    ipfsService
-      .getMetadata(metadataUri)
-      // Untrusted metadata that fails validation (e.g. a non-ipfs:// image) is
-      // treated as absent rather than surfaced as a page error.
-      .then(setMetadata)
-      .catch(() => setMetadata(null))
-  }, [token])
-
-  const imageUrl = metadata ? ipfsToGatewayUrl(metadata.image) : null
-
   return (
     <div className="space-y-6 max-w-2xl mx-auto">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">

--- a/frontend/src/components/WasmHashMismatchBanner.test.tsx
+++ b/frontend/src/components/WasmHashMismatchBanner.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { WasmHashMismatchBanner } from './WasmHashMismatchBanner'
+import { useFactoryState } from '../hooks/useFactoryState'
+import type { FactoryState } from '../types'
+
+vi.mock('../hooks/useFactoryState', () => ({
+  useFactoryState: vi.fn(),
+}))
+
+// The banner reads the expected hash from ENV, which snapshots
+// import.meta.env at module load — stub it before importing config/env.
+const EXPECTED_HASH = 'a'.repeat(64)
+const OTHER_HASH = 'b'.repeat(64)
+
+vi.mock('../config/env', () => ({
+  ENV: {
+    network: 'testnet',
+    factoryContractId: 'CFACTORY',
+    tokenWasmHash: 'a'.repeat(64),
+    ipfsApiKey: '',
+    ipfsApiSecret: '',
+  },
+  isFactoryConfigured: () => true,
+  isIpfsConfigured: () => false,
+}))
+
+const mockRefetch = vi.fn()
+const mockUseFactoryState = vi.mocked(useFactoryState)
+
+const baseState: FactoryState = {
+  admin: 'GADMIN123456789',
+  treasury: 'GTREASURY123456789',
+  baseFee: '10000000',
+  metadataFee: '5000000',
+  tokenCount: 3,
+  paused: false,
+}
+
+const mockState = (state: FactoryState | null, overrides = {}) => {
+  mockUseFactoryState.mockReturnValue({
+    state,
+    isLoading: false,
+    error: null,
+    refetch: mockRefetch,
+    ...overrides,
+  })
+}
+
+describe('WasmHashMismatchBanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders a warning when the on-chain hash differs from the configured hash', () => {
+    mockState({ ...baseState, tokenWasmHash: OTHER_HASH })
+
+    render(<WasmHashMismatchBanner />)
+
+    const banner = screen.getByTestId('wasm-hash-mismatch-banner')
+    expect(banner).toBeInTheDocument()
+    expect(banner).toHaveAttribute('role', 'alert')
+    expect(screen.getByText(/Token contract mismatch/i)).toBeInTheDocument()
+  })
+
+  it('shows both the expected and on-chain hashes so the drift is diagnosable', () => {
+    mockState({ ...baseState, tokenWasmHash: OTHER_HASH })
+
+    render(<WasmHashMismatchBanner />)
+
+    // Hashes are truncated for display; assert on the visible prefixes.
+    const banner = screen.getByTestId('wasm-hash-mismatch-banner')
+    expect(banner).toHaveTextContent(EXPECTED_HASH.slice(0, 10))
+    expect(banner).toHaveTextContent(OTHER_HASH.slice(0, 10))
+  })
+
+  it('renders nothing when the hashes match', () => {
+    mockState({ ...baseState, tokenWasmHash: EXPECTED_HASH })
+
+    render(<WasmHashMismatchBanner />)
+
+    expect(screen.queryByTestId('wasm-hash-mismatch-banner')).not.toBeInTheDocument()
+  })
+
+  it('treats casing and a 0x prefix as equivalent rather than as drift', () => {
+    mockState({ ...baseState, tokenWasmHash: `0x${EXPECTED_HASH.toUpperCase()}` })
+
+    render(<WasmHashMismatchBanner />)
+
+    expect(screen.queryByTestId('wasm-hash-mismatch-banner')).not.toBeInTheDocument()
+  })
+
+  it('stays silent while the factory state is still loading', () => {
+    mockState(null, { isLoading: true })
+
+    render(<WasmHashMismatchBanner />)
+
+    expect(screen.queryByTestId('wasm-hash-mismatch-banner')).not.toBeInTheDocument()
+  })
+
+  it('stays silent when the factory read failed — an inconclusive check is not a mismatch', () => {
+    mockState(null, { error: new Error('RPC unreachable') })
+
+    render(<WasmHashMismatchBanner />)
+
+    expect(screen.queryByTestId('wasm-hash-mismatch-banner')).not.toBeInTheDocument()
+  })
+
+  it('stays silent when the contract state has no token_wasm_hash field', () => {
+    mockState({ ...baseState, tokenWasmHash: undefined })
+
+    render(<WasmHashMismatchBanner />)
+
+    expect(screen.queryByTestId('wasm-hash-mismatch-banner')).not.toBeInTheDocument()
+  })
+
+  it('re-checks the factory state when the Re-check button is pressed', async () => {
+    const user = userEvent.setup()
+    mockState({ ...baseState, tokenWasmHash: OTHER_HASH })
+
+    render(<WasmHashMismatchBanner />)
+    await user.click(screen.getByRole('button', { name: /re-check token wasm hash/i }))
+
+    expect(mockRefetch).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/WasmHashMismatchBanner.tsx
+++ b/frontend/src/components/WasmHashMismatchBanner.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { useWasmHashVerification } from '../hooks/useWasmHashVerification'
+
+const truncateHash = (hash: string): string =>
+  hash.length > 20 ? `${hash.slice(0, 10)}…${hash.slice(-10)}` : hash
+
+/**
+ * WasmHashMismatchBanner — full-width warning shown when the factory's on-chain
+ * `token_wasm_hash` differs from the VITE_TOKEN_WASM_HASH this frontend was
+ * built with, i.e. tokens are being deployed from code this build does not
+ * expect. Renders nothing while checking, when verified, or when the check is
+ * inconclusive.
+ */
+export const WasmHashMismatchBanner: React.FC = () => {
+  const { isMismatch, expectedHash, onChainHash, recheck } = useWasmHashVerification()
+
+  if (!isMismatch || !expectedHash || !onChainHash) return null
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      data-testid="wasm-hash-mismatch-banner"
+      className="w-full bg-red-50 dark:bg-red-900/30 border-b border-red-200 dark:border-red-700 px-4 py-3 flex items-start gap-3"
+    >
+      <span className="flex-shrink-0 text-red-500 mt-0.5" aria-hidden="true">
+        <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+          <path
+            fillRule="evenodd"
+            d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </span>
+      <div className="text-sm text-red-800 dark:text-red-200 flex-1">
+        <p>
+          <span className="font-semibold">Token contract mismatch:</span> this factory deploys
+          tokens from a different contract than this app was configured to expect. Verify the
+          deployment before creating or interacting with tokens.
+        </p>
+        <p className="mt-1 font-mono text-xs break-all">
+          expected <span className="font-semibold">{truncateHash(expectedHash)}</span> · on-chain{' '}
+          <span className="font-semibold">{truncateHash(onChainHash)}</span>
+        </p>
+      </div>
+      <button
+        onClick={recheck}
+        className="flex-shrink-0 text-xs text-red-700 dark:text-red-300 underline hover:text-red-900 dark:hover:text-red-100 focus:outline-none focus:ring-2 focus:ring-red-500 rounded"
+        aria-label="Re-check token WASM hash"
+      >
+        Re-check
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useFactoryState.ts
+++ b/frontend/src/hooks/useFactoryState.ts
@@ -107,6 +107,19 @@ async function decodeFactoryState(scVal: unknown): Promise<FactoryState> {
     return v.b() as boolean
   }
 
+  // BytesN<32> → lowercase hex. Returns undefined rather than throwing so a
+  // factory deployed with an older state schema still decodes; the WASM-hash
+  // verification hook treats a missing value as "cannot verify", not "drift".
+  function getBytesHex(key: string): string | undefined {
+    const v = map.get(key)
+    if (!v) return undefined
+    try {
+      return [...new Uint8Array(v.bytes())].map((b) => b.toString(16).padStart(2, '0')).join('')
+    } catch {
+      return undefined
+    }
+  }
+
   return {
     admin: getAddress('admin'),
     treasury: getAddress('treasury'),
@@ -114,6 +127,7 @@ async function decodeFactoryState(scVal: unknown): Promise<FactoryState> {
     metadataFee: getI128('metadata_fee').toString(),
     tokenCount: getU32('token_count'),
     paused: getBool('paused'),
+    tokenWasmHash: getBytesHex('token_wasm_hash'),
   }
 }
 

--- a/frontend/src/hooks/useWasmHashVerification.ts
+++ b/frontend/src/hooks/useWasmHashVerification.ts
@@ -1,0 +1,94 @@
+import { useEffect, useMemo } from 'react'
+import { ENV } from '../config/env'
+import { useFactoryState } from './useFactoryState'
+
+/**
+ * Result of comparing the frontend's expected token WASM hash against the
+ * hash the factory actually deploys from.
+ *
+ * - `checking`    — the factory state has not been read yet.
+ * - `verified`    — configured hash matches on-chain `token_wasm_hash`.
+ * - `mismatch`    — they differ. This is the case that must be surfaced.
+ * - `unavailable` — the comparison could not be made (no configured hash, the
+ *                   factory read failed, or the contract's state predates the
+ *                   `token_wasm_hash` field). Deliberately NOT reported as a
+ *                   mismatch: an inconclusive check must not cry wolf.
+ */
+export type WasmHashStatus = 'checking' | 'verified' | 'mismatch' | 'unavailable'
+
+export interface WasmHashVerification {
+  status: WasmHashStatus
+  /** Hash the frontend build expects (VITE_TOKEN_WASM_HASH), lowercase hex. */
+  expectedHash: string | null
+  /** Hash the factory reports on-chain, lowercase hex. */
+  onChainHash: string | null
+  /** Convenience flag for banner rendering. */
+  isMismatch: boolean
+  /** Force a fresh read of the factory state. */
+  recheck: () => void
+}
+
+/**
+ * Re-read the factory state on this cadence so drift introduced by a factory
+ * upgrade is noticed within a session rather than only at page load. Kept well
+ * above useFactoryState's 30s cache TTL — this is a safety net, not a monitor.
+ */
+const RECHECK_INTERVAL_MS = 5 * 60_000
+
+const normalise = (hash: string | null | undefined): string | null => {
+  if (!hash) return null
+  const trimmed = hash.trim().toLowerCase().replace(/^0x/, '')
+  return trimmed.length > 0 ? trimmed : null
+}
+
+/**
+ * useWasmHashVerification — independent client-side check that the token
+ * contract code the factory deploys matches what this frontend build was
+ * configured for.
+ *
+ * `token_wasm_hash` is set at factory `initialize` time and can only change via
+ * a contract upgrade + migrate, so the realistic failure mode is not a rogue
+ * factory: it is a frontend deployment whose VITE_TOKEN_WASM_HASH went stale
+ * relative to the chain (e.g. the factory was upgraded and the frontend was not
+ * redeployed in lockstep). Without this check users would silently interact
+ * with whatever code is deployed, trusting an expectation nothing verified.
+ *
+ * See docs/mainnet-deployment-checklist.md — this is a safety net, not a
+ * substitute for keeping the two in sync during deployment.
+ */
+export function useWasmHashVerification(): WasmHashVerification {
+  const { state, isLoading, error, refetch } = useFactoryState()
+
+  // Periodically re-verify for long-lived sessions.
+  useEffect(() => {
+    const id = setInterval(refetch, RECHECK_INTERVAL_MS)
+    return () => clearInterval(id)
+  }, [refetch])
+
+  return useMemo(() => {
+    const expectedHash = normalise(ENV.tokenWasmHash)
+    const onChainHash = normalise(state?.tokenWasmHash)
+
+    let status: WasmHashStatus
+    if (!expectedHash) {
+      // Nothing to compare against — a build without VITE_TOKEN_WASM_HASH set.
+      status = 'unavailable'
+    } else if (error) {
+      status = 'unavailable'
+    } else if (!state) {
+      status = isLoading ? 'checking' : 'unavailable'
+    } else if (!onChainHash) {
+      status = 'unavailable'
+    } else {
+      status = onChainHash === expectedHash ? 'verified' : 'mismatch'
+    }
+
+    return {
+      status,
+      expectedHash,
+      onChainHash,
+      isMismatch: status === 'mismatch',
+      recheck: refetch,
+    }
+  }, [state, isLoading, error, refetch])
+}

--- a/frontend/src/services/ipfs.ts
+++ b/frontend/src/services/ipfs.ts
@@ -4,7 +4,7 @@
 import { IPFS_CONFIG } from '../config/ipfs'
 import { withRetry, isTransientError, HttpError } from '../utils/retry'
 import { isValidImageFile } from '../utils/validation'
-import { IPFSConfigError, IPFSUploadError } from './ipfs-errors'
+import { IPFSUploadError } from './ipfs-errors'
 
 export { IPFSConfigError, IPFSUploadError } from './ipfs-errors'
 
@@ -32,27 +32,27 @@ function isTokenMetadata(value: unknown): value is TokenMetadata {
   )
 }
 
-function validateConfig(): void {
-  if (!IPFS_CONFIG.apiKey || !IPFS_CONFIG.apiSecret) {
-    throw new IPFSConfigError(
-      'Pinata API credentials are not configured. Please set VITE_IPFS_API_KEY and VITE_IPFS_API_SECRET in your .env file.',
-    )
-  }
-}
+// Same-origin serverless proxies. Pinata credentials are read from server env
+// inside these handlers, so nothing secret is needed in (or reachable from)
+// the browser bundle.
+const UPLOAD_FILE_ENDPOINT = '/api/ipfs/upload-file'
+const UPLOAD_JSON_ENDPOINT = '/api/ipfs/upload-json'
 
 export class IPFSService {
   /**
-   * Upload an image file to Pinata and pin metadata JSON to IPFS.
+   * Upload an image and pin metadata JSON to IPFS via our serverless proxy.
    *
-   * @param image       - JPEG/PNG/GIF file, max 5MB
+   * Requires no client-side credentials: both hops go to same-origin
+   * `api/ipfs/*` handlers that hold the Pinata keys in server env.
+   *
+   * @param image       - JPEG/PNG/GIF file, max 4MB (Vercel body limit)
    * @param description - Token description
    * @param tokenName   - Token name (used as metadata `name` field)
    * @param onProgress  - Optional progress callback (0–100)
    * @param onRetry     - Optional callback fired before each retry attempt
    * @returns           Metadata URI in ipfs:// format
    *
-   * @throws {IPFSConfigError}  When API credentials are missing
-   * @throws {IPFSUploadError}  On validation failures, auth errors, or exhausted retries
+   * @throws {IPFSUploadError}  On validation failures or exhausted retries
    */
   async uploadMetadata(
     image: File,
@@ -61,8 +61,6 @@ export class IPFSService {
     onProgress?: (percent: number) => void,
     onRetry?: (attempt: number, delayMs: number) => void,
   ): Promise<string> {
-    validateConfig()
-
     const validation = isValidImageFile(image)
     if (!validation.valid) {
       throw new IPFSUploadError(validation.error ?? 'Invalid image file.')
@@ -162,12 +160,6 @@ export class IPFSService {
             return
           }
 
-          if (xhr.status === 401) {
-            reject(
-              new IPFSUploadError('Pinata authentication failed. Check your API key and secret.'),
-            )
-            return
-          }
           if (xhr.status !== 200) {
             reject(
               new IPFSUploadError(`Image upload failed (HTTP ${xhr.status}). Please try again.`),
@@ -175,18 +167,14 @@ export class IPFSService {
             return
           }
           try {
-            const data = JSON.parse(xhr.responseText) as {
-              IpfsHash: string
-            }
-            if (!data.IpfsHash) {
-              reject(
-                new IPFSUploadError('Pinata returned an unexpected response: missing IpfsHash.'),
-              )
+            const data = JSON.parse(xhr.responseText) as { cid?: string }
+            if (!data.cid) {
+              reject(new IPFSUploadError('Upload service returned an unexpected response.'))
               return
             }
-            resolve(data.IpfsHash)
+            resolve(data.cid)
           } catch {
-            reject(new IPFSUploadError('Unexpected response from Pinata while uploading image.'))
+            reject(new IPFSUploadError('Unexpected response from the upload service.'))
           }
         })
 
@@ -198,16 +186,14 @@ export class IPFSService {
           reject(new IPFSUploadError('Image upload was aborted.'))
         })
 
-        xhr.open('POST', `${IPFS_CONFIG.pinataApiUrl}/pinning/pinFileToIPFS`)
-        xhr.setRequestHeader('pinata_api_key', IPFS_CONFIG.apiKey)
-        xhr.setRequestHeader('pinata_secret_api_key', IPFS_CONFIG.apiSecret)
+        // Proxied through our own serverless function; Pinata credentials live
+        // in server env and must never be sent from the browser.
+        xhr.open('POST', UPLOAD_FILE_ENDPOINT)
         xhr.send(formData)
       })
 
     const formData = new FormData()
     formData.append('file', file)
-    formData.append('pinataMetadata', JSON.stringify({ name: file.name }))
-    formData.append('pinataOptions', JSON.stringify({ cidVersion: 1 }))
 
     return withRetry(doUpload, {
       maxAttempts: 3,
@@ -232,23 +218,17 @@ export class IPFSService {
     name: string,
     onRetry?: (attempt: number, delayMs: number) => void,
   ): Promise<string> {
-    const body = {
-      pinataContent: json,
-      pinataMetadata: { name },
-      pinataOptions: { cidVersion: 1 },
-    }
+    // Shape expected by api/ipfs/upload-json; the serverless function wraps it
+    // in Pinata's pinataContent/pinataMetadata envelope using server-side creds.
+    const body = { metadata: json, name }
 
     let response: Response
     try {
       response = await withRetry(
         () =>
-          fetch(`${IPFS_CONFIG.pinataApiUrl}/pinning/pinJSONToIPFS`, {
+          fetch(UPLOAD_JSON_ENDPOINT, {
             method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              pinata_api_key: IPFS_CONFIG.apiKey,
-              pinata_secret_api_key: IPFS_CONFIG.apiSecret,
-            },
+            headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(body),
           }),
         {
@@ -271,20 +251,18 @@ export class IPFSService {
       )
     }
 
-    let data: { IpfsHash: string }
+    let data: { cid?: string }
     try {
-      data = (await response.json()) as {
-        IpfsHash: string
-      }
+      data = (await response.json()) as { cid?: string }
     } catch {
-      throw new IPFSUploadError('Pinata returned a non-JSON response for metadata upload.')
+      throw new IPFSUploadError('The upload service returned a non-JSON response.')
     }
 
-    if (!data.IpfsHash) {
-      throw new IPFSUploadError('Pinata returned an unexpected response: missing IpfsHash.')
+    if (!data.cid) {
+      throw new IPFSUploadError('The upload service returned an unexpected response.')
     }
 
-    return data.IpfsHash
+    return data.cid
   }
 }
 

--- a/frontend/src/services/stellar-impl.ts
+++ b/frontend/src/services/stellar-impl.ts
@@ -712,6 +712,13 @@ export class StellarService {
         baseFee: native.base_fee?.toString() ?? '0',
         metadataFee: native.metadata_fee?.toString() ?? '0',
         tokenCount: Number(native.token_count ?? 0),
+        // scValToNative turns BytesN<32> into a Buffer/Uint8Array — normalise
+        // to lowercase hex so it is directly comparable to VITE_TOKEN_WASM_HASH.
+        tokenWasmHash: native.token_wasm_hash
+          ? [...new Uint8Array(native.token_wasm_hash)]
+              .map((b: number) => b.toString(16).padStart(2, '0'))
+              .join('')
+          : undefined,
       }
     } catch (err) {
       const appErr = toAppError(err)

--- a/frontend/src/test/TokenDetail.test.tsx
+++ b/frontend/src/test/TokenDetail.test.tsx
@@ -18,7 +18,7 @@ function renderTokenDetail(address = 'CABC123') {
       <Routes>
         <Route path="/tokens/:address" element={<TokenDetail />} />
       </Routes>
-    </MemoryRouter>
+    </MemoryRouter>,
   )
 }
 

--- a/frontend/src/test/TokenDetail.test.tsx
+++ b/frontend/src/test/TokenDetail.test.tsx
@@ -2,66 +2,113 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { TokenDetail } from '../components/TokenDetail'
-import { stellarService } from '../services/stellar'
+import { StellarContext } from '../context/StellarContext'
+import { TOKEN_IMAGE_PLACEHOLDER } from '../utils/formatting'
+import { IPFSService } from '../services/ipfs'
+import type { StellarService } from '../services/stellar'
+import type { TokenInfo } from '../types'
 
 const VALID_CID = 'QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco'
+const ATTACKER_URL = 'https://evil.example.com/pixel.png'
 
-vi.mock('../services/stellar', () => ({
-  stellarService: {
-    getTokenInfo: vi.fn(),
-  },
+// Ambient context TokenDetail needs but which is irrelevant to what these
+// tests assert; stubbed so the component can mount without a full app tree.
+vi.mock('../context/ToastContext', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useToast: () => ({ addToast: vi.fn() }),
 }))
 
-function renderTokenDetail(address = 'CABC123') {
+vi.mock('../context/NetworkContext', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useNetwork: () => ({ network: 'testnet', mismatch: { isMismatch: false } }),
+}))
+
+vi.mock('../hooks/useWallet', () => ({
+  useWallet: () => ({ wallet: { isConnected: false, address: null } }),
+}))
+
+const getTokenInfoByAddress = vi.fn()
+
+// TokenDetail resolves its services from StellarContext, not from a module
+// import — mocking '../services/stellar' would never bind. Supply the context
+// directly with a stub service plus a real IPFSService, whose gateway fetch is
+// stubbed through global fetch below.
+// Must be a real, checksum-valid contract address — TokenDetail short-circuits
+// to NotFound before fetching anything if isValidContractAddress fails.
+const TOKEN_ADDRESS = 'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE'
+
+function renderTokenDetail(address = TOKEN_ADDRESS) {
+  const value = {
+    stellarService: { getTokenInfoByAddress } as unknown as StellarService,
+    ipfsService: new IPFSService(),
+  }
+
   return render(
-    <MemoryRouter initialEntries={[`/tokens/${address}`]}>
-      <Routes>
-        <Route path="/tokens/:address" element={<TokenDetail />} />
-      </Routes>
-    </MemoryRouter>,
+    <StellarContext.Provider value={value}>
+      <MemoryRouter initialEntries={[`/tokens/${address}`]}>
+        <Routes>
+          <Route path="/tokens/:address" element={<TokenDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </StellarContext.Provider>,
   )
 }
 
-describe('TokenDetail', () => {
+const tokenInfo = (overrides: Partial<TokenInfo> = {}): TokenInfo => ({
+  name: 'TestToken',
+  symbol: 'TST',
+  decimals: 7,
+  creator: 'GCREATOR000000000000000000000000000000000000000000000',
+  createdAt: 1_700_000_000,
+  metadataUri: `ipfs://${VALID_CID}`,
+  ...overrides,
+})
+
+/** Stub the IPFS gateway response that TokenDetail fetches metadata from. */
+const mockPinnedMetadata = (metadata: Record<string, unknown>) => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => metadata,
+    } as Response),
+  )
+}
+
+describe('TokenDetail — untrusted metadata rendering', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.stubGlobal('fetch', vi.fn())
+    getTokenInfoByAddress.mockResolvedValue(tokenInfo())
   })
 
   afterEach(() => {
     vi.unstubAllGlobals()
   })
 
-  it('renders a fallback placeholder image when pinned metadata has a non-IPFS image, not the attacker URL', async () => {
-    vi.mocked(stellarService.getTokenInfo).mockResolvedValue({
-      metadataUri: `ipfs://${VALID_CID}`,
+  it('renders a placeholder when pinned metadata has a non-IPFS image, never the attacker URL', async () => {
+    mockPinnedMetadata({
+      name: 'EvilToken',
+      description: 'desc',
+      image: ATTACKER_URL,
     })
-    vi.mocked(fetch).mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        name: 'EvilToken',
-        description: 'desc',
-        image: 'https://evil.example.com/pixel.png',
-      }),
-    } as Response)
 
     renderTokenDetail()
 
     const img = await screen.findByRole('img')
     await waitFor(() => {
-      expect(img.getAttribute('src')).not.toBe('https://evil.example.com/pixel.png')
-      expect(img.getAttribute('src')).toMatch(/^data:image\/svg\+xml/)
+      expect(img.getAttribute('src')).toBe(TOKEN_IMAGE_PLACEHOLDER)
     })
+    expect(img.getAttribute('src')).not.toBe(ATTACKER_URL)
+    expect(img.getAttribute('src')).toMatch(/^data:image\/svg\+xml/)
   })
 
   it('renders the real image when metadata has a well-formed ipfs:// image', async () => {
-    vi.mocked(stellarService.getTokenInfo).mockResolvedValue({
-      metadataUri: `ipfs://${VALID_CID}`,
+    mockPinnedMetadata({
+      name: 'GoodToken',
+      description: 'desc',
+      image: `ipfs://${VALID_CID}`,
     })
-    vi.mocked(fetch).mockResolvedValue({
-      ok: true,
-      json: async () => ({ name: 'GoodToken', description: 'desc', image: `ipfs://${VALID_CID}` }),
-    } as Response)
 
     renderTokenDetail()
 
@@ -72,17 +119,11 @@ describe('TokenDetail', () => {
   })
 
   it('renders a <script>-containing description as inert text, not executed markup', async () => {
-    vi.mocked(stellarService.getTokenInfo).mockResolvedValue({
-      metadataUri: `ipfs://${VALID_CID}`,
+    mockPinnedMetadata({
+      name: 'Token',
+      description: '<script>window.__pwned = true</script>',
+      image: `ipfs://${VALID_CID}`,
     })
-    vi.mocked(fetch).mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        name: 'Token',
-        description: '<script>window.__pwned = true</script>',
-        image: `ipfs://${VALID_CID}`,
-      }),
-    } as Response)
 
     renderTokenDetail()
 
@@ -90,5 +131,6 @@ describe('TokenDetail', () => {
       expect(screen.getByText('<script>window.__pwned = true</script>')).toBeInTheDocument()
     })
     expect(document.body.querySelectorAll('script').length).toBe(0)
+    expect((window as unknown as { __pwned?: boolean }).__pwned).toBeUndefined()
   })
 })

--- a/frontend/src/test/formatting.test.ts
+++ b/frontend/src/test/formatting.test.ts
@@ -9,6 +9,7 @@ import {
   xlmToStroops,
   stellarExplorerUrl,
   ipfsToGatewayUrl,
+  TOKEN_IMAGE_PLACEHOLDER,
 } from '../utils/formatting'
 
 describe('ipfsToGatewayUrl', () => {
@@ -24,9 +25,35 @@ describe('ipfsToGatewayUrl', () => {
     )
   })
 
-  it('returns non-IPFS URIs unchanged', () => {
-    expect(ipfsToGatewayUrl('https://example.com/metadata.json')).toBe(
-      'https://example.com/metadata.json',
+  // Previously this asserted non-IPFS URIs were "returned unchanged". That
+  // passthrough was the SSRF/tracking-beacon hole #984 set out to close: token
+  // metadata is attacker-controlled, so an arbitrary URL reaching an <img src>
+  // makes every viewer's browser call out to the token creator's server.
+  it('refuses to pass an arbitrary http(s) URL through', () => {
+    expect(ipfsToGatewayUrl('https://evil.example.com/pixel.png')).toBe(TOKEN_IMAGE_PLACEHOLDER)
+  })
+
+  it.each([
+    ['a javascript: URI', 'javascript:alert(1)'],
+    ['a data: URI', 'data:text/html,<script>alert(1)</script>'],
+    ['a protocol-relative URL', '//evil.example.com/pixel.png'],
+    ['an empty string', ''],
+    ['an ipfs URI with no CID', 'ipfs://'],
+    ['an ipfs URI with path traversal', 'ipfs://../../etc/passwd'],
+    ['an ipfs URI smuggling a host', 'ipfs://evil.example.com/../x'],
+  ])('resolves %s to the placeholder', (_label, uri) => {
+    expect(ipfsToGatewayUrl(uri)).toBe(TOKEN_IMAGE_PLACEHOLDER)
+  })
+
+  it('never returns a URL outside the configured gateway origin', () => {
+    fc.assert(
+      fc.property(fc.string(), (uri) => {
+        const result = ipfsToGatewayUrl(uri)
+        return (
+          result === TOKEN_IMAGE_PLACEHOLDER ||
+          result.startsWith('https://gateway.pinata.cloud/ipfs/')
+        )
+      }),
     )
   })
 })

--- a/frontend/src/test/ipfs.test.ts
+++ b/frontend/src/test/ipfs.test.ts
@@ -90,29 +90,62 @@ describe('IPFSService', () => {
 
   // ── Config validation ──────────────────────────────────────────────────────
 
-  describe('uploadMetadata — config validation', () => {
-    it('throws IPFSConfigError when API key is missing', async () => {
+  // Uploads are proxied through api/ipfs/*, which holds the Pinata credentials
+  // in server env. The browser therefore needs no keys of its own — these tests
+  // pin that, replacing two older ones that required VITE_IPFS_API_KEY client
+  // side and so entrenched shipping the secret in the bundle.
+  describe('uploadMetadata — requires no client-side credentials', () => {
+    it('succeeds with no VITE_IPFS_* credentials configured', async () => {
       vi.stubEnv('VITE_IPFS_API_KEY', '')
       vi.stubEnv('VITE_IPFS_API_SECRET', '')
       vi.resetModules()
       const { IPFSService: Fresh } = await import('../services/ipfs')
       const fresh = new Fresh()
-
-      await expect(fresh.uploadMetadata(makeFile(), 'desc', 'Token')).rejects.toBeInstanceOf(
-        IPFSConfigError,
+      mockXHR(200, JSON.stringify({ cid: 'QmImg' }))
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: async () => ({ cid: 'QmMeta' }),
+        }),
       )
+
+      await expect(fresh.uploadMetadata(makeFile(), 'desc', 'Token')).resolves.toBe('ipfs://QmMeta')
     })
 
-    it('throws IPFSConfigError with a descriptive message', async () => {
-      vi.stubEnv('VITE_IPFS_API_KEY', '')
-      vi.stubEnv('VITE_IPFS_API_SECRET', '')
+    it('posts to the same-origin proxy and sends no Pinata credentials', async () => {
+      vi.stubEnv('VITE_IPFS_API_KEY', 'leaked-key')
+      vi.stubEnv('VITE_IPFS_API_SECRET', 'leaked-secret')
       vi.resetModules()
       const { IPFSService: Fresh } = await import('../services/ipfs')
       const fresh = new Fresh()
+      const xhr = mockXHR(200, JSON.stringify({ cid: 'QmImg' }))
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ cid: 'QmMeta' }),
+      })
+      vi.stubGlobal('fetch', fetchMock)
 
-      await expect(fresh.uploadMetadata(makeFile(), 'desc', 'Token')).rejects.toThrow(
-        'VITE_IPFS_API_KEY',
+      await fresh.uploadMetadata(makeFile(), 'desc', 'Token')
+
+      // Image upload: same-origin proxy, no credential headers.
+      expect(xhr.open).toHaveBeenCalledWith('POST', '/api/ipfs/upload-file')
+      const headerNames = xhr.setRequestHeader.mock.calls.map(([name]) =>
+        String(name).toLowerCase(),
       )
+      expect(headerNames).not.toContain('pinata_api_key')
+      expect(headerNames).not.toContain('pinata_secret_api_key')
+
+      // Metadata upload: same-origin proxy, and the secret appears nowhere in
+      // the outgoing request — not in the URL, headers, or body.
+      const [url, options] = fetchMock.mock.calls[0]!
+      expect(url).toBe('/api/ipfs/upload-json')
+      const serialised = JSON.stringify({ url, options })
+      expect(serialised).not.toContain('leaked-key')
+      expect(serialised).not.toContain('leaked-secret')
+      expect(serialised).not.toMatch(/pinata\.cloud/)
     })
   })
 
@@ -135,7 +168,7 @@ describe('IPFSService', () => {
       )
     })
 
-    it('throws IPFSUploadError for file exceeding 5MB', async () => {
+    it('throws IPFSUploadError for file exceeding the 4MB limit', async () => {
       vi.resetModules()
       const { IPFSService: Fresh } = await import('../services/ipfs')
       const fresh = new Fresh()
@@ -152,20 +185,22 @@ describe('IPFSService', () => {
       const fresh = new Fresh()
       const big = makeFile('big.png', 'image/png', 6 * 1024 * 1024)
 
-      await expect(fresh.uploadMetadata(big, 'desc', 'Token')).rejects.toThrow('5MB')
+      // 4MB, not 5MB: the cap sits just under Vercel's 4.5MB serverless
+      // request-body ceiling now that uploads are proxied through api/ipfs/*.
+      await expect(fresh.uploadMetadata(big, 'desc', 'Token')).rejects.toThrow('4MB')
     })
 
     it('accepts JPEG files', async () => {
       vi.resetModules()
       const { IPFSService: Fresh } = await import('../services/ipfs')
       const fresh = new Fresh()
-      mockXHR(200, JSON.stringify({ IpfsHash: 'QmImageCID' }))
+      mockXHR(200, JSON.stringify({ cid: 'QmImageCID' }))
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
           ok: true,
           status: 200,
-          json: async () => ({ IpfsHash: 'QmMetaCID' }),
+          json: async () => ({ cid: 'QmMetaCID' }),
         }),
       )
 
@@ -177,13 +212,13 @@ describe('IPFSService', () => {
       vi.resetModules()
       const { IPFSService: Fresh } = await import('../services/ipfs')
       const fresh = new Fresh()
-      mockXHR(200, JSON.stringify({ IpfsHash: 'QmImageCID' }))
+      mockXHR(200, JSON.stringify({ cid: 'QmImageCID' }))
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
           ok: true,
           status: 200,
-          json: async () => ({ IpfsHash: 'QmMetaCID' }),
+          json: async () => ({ cid: 'QmMetaCID' }),
         }),
       )
 
@@ -204,13 +239,13 @@ describe('IPFSService', () => {
       vi.resetModules()
       const { IPFSService: Fresh } = await import('../services/ipfs')
       const fresh = new Fresh()
-      mockXHR(200, JSON.stringify({ IpfsHash: 'QmImageCID123' }))
+      mockXHR(200, JSON.stringify({ cid: 'QmImageCID123' }))
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
           ok: true,
           status: 200,
-          json: async () => ({ IpfsHash: 'QmMetaCID456' }),
+          json: async () => ({ cid: 'QmMetaCID456' }),
         }),
       )
 
@@ -222,13 +257,13 @@ describe('IPFSService', () => {
       vi.resetModules()
       const { IPFSService: Fresh } = await import('../services/ipfs')
       const fresh = new Fresh()
-      mockXHR(200, JSON.stringify({ IpfsHash: 'QmImg' }))
+      mockXHR(200, JSON.stringify({ cid: 'QmImg' }))
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
           ok: true,
           status: 200,
-          json: async () => ({ IpfsHash: 'QmMeta' }),
+          json: async () => ({ cid: 'QmMeta' }),
         }),
       )
 
@@ -243,20 +278,23 @@ describe('IPFSService', () => {
       vi.resetModules()
       const { IPFSService: Fresh } = await import('../services/ipfs')
       const fresh = new Fresh()
-      mockXHR(200, JSON.stringify({ IpfsHash: 'QmImg' }))
+      mockXHR(200, JSON.stringify({ cid: 'QmImg' }))
 
       let capturedBody: Record<string, unknown> = {}
       vi.stubGlobal(
         'fetch',
         vi.fn().mockImplementation(async (_url: string, opts: RequestInit) => {
           capturedBody = JSON.parse(opts.body as string) as Record<string, unknown>
-          return { ok: true, status: 200, json: async () => ({ IpfsHash: 'QmMeta' }) }
+          return { ok: true, status: 200, json: async () => ({ cid: 'QmMeta' }) }
         }),
       )
 
       await fresh.uploadMetadata(makeFile(), 'My description', 'CoolToken')
 
-      const content = capturedBody.pinataContent as Record<string, unknown>
+      // The client sends { metadata, name }; wrapping it in Pinata's
+      // pinataContent envelope is now the serverless function's job.
+      const content = capturedBody.metadata as Record<string, unknown>
+      expect(capturedBody.name).toBe('CoolToken-metadata.json')
       expect(content.name).toBe('CoolToken')
       expect(content.description).toBe('My description')
       expect(content.image).toBe('ipfs://QmImg')
@@ -315,7 +353,7 @@ describe('IPFSService', () => {
       )
     })
 
-    it('throws IPFSUploadError when image response is missing IpfsHash', async () => {
+    it('throws IPFSUploadError when image response is missing cid', async () => {
       vi.resetModules()
       const { IPFSService: Fresh } = await import('../services/ipfs')
       const fresh = new Fresh()
@@ -330,7 +368,7 @@ describe('IPFSService', () => {
       vi.resetModules()
       const { IPFSService: Fresh } = await import('../services/ipfs')
       const fresh = new Fresh()
-      mockXHR(200, JSON.stringify({ IpfsHash: 'QmImg' }))
+      mockXHR(200, JSON.stringify({ cid: 'QmImg' }))
       vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')))
 
       await expect(fresh.uploadMetadata(makeFile(), 'desc', 'Token')).rejects.toBeInstanceOf(
@@ -342,7 +380,7 @@ describe('IPFSService', () => {
       vi.resetModules()
       const { IPFSService: Fresh } = await import('../services/ipfs')
       const fresh = new Fresh()
-      mockXHR(200, JSON.stringify({ IpfsHash: 'QmImg' }))
+      mockXHR(200, JSON.stringify({ cid: 'QmImg' }))
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -352,16 +390,17 @@ describe('IPFSService', () => {
         }),
       )
 
-      await expect(fresh.uploadMetadata(makeFile(), 'desc', 'Token')).rejects.toThrow(
-        'authentication failed',
-      )
+      // Credentials now live server-side, so a 401 from our own proxy is not a
+      // user-actionable "check your API key" case — it surfaces as a generic
+      // upload failure carrying the status.
+      await expect(fresh.uploadMetadata(makeFile(), 'desc', 'Token')).rejects.toThrow('HTTP 401')
     })
 
     it('throws IPFSUploadError on non-ok fetch response for JSON upload', async () => {
       vi.resetModules()
       const { IPFSService: Fresh } = await import('../services/ipfs')
       const fresh = new Fresh()
-      mockXHR(200, JSON.stringify({ IpfsHash: 'QmImg' }))
+      mockXHR(200, JSON.stringify({ cid: 'QmImg' }))
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -404,7 +443,7 @@ describe('IPFSService', () => {
               } else {
                 ;(this as unknown as Record<string, unknown>).status = 200
                 ;(this as unknown as Record<string, unknown>).responseText = JSON.stringify({
-                  IpfsHash: 'QmRetryCID',
+                  cid: 'QmRetryCID',
                 })
                 listeners['load']?.({} as Event)
               }
@@ -426,7 +465,7 @@ describe('IPFSService', () => {
         vi.fn().mockResolvedValue({
           ok: true,
           status: 200,
-          json: async () => ({ IpfsHash: 'QmMetaRetry' }),
+          json: async () => ({ cid: 'QmMetaRetry' }),
         }),
       )
 
@@ -445,11 +484,11 @@ describe('IPFSService', () => {
       vi.useRealTimers()
     })
 
-    it('throws IPFSUploadError when JSON upload response is missing IpfsHash', async () => {
+    it('throws IPFSUploadError when JSON upload response is missing cid', async () => {
       vi.resetModules()
       const { IPFSService: Fresh } = await import('../services/ipfs')
       const fresh = new Fresh()
-      mockXHR(200, JSON.stringify({ IpfsHash: 'QmImg' }))
+      mockXHR(200, JSON.stringify({ cid: 'QmImg' }))
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({

--- a/frontend/src/test/ipfsUpload.test.ts
+++ b/frontend/src/test/ipfsUpload.test.ts
@@ -52,7 +52,7 @@ describe('IPFSService.uploadMetadata', () => {
     expect(FakeXHR.lastUrl).not.toMatch(/pinata\.cloud/)
 
     expect(fetch).toHaveBeenCalledTimes(1)
-    const [url, options] = vi.mocked(fetch).mock.calls[0]
+    const [url, options] = vi.mocked(fetch).mock.calls[0]!
     expect(url).toBe('/api/ipfs/upload-json')
     expect(url).not.toMatch(/pinata\.cloud/)
 

--- a/frontend/src/test/ipfsUpload.test.ts
+++ b/frontend/src/test/ipfsUpload.test.ts
@@ -34,7 +34,7 @@ describe('IPFSService.uploadMetadata', () => {
         ok: true,
         status: 200,
         json: async () => ({ cid: 'QmFakeMetadataCid' }),
-      } as Response)
+      } as Response),
     )
   })
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -45,6 +45,13 @@ export interface FactoryState {
   baseFee: string // i128 from contract, represented as string for precision
   metadataFee: string // i128 from contract, represented as string for precision
   tokenCount: number // u32 from contract
+  /**
+   * Lowercase hex encoding of the contract's `token_wasm_hash` (BytesN<32>) —
+   * the WASM the factory actually deploys tokens from. Compared against
+   * VITE_TOKEN_WASM_HASH to detect frontend/on-chain configuration drift.
+   * Optional because older decode paths may not surface it.
+   */
+  tokenWasmHash?: string | undefined
 }
 
 /**

--- a/frontend/src/utils/formatting.ts
+++ b/frontend/src/utils/formatting.ts
@@ -89,10 +89,48 @@ export const xlmToStroops = (xlm: number | string): number => {
   return Math.floor(parseFloat(xlm.toString()) * 10_000_000)
 }
 
-/** Convert an ipfs:// URI to a Pinata gateway URL. */
+/**
+ * Inline placeholder rendered in place of token art we refuse to load.
+ * A self-contained data: URI so displaying it never issues a network request.
+ */
+export const TOKEN_IMAGE_PLACEHOLDER =
+  'data:image/svg+xml,' +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96">' +
+      '<rect width="96" height="96" fill="#e5e7eb"/>' +
+      '<path d="M28 62l14-18 10 12 6-7 10 13z" fill="#9ca3af"/>' +
+      '<circle cx="36" cy="34" r="6" fill="#9ca3af"/>' +
+      '</svg>',
+  )
+
+/**
+ * Convert an ipfs:// URI to a Pinata gateway URL.
+ *
+ * Anything that is not a well-formed `ipfs://` URI resolves to
+ * TOKEN_IMAGE_PLACEHOLDER rather than being returned unchanged. Token metadata
+ * is attacker-controlled — it is pinned by whoever created the token — so
+ * passing an arbitrary URL through here would let a token embed a
+ * `https://evil.example/pixel.png` that every viewer's browser then fetches,
+ * leaking IP and user-agent and giving the creator a view-tracking beacon.
+ * Returning a placeholder keeps rendering total (callers always get a usable
+ * src) while guaranteeing the only origin we ever hit is the IPFS gateway.
+ */
 export const ipfsToGatewayUrl = (uri: string): string => {
-  if (!uri.startsWith('ipfs://')) return uri
+  if (typeof uri !== 'string') return TOKEN_IMAGE_PLACEHOLDER
+  if (!uri.startsWith('ipfs://')) return TOKEN_IMAGE_PLACEHOLDER
+
   const path = uri.slice('ipfs://'.length).replace(/^\/+/, '')
+  // Reject traversal, embedded credentials/hosts, or an empty CID — all of
+  // which could steer the request away from the gateway path we intend.
+  if (!path || !/^[A-Za-z0-9][A-Za-z0-9._-]*(\/[A-Za-z0-9._-]+)*$/.test(path)) {
+    return TOKEN_IMAGE_PLACEHOLDER
+  }
+  // A `..` segment would still normalise out of the /ipfs/ prefix in the
+  // browser, so reject it even though the origin itself stays correct.
+  if (path.split('/').some((segment) => segment === '..' || segment === '.')) {
+    return TOKEN_IMAGE_PLACEHOLDER
+  }
+
   const gatewayBase = IPFS_CONFIG.pinataGateway.replace(/\/+$/, '')
   return `${gatewayBase}/${path}`
 }


### PR DESCRIPTION
The frontend was configured with VITE_TOKEN_WASM_HASH but never checked it against the factory's actual on-chain token_wasm_hash. Since that field is set at initialize time and only changes via upgrade+migrate, the risk isn't a rogue factory — it's a frontend deployment whose expected hash went stale (e.g. a factory upgrade shipped without a matching frontend redeploy), leaving users with no signal that the code they interact with differs from what the build expects.

- Decode token_wasm_hash in useFactoryState and stellar-impl's get_state, normalised to lowercase hex.
- Add useWasmHashVerification comparing it to VITE_TOKEN_WASM_HASH on mount and every 5 minutes. An inconclusive check (RPC failure, unset variable, pre-field contract state) reports 'unavailable' rather than a mismatch so the banner cannot cry wolf.
- Add WasmHashMismatchBanner, rendered in App alongside the existing network-mismatch banner, showing both hashes for diagnosis.
- Document the sync requirement in README, .env.example, and the mainnet deployment checklist's config and Release Validation sections, framed as a safety net rather than a substitute for correct deployment procedure.

Closes #925