### PR TITLE
fix(frontend): resolve token identity from contract views, not events (#1018)

### DIFF
--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -1110,6 +1110,60 @@ impl TokenFactory {
             .ok_or(Error::TokenNotFound)
     }
 
+    /// Resolve a token's storage index from its contract address.
+    ///
+    /// The `TokenIndex(address)` mapping is written by `create_token` /
+    /// `create_tokens_batch` when a token is registered, so this is the
+    /// authoritative address → index lookup. Returns `TokenNotFound` when the
+    /// address was never registered with this factory.
+    ///
+    /// This exists so off-chain clients can resolve a token's identity in O(1)
+    /// from its address alone, rather than re-deriving it from the factory's
+    /// event stream — which only reflects a bounded RPC retention window and
+    /// silently truncates once history exceeds one page.
+    pub fn get_token_index(env: Env, token_address: Address) -> Result<u32, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::TokenIndex(token_address))
+            .ok_or(Error::TokenNotFound)
+    }
+
+    /// Return a token's full `TokenInfo` addressed by its contract address.
+    ///
+    /// Equivalent to `get_token_info(get_token_index(address))` but in a single
+    /// call. This is the source of truth for a token's name, symbol, decimals,
+    /// creator and creation time — clients must prefer it over event-derived
+    /// data, which cannot be trusted for tokens created outside the RPC's
+    /// event-retention window. Returns `TokenNotFound` for unregistered
+    /// addresses.
+    pub fn get_token_info_by_address(
+        env: Env,
+        token_address: Address,
+    ) -> Result<TokenInfo, Error> {
+        let index: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TokenIndex(token_address))
+            .ok_or(Error::TokenNotFound)?;
+        env.storage()
+            .instance()
+            .get(&DataKey::TokenInfo(index))
+            .ok_or(Error::TokenNotFound)
+    }
+
+    /// Return the metadata URI set for a token, or `None` if none was set.
+    ///
+    /// Metadata is written by `set_metadata` and stored under
+    /// `DataKey::Metadata(address)`. Exposing it as a view lets clients read
+    /// the current URI directly from contract state instead of scanning `meta`
+    /// events, which are subject to the same retention truncation as every
+    /// other event.
+    pub fn get_metadata(env: Env, token_address: Address) -> Option<String> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Metadata(token_address))
+    }
+
     /// Return a paginated slice of token indices for `creator`.
     ///
     /// `offset` is the 0-based index of the first element to return, and

--- a/contracts/token-factory/src/test.rs
+++ b/contracts/token-factory/src/test.rs
@@ -1154,6 +1154,110 @@ fn test_get_token_info_not_found() {
     );
 }
 
+// ── get_token_index / get_token_info_by_address / get_metadata ────────────────
+
+#[test]
+fn test_get_token_index_resolves_registered_address() {
+    let s = Setup::new();
+    let creator = Address::generate(&s.env);
+    let token_addr = seed_token(&s, &creator, true, None);
+    // seed_token increments token_count starting from 1, so this is index 1.
+    assert_eq!(s.client.get_token_index(&token_addr), 1);
+}
+
+#[test]
+fn test_get_token_index_not_found_for_unregistered_address() {
+    let s = Setup::new();
+    let stranger = Address::generate(&s.env);
+    assert_eq!(
+        s.client.try_get_token_index(&stranger),
+        Err(Ok(Error::TokenNotFound))
+    );
+}
+
+/// Regression for #1018: a token's identity must resolve from its address via
+/// the contract regardless of how old it is or how many events came after it.
+/// Event-derived lookups dropped tokens created beyond the first event page and
+/// fabricated placeholder data (address-as-name, guessed decimals); the on-chain
+/// index has no such window.
+#[test]
+fn test_get_token_info_by_address_returns_authoritative_identity() {
+    let s = Setup::new();
+    let creator = Address::generate(&s.env);
+    let token_addr = s.new_token(&creator);
+    let info = TokenInfo {
+        name: String::from_str(&s.env, "AncientToken"),
+        symbol: String::from_str(&s.env, "OLD"),
+        decimals: 12,
+        creator: creator.clone(),
+        created_at: 42,
+        burn_enabled: false,
+        max_supply: Some(1_000_000),
+    };
+    s.env.as_contract(&s.client.address, || {
+        s.env.storage().instance().set(&DataKey::TokenInfo(7), &info);
+        s.env
+            .storage()
+            .instance()
+            .set(&DataKey::TokenIndex(token_addr.clone()), &7u32);
+    });
+
+    let resolved = s.client.get_token_info_by_address(&token_addr);
+    assert_eq!(resolved.name, String::from_str(&s.env, "AncientToken"));
+    assert_eq!(resolved.symbol, String::from_str(&s.env, "OLD"));
+    assert_eq!(resolved.decimals, 12);
+    assert_eq!(resolved.creator, creator);
+    assert_eq!(resolved.created_at, 42);
+    assert_eq!(resolved.max_supply, Some(1_000_000));
+}
+
+#[test]
+fn test_get_token_info_by_address_not_found() {
+    let s = Setup::new();
+    let stranger = Address::generate(&s.env);
+    assert_eq!(
+        s.client.try_get_token_info_by_address(&stranger),
+        Err(Ok(Error::TokenNotFound))
+    );
+}
+
+/// A registered `TokenIndex` whose `TokenInfo` entry is missing must surface
+/// as `TokenNotFound` rather than trapping.
+#[test]
+fn test_get_token_info_by_address_missing_info_entry() {
+    let s = Setup::new();
+    let token_addr = s.new_token(&Address::generate(&s.env));
+    s.env.as_contract(&s.client.address, || {
+        s.env
+            .storage()
+            .instance()
+            .set(&DataKey::TokenIndex(token_addr.clone()), &99u32);
+    });
+    assert_eq!(
+        s.client.try_get_token_info_by_address(&token_addr),
+        Err(Ok(Error::TokenNotFound))
+    );
+}
+
+#[test]
+fn test_get_metadata_none_before_set_then_some_after() {
+    let s = Setup::new();
+    let creator = Address::generate(&s.env);
+    let token_addr = seed_token(&s, &creator, true, None);
+
+    assert_eq!(s.client.get_metadata(&token_addr), None);
+
+    let uri = String::from_str(&s.env, "ipfs://QmMeta");
+    s.env.as_contract(&s.client.address, || {
+        s.env
+            .storage()
+            .instance()
+            .set(&DataKey::Metadata(token_addr.clone()), &uri);
+    });
+
+    assert_eq!(s.client.get_metadata(&token_addr), Some(uri));
+}
+
 #[test]
 fn test_get_tokens_by_creator() {
     let s = Setup::new();

--- a/docs/contract-abi.md
+++ b/docs/contract-abi.md
@@ -6,14 +6,14 @@ The contract binary is built as `token_factory.wasm` (released alongside the fro
 
 ## Conventions
 
-| Soroban | TypeScript |
-|---|---|
-| `Address` | `string` (Stellar `G...` or contract `C...`) |
-| `u32` | `number` |
-| `u64` | `number` (lossy above `Number.MAX_SAFE_INTEGER`) |
-| `i128` | `string` (decimal) |
-| `Vec<T>` | `T[]` |
-| `Option<T>` | `T \| undefined` |
+| Soroban     | TypeScript                                       |
+| ----------- | ------------------------------------------------ |
+| `Address`   | `string` (Stellar `G...` or contract `C...`)     |
+| `u32`       | `number`                                         |
+| `u64`       | `number` (lossy above `Number.MAX_SAFE_INTEGER`) |
+| `i128`      | `string` (decimal)                               |
+| `Vec<T>`    | `T[]`                                            |
+| `Option<T>` | `T \| undefined`                                 |
 
 ## Initialization
 
@@ -21,14 +21,14 @@ The contract binary is built as `token_factory.wasm` (released alongside the fro
 
 One-time setup. Fails with `Error::AlreadyInitialized` on retry.
 
-| Param | Type | Description |
-|---|---|---|
-| `admin` | `Address` | Authority for upgrades, fee updates, pause, and admin transfer. |
-| `treasury` | `Address` | Default recipient of factory fees. |
-| `fee_token` | `Address` | SEP-41 token used for fee payments. |
-| `token_wasm_hash` | `BytesN<32>` | Hash of the token-contract WASM deployed for each new token. |
-| `base_fee` | `i128` | Fee charged for `create_token`, `mint_tokens`, `create_tokens_batch`. **Must be ≥ 0.** |
-| `metadata_fee` | `i128` | Fee charged for `set_metadata`. **Must be ≥ 0.** |
+| Param             | Type         | Description                                                                            |
+| ----------------- | ------------ | -------------------------------------------------------------------------------------- |
+| `admin`           | `Address`    | Authority for upgrades, fee updates, pause, and admin transfer.                        |
+| `treasury`        | `Address`    | Default recipient of factory fees.                                                     |
+| `fee_token`       | `Address`    | SEP-41 token used for fee payments.                                                    |
+| `token_wasm_hash` | `BytesN<32>` | Hash of the token-contract WASM deployed for each new token.                           |
+| `base_fee`        | `i128`       | Fee charged for `create_token`, `mint_tokens`, `create_tokens_batch`. **Must be ≥ 0.** |
+| `metadata_fee`    | `i128`       | Fee charged for `set_metadata`. **Must be ≥ 0.**                                       |
 
 **Fee sign constraint:** Both `base_fee` and `metadata_fee` must be **≥ 0**. A value of `0` is explicitly permitted (free token creation is a valid use-case). Any negative value is rejected with `Error::InvalidParameters` before any state is written. This constraint exists because:
 
@@ -51,25 +51,25 @@ Atomically deploy `tokens` (a `Vec<BatchTokenParams>`). Requires `fee_payment >=
 
 Soroban transactions are subject to per-transaction resource budgets enforced by the ledger. Exceeding these limits causes an immediate `ExceededLimit` error and costs the full simulation fee — the user never gets a refund.
 
-The table below shows measured CPU instructions and memory bytes consumed by `create_tokens_batch` at representative batch sizes. Numbers were obtained by running the benchmark harness in `contracts/token-factory/src/bench.rs` via `cargo test bench_ -- --nocapture` and comparing against the Soroban mainnet resource limits. **Important:** the Soroban native test environment underestimates real WASM CPU instruction counts (~30×) and memory (~5×) compared to an actual on-chain simulation, so the values below are used for *relative* regression detection — the production limits column reflects real network values.
+The table below shows measured CPU instructions and memory bytes consumed by `create_tokens_batch` at representative batch sizes. Numbers were obtained by running the benchmark harness in `contracts/token-factory/src/bench.rs` via `cargo test bench_ -- --nocapture` and comparing against the Soroban mainnet resource limits. **Important:** the Soroban native test environment underestimates real WASM CPU instruction counts (~30×) and memory (~5×) compared to an actual on-chain simulation, so the values below are used for _relative_ regression detection — the production limits column reflects real network values.
 
-| Batch size | Test-env CPU (M insns) | Test-env Mem (MB) | Ledger reads | Ledger writes | Within mainnet limits? |
-|:---:|---:|---:|---:|---:|:---:|
-| 1  | ~0.65 M  | ~1.1 MB  |  6 |  6 | ✅ |
-| 5  | ~2.5 M   | ~4.3 MB  | 18 | 18 | ✅ |
-| 10 | ~4.9 M   | ~8.6 MB  | 33 | 33 | ✅ |
-| 15 | ~7.3 M   | ~13 MB   | 48 | 48 | ✅ |
-| 20 | ~9.7 M   | ~17 MB   | 63 | 63 | ✅ ← **recommended max** |
-| 25 | ~12 M    | ~22 MB   | 78 | 78 | ⚠️ approaches write limit |
+| Batch size | Test-env CPU (M insns) | Test-env Mem (MB) | Ledger reads | Ledger writes |  Within mainnet limits?   |
+| :--------: | ---------------------: | ----------------: | -----------: | ------------: | :-----------------------: |
+|     1      |                ~0.65 M |           ~1.1 MB |            6 |             6 |            ✅             |
+|     5      |                 ~2.5 M |           ~4.3 MB |           18 |            18 |            ✅             |
+|     10     |                 ~4.9 M |           ~8.6 MB |           33 |            33 |            ✅             |
+|     15     |                 ~7.3 M |            ~13 MB |           48 |            48 |            ✅             |
+|     20     |                 ~9.7 M |            ~17 MB |           63 |            63 | ✅ ← **recommended max**  |
+|     25     |                  ~12 M |            ~22 MB |           78 |            78 | ⚠️ approaches write limit |
 
 **Current Soroban per-transaction limits (Stellar Protocol 21+, mainnet):**
 
-| Resource | Mainnet limit |
-|---|---|
-| CPU instructions | 600 000 000 (600 M) |
-| Memory | 41 943 040 bytes (40 MB) |
-| Ledger entries (read) | 100 per transaction |
-| Ledger entries (write) | 50 per transaction |
+| Resource               | Mainnet limit            |
+| ---------------------- | ------------------------ |
+| CPU instructions       | 600 000 000 (600 M)      |
+| Memory                 | 41 943 040 bytes (40 MB) |
+| Ledger entries (read)  | 100 per transaction      |
+| Ledger entries (write) | 50 per transaction       |
 
 > **Note:** The test-harness numbers above are native Rust measurements. Actual on-chain WASM costs are ~30× higher for CPU and ~5× higher for memory. At batch size 20 the extrapolated WASM-equivalent values are approximately 290 M CPU instructions and 85 MB memory — comfortably within the 600 M CPU limit but approaching the 40 MB memory limit. This provides a margin of ~52 % on CPU and ~0 % margin on memory at the extrapolated scale, which is why **20 is the recommended cap** rather than a higher number.
 >
@@ -117,27 +117,39 @@ Current set-metadata fee.
 
 Look up a single token by 1-based index. Returns `Error::TokenNotFound` for unknown indices.
 
+### `get_token_index(token_address) → u32`
+
+Resolve a token's 1-based storage index from its contract address, via the `TokenIndex(address)` mapping written at creation. Returns `Error::TokenNotFound` for addresses not registered with this factory. This is the authoritative address → index lookup — clients must not re-derive identity from the factory event stream, which only reflects a bounded RPC retention window.
+
+### `get_token_info_by_address(token_address) → TokenInfo`
+
+Return a token's full `TokenInfo` addressed by its contract address — equivalent to `get_token_info(get_token_index(address))` in a single call. This is the **source of truth** for a token's name, symbol, decimals, creator and creation time; unlike event-derived data it is unaffected by RPC event retention, so a token created arbitrarily long ago still resolves correctly. Returns `Error::TokenNotFound` for unregistered addresses (including the case where the index mapping exists but the `TokenInfo` entry is missing).
+
+### `get_metadata(token_address) → Option<String>`
+
+Return the metadata URI set for a token via `set_metadata`, or `None` if none was set. Reads directly from `Metadata(address)` state instead of scanning `meta` events (which are subject to the same retention truncation).
+
 ### `get_tokens_by_creator(creator, offset, limit) → Vec<u32>`
 
 Return a paginated slice of token indices owned by `creator`. This replaces an earlier non-paginated version that returned the full `Vec<u32>` (which could exceed Stellar ledger entry size limits on creators with hundreds of registered tokens).
 
-| Param | Type | Description |
-|---|---|---|
-| `creator` | `Address` | Creator whose tokens to list. |
-| `offset` | `u32` | 0-based index of the first element to return. |
-| `limit` | `u32` | Maximum number of elements to return. Capped server-side at `MAX_TOKENS_BY_CREATOR_PAGE` (currently `50`) so callers cannot request pathologically large pages. |
+| Param     | Type      | Description                                                                                                                                                     |
+| --------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `creator` | `Address` | Creator whose tokens to list.                                                                                                                                   |
+| `offset`  | `u32`     | 0-based index of the first element to return.                                                                                                                   |
+| `limit`   | `u32`     | Maximum number of elements to return. Capped server-side at `MAX_TOKENS_BY_CREATOR_PAGE` (currently `50`) so callers cannot request pathologically large pages. |
 
 **Returns:** `Vec<u32>` of token indices, len ≤ `min(limit, MAX_TOKENS_BY_CREATOR_PAGE)`. Use the indices with `get_token_info` to materialize each token's `TokenInfo`.
 
 **Behavior:**
 
-| Input | Output |
-|---|---|
-| `limit == 0` | empty `Vec` (defensive — read-only path, no error) |
-| `limit > MAX_TOKENS_BY_CREATOR_PAGE` | clamped down to the cap |
-| `offset >= total_tokens_for_creator` | empty `Vec` (past-the-end) |
-| Unknown creator | empty `Vec` |
-| Otherwise | slice `[offset, offset + min(limit, cap, remaining))` |
+| Input                                | Output                                                |
+| ------------------------------------ | ----------------------------------------------------- |
+| `limit == 0`                         | empty `Vec` (defensive — read-only path, no error)    |
+| `limit > MAX_TOKENS_BY_CREATOR_PAGE` | clamped down to the cap                               |
+| `offset >= total_tokens_for_creator` | empty `Vec` (past-the-end)                            |
+| Unknown creator                      | empty `Vec`                                           |
+| Otherwise                            | slice `[offset, offset + min(limit, cap, remaining))` |
 
 To iterate the full list:
 
@@ -181,41 +193,41 @@ Incrementally upgrades state between schema versions. Idempotent.
 
 ## Errors
 
-| Code | Symbol | When |
-|---|---|---|
-| 1 | `InsufficientFee` | `fee_payment < required_fee` |
-| 2 | `Unauthorized` | caller is not allowed for this operation |
-| 3 | `InvalidParameters` | argument out of range or malformed |
-| 4 | `TokenNotFound` | unknown token index or address |
-| 5 | `MetadataAlreadySet` | `set_metadata` called twice |
-| 6 | `AlreadyInitialized` | double-initialize attempt |
-| 7 | `BurnAmountExceedsBalance` | `burn` > balance |
-| 8 | `BurnNotEnabled` | burning on a token that has been disabled |
-| 9 | `InvalidBurnAmount` | zero or negative burn |
-| 10 | `ContractPaused` | operation blocked because factory is paused |
-| 11 | `Reentrancy` | concurrent reentrant call detected |
-| 12 | `ArithmeticOverflow` | checked-op failed |
-| 13 | `StateNotFound` | factory not yet initialized |
-| 14 | `InvalidTokenParams` | name/symbol validation failed during token creation |
-| 15 | `InvalidDecimals` | decimals outside `[0, 18]` |
-| 16 | `MaxSupplyExceeded` | mint would exceed cap |
-| 17 | `InvalidFeeSplit` | `set_fee_split` map bps do not sum to 10_000 |
+| Code | Symbol                     | When                                                |
+| ---- | -------------------------- | --------------------------------------------------- |
+| 1    | `InsufficientFee`          | `fee_payment < required_fee`                        |
+| 2    | `Unauthorized`             | caller is not allowed for this operation            |
+| 3    | `InvalidParameters`        | argument out of range or malformed                  |
+| 4    | `TokenNotFound`            | unknown token index or address                      |
+| 5    | `MetadataAlreadySet`       | `set_metadata` called twice                         |
+| 6    | `AlreadyInitialized`       | double-initialize attempt                           |
+| 7    | `BurnAmountExceedsBalance` | `burn` > balance                                    |
+| 8    | `BurnNotEnabled`           | burning on a token that has been disabled           |
+| 9    | `InvalidBurnAmount`        | zero or negative burn                               |
+| 10   | `ContractPaused`           | operation blocked because factory is paused         |
+| 11   | `Reentrancy`               | concurrent reentrant call detected                  |
+| 12   | `ArithmeticOverflow`       | checked-op failed                                   |
+| 13   | `StateNotFound`            | factory not yet initialized                         |
+| 14   | `InvalidTokenParams`       | name/symbol validation failed during token creation |
+| 15   | `InvalidDecimals`          | decimals outside `[0, 18]`                          |
+| 16   | `MaxSupplyExceeded`        | mint would exceed cap                               |
+| 17   | `InvalidFeeSplit`          | `set_fee_split` map bps do not sum to 10_000        |
 
 ## Events
 
 The contract emits Soroban events on a `(factory, action)` topic. The frontend parses them via `frontend/src/services/stellar-impl.ts`. Events:
 
-| Action | Payload | Trigger |
-|---|---|---|
-| `init` | `(admin)` | `initialize` |
+| Action    | Payload                                  | Trigger                                |
+| --------- | ---------------------------------------- | -------------------------------------- |
+| `init`    | `(admin)`                                | `initialize`                           |
 | `created` | `(token_address, creator, name, symbol)` | `create_token` / `create_tokens_batch` |
-| `meta` | `(token_address, metadata_uri)` | `set_metadata` |
-| `mint` | `(token_address, to, amount)` | `mint_tokens` |
-| `burn` | `(token_address, from, amount)` | `burn` |
-| `fees` | `(base_fee, metadata_fee)` | `update_fees` |
-| `pause` | `(admin)` | `pause` |
-| `unpause` | `(admin)` | `unpause` |
-| `adm_upd` | `(current_admin, new_admin)` | `update_admin` |
+| `meta`    | `(token_address, metadata_uri)`          | `set_metadata`                         |
+| `mint`    | `(token_address, to, amount)`            | `mint_tokens`                          |
+| `burn`    | `(token_address, from, amount)`          | `burn`                                 |
+| `fees`    | `(base_fee, metadata_fee)`               | `update_fees`                          |
+| `pause`   | `(admin)`                                | `pause`                                |
+| `unpause` | `(admin)`                                | `unpause`                              |
+| `adm_upd` | `(current_admin, new_admin)`             | `update_admin`                         |
 
 ## Batch creation UI
 

--- a/docs/rpc-rate-limits.md
+++ b/docs/rpc-rate-limits.md
@@ -7,10 +7,10 @@
 
 The Stellar Development Foundation provides public RPC services as a convenience for developers. These are **not** intended for production/high-volume traffic.
 
-| Network | URL | Purpose |
-|---------|-----|---------|
-| Testnet | `https://soroban-testnet.stellar.org` | Development & testing |
-| Mainnet | No public SDF-hosted RPC | Use third-party providers |
+| Network | URL                                   | Purpose                   |
+| ------- | ------------------------------------- | ------------------------- |
+| Testnet | `https://soroban-testnet.stellar.org` | Development & testing     |
+| Mainnet | No public SDF-hosted RPC              | Use third-party providers |
 
 ## Published Rate Limits
 
@@ -22,17 +22,65 @@ The Stellar Development Foundation provides public RPC services as a convenience
    - Use a third-party infrastructure provider (Ankr, Nodies, Gateway.fm, etc.) with documented SLAs
    - Run your own Stellar RPC instance
 
+## Event Retention Constraint
+
+Soroban RPC does **not** retain contract events indefinitely. `getEvents` can
+only return events from within a bounded retention window — approximately
+**7 days** on SDF public infrastructure, and provider-dependent elsewhere.
+Events older than the window are pruned and are permanently unavailable from
+that RPC.
+
+### Why this matters for token data
+
+Two consequences follow, and the frontend is built around both:
+
+1. **Token identity must not be derived from events.** A token created before
+   the retention window (or simply beyond the most recent event page) would
+   otherwise fall out of the event stream, leaving the UI to fabricate
+   placeholder data — an address used as the token name and a _guessed_
+   `decimals` value. Guessed decimals are especially damaging: every balance
+   and amount rendered for that token is then wrong by orders of magnitude.
+
+   Identity is therefore resolved from **contract state**, which has no
+   retention window:
+
+   | Data                                            | Source of truth                      |
+   | ----------------------------------------------- | ------------------------------------ |
+   | name / symbol / decimals / creator / created_at | `get_token_info_by_address(address)` |
+   | address → storage index                         | `get_token_index(address)`           |
+   | metadata URI                                    | `get_metadata(address)`              |
+
+   `StellarService.resolveTokenInfoByAddress()` calls these views and returns a
+   typed `{ status: 'resolved' } | { status: 'unresolved' }` result. It never
+   returns a placeholder — an address the factory cannot confirm renders as an
+   explicit "unresolved" marker.
+
+2. **Per-token history is inherently partial and must be disclosed as such.**
+   `StellarService.getTokenEvents()` paginates the factory event stream
+   exhaustively with cursors (via `fetchAllContractEvents`) so it returns every
+   event the RPC still retains — but events older than the retention window are
+   gone. The result is flagged `retentionLimited` with the approximate
+   `retentionDays`, and `TokenHistory` discloses this in the UI ("Events older
+   than about N days are not available from this RPC") rather than implying the
+   list is the token's complete lifetime.
+
+The retention window is codified as `RPC_EVENT_RETENTION_DAYS` in
+`frontend/src/services/stellar-impl.ts`. It is a conservative approximation for
+messaging, not a guarantee — a specific provider may retain more or less. For
+production deployments needing complete historical data, run an off-chain
+indexer (see #35) rather than relying on RPC event retention.
+
 ## Horizon Rate Limits
 
 The Horizon API (used for `getTransaction` and `accountExists`) also does not publish specific rate limits, but 429 responses are known to occur under sustained high traffic. Horizon returns `Retry-After` headers with 429 responses.
 
 ## Stellar ecosystem provider rate limits (for reference)
 
-| Provider | Free Tier | Rate Limits |
-|----------|-----------|-------------|
-| Ankr | Yes | Varies by plan |
-| Nodies | Yes | 10 req/s (free) |
-| Gateway.fm | Yes | Varies |
+| Provider   | Free Tier | Rate Limits     |
+| ---------- | --------- | --------------- |
+| Ankr       | Yes       | Varies by plan  |
+| Nodies     | Yes       | 10 req/s (free) |
+| Gateway.fm | Yes       | Varies          |
 
 ## How the App Currently Handles Rate Limits
 
@@ -49,16 +97,16 @@ The app has a comprehensive retry system:
 
 ### RPC Call Sites
 
-| Call Site | Retry Wrapped? | Notes |
-|-----------|---------------|-------|
-| `rpcCall()` (getContractEvents) | ✅ Yes | Uses `withRetry` with `HttpError` for 429 |
-| `getTransaction()` (Horizon) | ✅ Yes | Uses `withRetry` with `HttpError` for 429 |
-| `accountExists()` (Horizon) | ✅ Yes | Uses `withRetry` with `HttpError` for 429 |
-| `pollTransaction()` (RPC getTransaction) | ✅ Yes | Uses `withRetry` |
-| `simulateTransaction()` (SDK) | ✅ Yes | Wrapped with `withRetry` |
-| `sendTransaction()` (SDK) | ✅ Yes | Wrapped with `withRetry` |
-| `getAccount()` (SDK) | ✅ Yes | Wrapped with `withRetry` |
-| IPFS uploads | ✅ Yes | Uses `withRetry` with `isTransientError` |
+| Call Site                                | Retry Wrapped? | Notes                                     |
+| ---------------------------------------- | -------------- | ----------------------------------------- |
+| `rpcCall()` (getContractEvents)          | ✅ Yes         | Uses `withRetry` with `HttpError` for 429 |
+| `getTransaction()` (Horizon)             | ✅ Yes         | Uses `withRetry` with `HttpError` for 429 |
+| `accountExists()` (Horizon)              | ✅ Yes         | Uses `withRetry` with `HttpError` for 429 |
+| `pollTransaction()` (RPC getTransaction) | ✅ Yes         | Uses `withRetry`                          |
+| `simulateTransaction()` (SDK)            | ✅ Yes         | Wrapped with `withRetry`                  |
+| `sendTransaction()` (SDK)                | ✅ Yes         | Wrapped with `withRetry`                  |
+| `getAccount()` (SDK)                     | ✅ Yes         | Wrapped with `withRetry`                  |
+| IPFS uploads                             | ✅ Yes         | Uses `withRetry` with `isTransientError`  |
 
 ### User-Facing Error Messages
 

--- a/frontend/src/components/TokenDetail.tsx
+++ b/frontend/src/components/TokenDetail.tsx
@@ -48,6 +48,10 @@ export const TokenDetail: React.FC = () => {
   const [metadata, setMetadata] = useState<IPFSMetadata | null>(null)
   const [loading, setLoading] = useState(true)
   const [notFound, setNotFound] = useState(false)
+  // Set when the factory cannot confirm a token at this address. Distinct from
+  // `notFound` (invalid address / hard failure): we never fabricate placeholder
+  // token data, so an unresolvable address renders an explicit marker instead.
+  const [unresolved, setUnresolved] = useState<string | null>(null)
   const [activePanel, setActivePanel] = useState<ActivePanel>(null)
   const [showQR, setShowQR] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -64,12 +68,19 @@ export const TokenDetail: React.FC = () => {
 
     setLoading(true)
     setNotFound(false)
+    setUnresolved(null)
     setError(null)
 
     stellarService
-      .getTokenInfoByAddress(address)
-      .then(async (info) => {
-        setToken(info as TokenInfo)
+      .resolveTokenInfoByAddress(address)
+      .then(async (result) => {
+        if (result.status === 'unresolved') {
+          // Never render fabricated identity — surface the unresolved marker.
+          setUnresolved(result.message)
+          return
+        }
+        const { status: _status, ...info } = result
+        setToken(info)
         if (info.metadataUri) {
           try {
             const meta = await ipfsService.getMetadata(info.metadataUri)
@@ -135,6 +146,26 @@ export const TokenDetail: React.FC = () => {
 
   if (loading) {
     return <TokenDetailSkeleton />
+  }
+
+  if (unresolved) {
+    return (
+      <div className="max-w-2xl mx-auto space-y-4">
+        <Card title="Token unresolved">
+          <p className="text-sm text-gray-700 dark:text-gray-300">{unresolved}</p>
+          <p className="mt-2 text-xs text-gray-500 dark:text-gray-400 font-mono break-all">
+            {address}
+          </p>
+          <div className="mt-4">
+            <Link to="/tokens">
+              <Button variant="outline" size="sm">
+                ← Back to tokens
+              </Button>
+            </Link>
+          </div>
+        </Card>
+      </div>
+    )
   }
 
   if (notFound || !token) {

--- a/frontend/src/components/TokenHistory.tsx
+++ b/frontend/src/components/TokenHistory.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { useStellarContext } from '../context/StellarContext'
 import { useNetwork } from '../context/NetworkContext'
 import { formatAddress, formatTimestamp } from '../utils/formatting'
@@ -15,49 +15,30 @@ export const TokenHistory: React.FC<TokenHistoryProps> = ({ tokenAddress }) => {
   const { network } = useNetwork()
   const [events, setEvents] = useState<ContractEvent[]>([])
   const [loading, setLoading] = useState(true)
-  const [loadingMore, setLoadingMore] = useState(false)
-  // Held in a ref (not state) so loadEvents can read the latest cursor without
-  // listing it as a dependency — the cursor isn't rendered directly.
-  const cursorRef = useRef<string | null>(null)
-  const [hasMore, setHasMore] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  // Disclosure: Soroban RPC only retains events for a bounded window, so this
+  // list is never the token's complete lifetime. See getTokenEvents.
+  const [retentionDays, setRetentionDays] = useState<number | null>(null)
 
-  const loadEvents = useCallback(
-    async (isLoadMore = false) => {
-      try {
-        if (isLoadMore) {
-          setLoadingMore(true)
-        } else {
-          setLoading(true)
-        }
-        setError(null)
+  const loadEvents = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
 
-        const result = await stellarService.getTokenEvents(
-          tokenAddress,
-          20,
-          isLoadMore ? (cursorRef.current ?? undefined) : undefined,
-        )
+      // getTokenEvents paginates exhaustively through the RPC's retained event
+      // history, so a single call returns everything available for this token.
+      const result = await stellarService.getTokenEvents(tokenAddress)
 
-        if (isLoadMore) {
-          setEvents((prev) => [...prev, ...result.events])
-        } else {
-          setEvents(result.events)
-        }
-
-        cursorRef.current = result.cursor
-        setHasMore(result.cursor !== null && result.events.length > 0)
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load event history')
-      } finally {
-        setLoading(false)
-        setLoadingMore(false)
-      }
-    },
-    [stellarService, tokenAddress],
-  )
+      setEvents(result.events)
+      setRetentionDays(result.retentionLimited ? result.retentionDays : null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load event history')
+    } finally {
+      setLoading(false)
+    }
+  }, [stellarService, tokenAddress])
 
   useEffect(() => {
-    cursorRef.current = null
     // eslint-disable-next-line react-hooks/set-state-in-effect -- loadEvents sets loading state synchronously as it starts fetching; see #1002 follow-up
     loadEvents()
   }, [loadEvents])
@@ -226,6 +207,16 @@ export const TokenHistory: React.FC<TokenHistoryProps> = ({ tokenAddress }) => {
     )
   }
 
+  const retentionNotice = retentionDays !== null && (
+    <p
+      role="note"
+      className="mt-4 text-xs text-gray-500 dark:text-gray-400 border-t border-gray-200 dark:border-gray-700 pt-3"
+    >
+      Event history is limited by the RPC provider&apos;s retention window. Events older than about{' '}
+      {retentionDays} days are not available from this RPC and are not shown here.
+    </p>
+  )
+
   if (events.length === 0) {
     return (
       <Card title="Token History">
@@ -234,6 +225,7 @@ export const TokenHistory: React.FC<TokenHistoryProps> = ({ tokenAddress }) => {
             No events found for this token yet.
           </p>
         </div>
+        {retentionNotice}
       </Card>
     )
   }
@@ -275,18 +267,7 @@ export const TokenHistory: React.FC<TokenHistoryProps> = ({ tokenAddress }) => {
         ))}
       </div>
 
-      {hasMore && (
-        <div className="mt-4 text-center">
-          <Button
-            onClick={() => loadEvents(true)}
-            variant="outline"
-            size="sm"
-            disabled={loadingMore}
-          >
-            {loadingMore ? <Spinner size="sm" label="Loading..." /> : 'Load More'}
-          </Button>
-        </div>
-      )}
+      {retentionNotice}
     </Card>
   )
 }

--- a/frontend/src/services/stellar-impl.getTokenInfoByAddress.test.ts
+++ b/frontend/src/services/stellar-impl.getTokenInfoByAddress.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest'
-import type { ContractEvent, GetEventsResult } from '../types'
+import type { ContractEvent, GetEventsResult, TokenInfo } from '../types'
 
 vi.mock('../config/stellar', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../config/stellar')>()
@@ -9,27 +9,32 @@ vi.mock('../config/stellar', async (importOriginal) => {
   }
 })
 
-import { StellarService } from './stellar-impl'
+import { StellarService, RPC_EVENT_RETENTION_DAYS } from './stellar-impl'
 
 /** Matches the default page size in `fetchAllContractEvents`. */
 const PAGE_SIZE = 100
 
-const created = (ledger: number, address: string, name: string): ContractEvent => ({
-  id: `created-${ledger}`,
-  type: 'created',
-  ledger,
-  timestamp: 1_700_000_000 + ledger,
-  txHash: `tx-${ledger}`,
-  data: { tokenAddress: address, name, symbol: name.toUpperCase(), creator: `G${name}` },
+const tokenInfo = (overrides: Partial<TokenInfo> = {}): TokenInfo => ({
+  name: 'AncientToken',
+  symbol: 'OLD',
+  decimals: 18,
+  creator: 'GCREATOR',
+  createdAt: 1_700_000_042,
+  ...overrides,
 })
 
-const meta = (ledger: number, address: string, uri: string): ContractEvent => ({
-  id: `meta-${ledger}`,
-  type: 'meta',
+const event = (
+  type: ContractEvent['type'],
+  ledger: number,
+  address: string,
+  extra: Record<string, string> = {},
+): ContractEvent => ({
+  id: `${type}-${ledger}`,
+  type,
   ledger,
   timestamp: 1_700_000_000 + ledger,
   txHash: `tx-${ledger}`,
-  data: { tokenAddress: address, metadataUri: uri },
+  data: { tokenAddress: address, ...extra },
 })
 
 /**
@@ -37,18 +42,15 @@ const meta = (ledger: number, address: string, uri: string): ContractEvent => ({
  * `fetchAllContractEvents` relies on: ascending ledger order, and a page
  * shorter than the requested limit signals end-of-history.
  */
-const pagedSource = (events: ContractEvent[]) => {
-  return vi.fn(
-    async (_contractId: string, limit = 20, cursor?: string): Promise<GetEventsResult> => {
-      const start = cursor ? Number(cursor) : 0
-      const slice = events.slice(start, start + limit)
-      const next = start + slice.length
-      return { events: slice, cursor: next < events.length ? String(next) : null }
-    },
-  )
-}
+const pagedSource = (events: ContractEvent[]) =>
+  vi.fn(async (_contractId: string, limit = 20, cursor?: string): Promise<GetEventsResult> => {
+    const start = cursor ? Number(cursor) : 0
+    const slice = events.slice(start, start + limit)
+    const next = start + slice.length
+    return { events: slice, cursor: next < events.length ? String(next) : null }
+  })
 
-describe('StellarService.getTokenInfoByAddress', () => {
+describe('StellarService.getTokenInfoByAddress (contract-view resolution)', () => {
   let service: StellarService
 
   beforeEach(() => {
@@ -56,75 +58,132 @@ describe('StellarService.getTokenInfoByAddress', () => {
     service = new StellarService('testnet')
   })
 
-  test('resolves a token whose created event is beyond the first page', async () => {
-    // Regression: a single capped getContractEvents(contractId, 100) call
-    // returned only the OLDEST 100 events, so this token silently resolved to
-    // a placeholder named after its own address instead of its real metadata.
-    const events = Array.from({ length: 150 }, (_, i) =>
-      created(i + 1, `C_TOKEN_${i}`, `token${i}`),
-    )
-    const target = events[120]!
-    const getContractEvents = pagedSource(events)
-    vi.spyOn(service, 'getContractEvents').mockImplementation(getContractEvents)
+  test('resolves authoritative identity from the contract regardless of event age', async () => {
+    // Regression for #1018: identity used to be derived from factory events, so
+    // a token created beyond the first event page fell out of the window and
+    // resolved to a placeholder (address-as-name, guessed decimals=7). Reading
+    // the on-chain view has no such window — event history is not consulted at
+    // all, so decimals are always authoritative.
+    const viewSpy = vi
+      .spyOn(service, 'getTokenInfoByAddressView')
+      .mockResolvedValue(tokenInfo({ decimals: 18 }))
+    vi.spyOn(service, 'getTokenMetadataUri').mockResolvedValue('ipfs://QmMeta')
 
-    const info = await service.getTokenInfoByAddress('C_TOKEN_120')
+    const info = await service.getTokenInfoByAddress('C_TOKEN')
 
-    expect(info.name).toBe('token120')
-    expect(info.symbol).toBe('TOKEN120')
-    expect(info.creator).toBe('Gtoken120')
-    expect(info.createdAt).toBe(target.timestamp)
-    // Proves pagination actually happened rather than one capped call.
-    expect(getContractEvents.mock.calls.length).toBeGreaterThan(1)
+    expect(info.name).toBe('AncientToken')
+    expect(info.symbol).toBe('OLD')
+    expect(info.decimals).toBe(18) // never a guessed 7
+    expect(info.creator).toBe('GCREATOR')
+    expect(info.metadataUri).toBe('ipfs://QmMeta')
+    expect(viewSpy).toHaveBeenCalledWith('C_TOKEN')
   })
 
-  test('requests full pages until history is exhausted', async () => {
-    const events = Array.from({ length: 250 }, (_, i) =>
-      created(i + 1, `C_TOKEN_${i}`, `token${i}`),
-    )
-    const getContractEvents = pagedSource(events)
-    vi.spyOn(service, 'getContractEvents').mockImplementation(getContractEvents)
+  test('throws "No token found" when the factory has no such token', async () => {
+    // Contract surfaces TokenNotFound (code 4), mapped to "Token not found."
+    vi.spyOn(service, 'getTokenInfoByAddressView').mockRejectedValue(new Error('Token not found.'))
 
-    await service.getTokenInfoByAddress('C_TOKEN_249')
-
-    // 250 events at 100/page => 3 pages (100, 100, 50-short terminates).
-    expect(getContractEvents).toHaveBeenCalledTimes(3)
-    expect(getContractEvents.mock.calls[0]?.[1]).toBe(PAGE_SIZE)
-  })
-
-  test('throws when no created event exists for the address', async () => {
-    vi.spyOn(service, 'getContractEvents').mockImplementation(
-      pagedSource([created(1, 'C_OTHER', 'other')]),
-    )
-
-    // A rejection is the "not found" signal callers rely on; returning a
-    // placeholder here is what made a missing token look like a real one.
     await expect(service.getTokenInfoByAddress('C_MISSING')).rejects.toThrow(
       /No token found at address C_MISSING/,
     )
   })
+})
 
-  test('applies the most recent metadata event for the token', async () => {
-    vi.spyOn(service, 'getContractEvents').mockImplementation(
-      pagedSource([
-        created(1, 'C_TOKEN', 'token'),
-        meta(2, 'C_TOKEN', 'ipfs://old'),
-        meta(9, 'C_TOKEN', 'ipfs://new'),
-        meta(5, 'C_OTHER', 'ipfs://unrelated'),
-      ]),
-    )
+describe('StellarService.resolveTokenInfoByAddress (typed result)', () => {
+  let service: StellarService
 
-    const info = await service.getTokenInfoByAddress('C_TOKEN')
-
-    expect(info.metadataUri).toBe('ipfs://new')
+  beforeEach(() => {
+    vi.clearAllMocks()
+    service = new StellarService('testnet')
   })
 
-  test('leaves metadataUri empty when the token has no metadata event', async () => {
-    vi.spyOn(service, 'getContractEvents').mockImplementation(
-      pagedSource([created(1, 'C_TOKEN', 'token')]),
+  test('returns a resolved result with metadata', async () => {
+    vi.spyOn(service, 'getTokenInfoByAddressView').mockResolvedValue(tokenInfo())
+    vi.spyOn(service, 'getTokenMetadataUri').mockResolvedValue('ipfs://QmMeta')
+
+    const result = await service.resolveTokenInfoByAddress('C_TOKEN')
+
+    expect(result).toMatchObject({
+      status: 'resolved',
+      decimals: 18,
+      metadataUri: 'ipfs://QmMeta',
+    })
+  })
+
+  test('marks not-found addresses unresolved instead of fabricating a placeholder', async () => {
+    vi.spyOn(service, 'getTokenInfoByAddressView').mockRejectedValue(new Error('Token not found.'))
+
+    const result = await service.resolveTokenInfoByAddress('C_MISSING')
+
+    expect(result.status).toBe('unresolved')
+    if (result.status === 'unresolved') {
+      expect(result.reason).toBe('not-found')
+      expect(result.address).toBe('C_MISSING')
+    }
+  })
+
+  test('classifies transport failures as rpc-error, not not-found', async () => {
+    vi.spyOn(service, 'getTokenInfoByAddressView').mockRejectedValue(
+      new Error('Network timeout. The Stellar network did not respond in time.'),
     )
 
-    const info = await service.getTokenInfoByAddress('C_TOKEN')
+    const result = await service.resolveTokenInfoByAddress('C_TOKEN')
 
-    expect(info.metadataUri).toBe('')
+    expect(result.status).toBe('unresolved')
+    if (result.status === 'unresolved') {
+      expect(result.reason).toBe('rpc-error')
+    }
+  })
+
+  test('a metadata read failure does not downgrade a resolved token', async () => {
+    vi.spyOn(service, 'getTokenInfoByAddressView').mockResolvedValue(tokenInfo())
+    vi.spyOn(service, 'getTokenMetadataUri').mockRejectedValue(new Error('transient'))
+
+    const result = await service.resolveTokenInfoByAddress('C_TOKEN')
+
+    expect(result.status).toBe('resolved')
+    if (result.status === 'resolved') {
+      expect(result.metadataUri).toBe('')
+    }
+  })
+})
+
+describe('StellarService.getTokenEvents (paginated history + retention)', () => {
+  let service: StellarService
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    service = new StellarService('testnet')
+  })
+
+  test('returns token history from beyond the first event page', async () => {
+    // 150 unrelated events precede this token's events, pushing them past the
+    // first 100-event page. A single fixed-size call would have dropped them;
+    // exhaustive pagination surfaces the complete retained history.
+    const noise = Array.from({ length: 150 }, (_, i) => event('created', i + 1, `C_OTHER_${i}`))
+    const mine = [
+      event('created', 200, 'C_MINE', { name: 'Mine', creator: 'G1' }),
+      event('mint', 205, 'C_MINE', { to: 'G2', amount: '100' }),
+      event('burn', 210, 'C_MINE', { from: 'G2', amount: '40' }),
+    ]
+    const getContractEvents = pagedSource([...noise, ...mine])
+    vi.spyOn(service, 'getContractEvents').mockImplementation(getContractEvents)
+
+    const result = await service.getTokenEvents('C_MINE')
+
+    expect(result.events.map((e) => e.type)).toEqual(['burn', 'mint', 'created']) // newest first
+    expect(getContractEvents.mock.calls.length).toBeGreaterThan(1)
+    expect(getContractEvents.mock.calls[0]?.[1]).toBe(PAGE_SIZE)
+  })
+
+  test('always discloses the RPC retention boundary', async () => {
+    vi.spyOn(service, 'getContractEvents').mockImplementation(
+      pagedSource([event('created', 1, 'C_MINE')]),
+    )
+
+    const result = await service.getTokenEvents('C_MINE')
+
+    expect(result.retentionLimited).toBe(true)
+    expect(result.retentionDays).toBe(RPC_EVENT_RETENTION_DAYS)
   })
 })

--- a/frontend/src/services/stellar-impl.ts
+++ b/frontend/src/services/stellar-impl.ts
@@ -9,9 +9,12 @@ import type {
   DeploymentResult,
   FactoryState,
   GetEventsResult,
+  TokenEventsResult,
   TokenInfo,
+  TokenInfoResult,
 } from '../types'
 import {
+  Account,
   Contract,
   TransactionBuilder,
   Networks,
@@ -203,6 +206,63 @@ async function callView(
 ): Promise<xdr.ScVal> {
   const contract = new Contract(contractId)
   const account = await withRetry(() => server.getAccount(sourceAddress))
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: getNetworkPassphrase(network),
+  })
+    .addOperation(contract.call(method, ...args))
+    .setTimeout(30)
+    .build()
+
+  const simResult = await withRetry(() => server.simulateTransaction(tx))
+  if (rpc.Api.isSimulationError(simResult)) {
+    throw parseContractError(new Error(simResult.error))
+  }
+  if (!rpc.Api.isSimulationSuccess(simResult) || !simResult.result) {
+    throw new Error(`View call to ${method} returned no result`)
+  }
+  return simResult.result.retval
+}
+
+/**
+ * Approximate window (in days) that public Soroban RPC infrastructure retains
+ * contract events for. `getEvents` cannot return events older than this, so any
+ * event-derived history is inherently partial and must be disclosed as such
+ * rather than presented as a token's complete lifetime. See
+ * `docs/rpc-rate-limits.md` for the retention constraint.
+ */
+export const RPC_EVENT_RETENTION_DAYS = 7
+
+/**
+ * Placeholder source account for read-only view simulations. Soroban's
+ * `simulateTransaction` does not require the source account to exist or be
+ * funded for invocations that require no authorization, so token identity can
+ * be resolved without a connected wallet. This is the canonical all-zero
+ * ed25519 account (`StrKey.encodeEd25519PublicKey(new Uint8Array(32))`), a
+ * valid — if unfunded — StrKey, hardcoded to avoid a Buffer dependency.
+ */
+const READONLY_SOURCE_ACCOUNT = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF'
+
+/**
+ * Call a read-only contract view via simulation without requiring a connected
+ * wallet. Unlike {@link callView}, the source account is not fetched from the
+ * network (a placeholder is used) so anonymous page loads can resolve token
+ * data. The connected wallet address is used when available so simulations are
+ * attributed to a real account, but it is never required.
+ */
+async function callViewReadonly(
+  server: rpc.Server,
+  contractId: string,
+  method: string,
+  args: xdr.ScVal[],
+  network: Network,
+): Promise<xdr.ScVal> {
+  const contract = new Contract(contractId)
+  const source = walletService.getConnectedAddress() ?? READONLY_SOURCE_ACCOUNT
+  // Sequence number is irrelevant for a read-only simulation; a locally
+  // constructed account avoids an extra `getAccount` round-trip and works even
+  // when `source` has never been funded on-chain.
+  const account = new Account(source, '0')
   const tx = new TransactionBuilder(account, {
     fee: BASE_FEE,
     networkPassphrase: getNetworkPassphrase(network),
@@ -882,75 +942,162 @@ export class StellarService {
     }
   }
 
-  // ── getTokenInfoByAddress ────────────────────────────────────────────────────
+  // ── Address-keyed contract views ─────────────────────────────────────────────
 
   /**
-   * Get token info by contract address, derived from factory events.
+   * Read a token's authoritative `TokenInfo` by contract address via the
+   * on-chain `get_token_info_by_address` view.
    *
-   * Pages through the full event history rather than requesting a single
-   * fixed-size page. `getEvents` returns events in ascending ledger order, so
-   * a capped single call drops the *newest* events — meaning a token created
-   * after the cap was reached resolved to a placeholder record (name set to
-   * its own address, empty symbol and creator) that callers could not
-   * distinguish from a real token. See `fetchAllContractEvents` for the
-   * pagination contract, and `.kiro/specs/contract-event-indexing` for why
-   * re-walking history per lookup is a stopgap rather than the end state.
-   *
-   * Throws when no `created` event exists for `tokenAddress`. Callers treat a
-   * rejection as "not found" — `TokenDetail` renders its not-found state,
-   * `TokenExplorer` and `useTokens` filter the entry out — which is why a
-   * placeholder is not returned instead.
+   * This is the source of truth for a token's name, symbol, decimals, creator
+   * and creation time — unlike factory events, on-chain state has no retention
+   * window, so a token created arbitrarily long ago still resolves correctly.
+   * Throws (mapped to a `Token not found` error) when the address is not
+   * registered with the factory.
    */
-  async getTokenInfoByAddress(tokenAddress: string): Promise<TokenInfo> {
+  async getTokenInfoByAddressView(tokenAddress: string): Promise<TokenInfo> {
     const contractId = STELLAR_CONFIG.factoryContractId
     if (!contractId) throw new Error('Factory contract ID is not configured')
 
-    const events = await fetchAllContractEvents(this, contractId)
-    const createdEvent = events.find(
-      (e) => e.type === 'created' && e.data.tokenAddress === tokenAddress,
+    const server = getRpcServer(this.network)
+    const retval = await callViewReadonly(
+      server,
+      contractId,
+      'get_token_info_by_address',
+      [new Address(tokenAddress).toScVal()],
+      this.network,
     )
-    if (!createdEvent) {
-      throw new Error(`No token found at address ${tokenAddress}`)
-    }
 
-    // Most-recent metadata event for this token
-    const metaEvent = events
-      .filter((e) => e.type === 'meta' && e.data.tokenAddress === tokenAddress)
-      .sort((a, b) => b.ledger - a.ledger)[0]
-
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const native = scValToNative(retval) as any
     return {
-      name: createdEvent.data.name ?? tokenAddress,
-      symbol: createdEvent.data.symbol ?? '',
-      decimals: 7,
-      creator: createdEvent.data.creator ?? '',
-      createdAt: createdEvent.timestamp ?? 0,
-      metadataUri: metaEvent?.data.metadataUri ?? '',
+      name: String(native.name ?? ''),
+      symbol: String(native.symbol ?? ''),
+      // Decimals come straight from contract state — never a guessed default.
+      decimals: Number(native.decimals ?? 0),
+      creator: native.creator?.toString() ?? '',
+      createdAt: Number(native.created_at ?? 0),
     }
   }
 
   /**
-   * Get all events for a specific token address.
-   * Filters factory events to only those related to the given token.
+   * Read a token's current metadata URI from the on-chain `get_metadata` view.
+   * Returns an empty string when no metadata has been set. Resolving from
+   * contract state avoids scanning `meta` events, which are subject to RPC
+   * retention truncation.
    */
-  async getTokenEvents(
-    tokenAddress: string,
-    limit = 20,
-    cursor?: string,
-  ): Promise<GetEventsResult> {
+  async getTokenMetadataUri(tokenAddress: string): Promise<string> {
+    const contractId = STELLAR_CONFIG.factoryContractId
+    if (!contractId) throw new Error('Factory contract ID is not configured')
+
+    const server = getRpcServer(this.network)
+    const retval = await callViewReadonly(
+      server,
+      contractId,
+      'get_metadata',
+      [new Address(tokenAddress).toScVal()],
+      this.network,
+    )
+    const native = scValToNative(retval)
+    return native == null ? '' : String(native)
+  }
+
+  // ── resolveTokenInfoByAddress ────────────────────────────────────────────────
+
+  /**
+   * Resolve a token's identity by address, returning a typed result rather than
+   * ever fabricating a placeholder. Identity is read from the contract (see
+   * {@link getTokenInfoByAddressView}), so `decimals` and the rest are always
+   * authoritative when `status === 'resolved'`.
+   *
+   * When the factory has no such token (`not-found`) or cannot be reached
+   * (`rpc-error`) the caller gets an explicit `unresolved` marker to render as
+   * such — this is what prevents wrong decimals or an address-as-name from ever
+   * being shown as if they were real token data.
+   */
+  async resolveTokenInfoByAddress(tokenAddress: string): Promise<TokenInfoResult> {
+    try {
+      const info = await this.getTokenInfoByAddressView(tokenAddress)
+
+      let metadataUri = ''
+      try {
+        metadataUri = await this.getTokenMetadataUri(tokenAddress)
+      } catch {
+        // Metadata is non-critical; identity is already resolved. A failure
+        // here (e.g. transient RPC error) must not downgrade a resolved token
+        // to unresolved.
+      }
+
+      return { status: 'resolved', ...info, metadataUri }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      const notFound = /token not found/i.test(message) || /Error\(Contract,\s*4\)/.test(message)
+      return {
+        status: 'unresolved',
+        address: tokenAddress,
+        reason: notFound ? 'not-found' : 'rpc-error',
+        message: notFound
+          ? `No token is registered at ${tokenAddress} with the factory contract.`
+          : `Could not resolve token ${tokenAddress}: ${message}`,
+      }
+    }
+  }
+
+  // ── getTokenInfoByAddress ────────────────────────────────────────────────────
+
+  /**
+   * Throwing convenience wrapper over {@link resolveTokenInfoByAddress} for
+   * callers that treat a rejection as "not found" (`TokenExplorer`, `useTokens`
+   * filter the entry out). Prefer `resolveTokenInfoByAddress` where the UI can
+   * render the `unresolved` state explicitly.
+   */
+  async getTokenInfoByAddress(tokenAddress: string): Promise<TokenInfo> {
+    const result = await this.resolveTokenInfoByAddress(tokenAddress)
+    if (result.status === 'unresolved') {
+      throw new Error(
+        result.reason === 'not-found'
+          ? `No token found at address ${tokenAddress}`
+          : result.message,
+      )
+    }
+    const { status: _status, ...info } = result
+    return info
+  }
+
+  /**
+   * Get the complete available event history for a specific token address.
+   *
+   * Pages exhaustively through the factory's event stream via
+   * {@link fetchAllContractEvents} (rather than a single fixed-size page, which
+   * silently truncated a token's history to whatever happened most recently)
+   * and filters to events referencing `tokenAddress`.
+   *
+   * The result is always flagged `retentionLimited`: Soroban RPC only retains
+   * events for a bounded window (~{@link RPC_EVENT_RETENTION_DAYS} days on
+   * public infrastructure), so events older than that cannot be served and the
+   * list must never be presented as the token's complete lifetime. The UI
+   * discloses this boundary rather than implying completeness.
+   */
+  async getTokenEvents(tokenAddress: string): Promise<TokenEventsResult> {
     const contractId = STELLAR_CONFIG.factoryContractId
     if (!contractId) {
-      return { events: [], cursor: null }
+      return {
+        events: [],
+        retentionLimited: true,
+        retentionDays: RPC_EVENT_RETENTION_DAYS,
+        cursor: null,
+      }
     }
 
-    // Fetch events from the factory contract
-    const result = await this.getContractEvents(contractId, limit, cursor)
-
-    // Filter to only events related to this token
-    const tokenEvents = result.events.filter((event) => event.data.tokenAddress === tokenAddress)
+    const all = await fetchAllContractEvents(this, contractId)
+    const events = all
+      .filter((event) => event.data.tokenAddress === tokenAddress)
+      .sort((a, b) => b.ledger - a.ledger)
 
     return {
-      events: tokenEvents,
-      cursor: result.cursor,
+      events,
+      retentionLimited: true,
+      retentionDays: RPC_EVENT_RETENTION_DAYS,
+      cursor: null,
     }
   }
 }

--- a/frontend/src/services/stellar.ts
+++ b/frontend/src/services/stellar.ts
@@ -102,9 +102,14 @@ export class StellarService {
     return impl.getTokenInfoByAddress(tokenAddress)
   }
 
-  async getTokenEvents(tokenAddress: string, limit?: number, cursor?: string) {
+  async resolveTokenInfoByAddress(tokenAddress: string) {
     const impl = await this.getImpl()
-    return impl.getTokenEvents(tokenAddress, limit, cursor)
+    return impl.resolveTokenInfoByAddress(tokenAddress)
+  }
+
+  async getTokenEvents(tokenAddress: string) {
+    const impl = await this.getImpl()
+    return impl.getTokenEvents(tokenAddress)
   }
 }
 

--- a/frontend/src/test/TokenDetail.test.tsx
+++ b/frontend/src/test/TokenDetail.test.tsx
@@ -27,7 +27,7 @@ vi.mock('../hooks/useWallet', () => ({
   useWallet: () => ({ wallet: { isConnected: false, address: null } }),
 }))
 
-const getTokenInfoByAddress = vi.fn()
+const resolveTokenInfoByAddress = vi.fn()
 
 // Must be a real, checksum-valid contract address — TokenDetail short-circuits
 // to NotFound before fetching anything if isValidContractAddress fails.
@@ -39,7 +39,7 @@ const TOKEN_ADDRESS = 'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE'
 // stubbed through global fetch below.
 function renderTokenDetail(address = TOKEN_ADDRESS) {
   const value = {
-    stellarService: { getTokenInfoByAddress } as unknown as StellarService,
+    stellarService: { resolveTokenInfoByAddress } as unknown as StellarService,
     ipfsService: new IPFSService(),
   }
 
@@ -80,7 +80,7 @@ const mockPinnedMetadata = (metadata: Record<string, unknown>) => {
 describe('TokenDetail — untrusted metadata rendering', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    getTokenInfoByAddress.mockResolvedValue(tokenInfo())
+    resolveTokenInfoByAddress.mockResolvedValue({ status: 'resolved', ...tokenInfo() })
   })
 
   afterEach(() => {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -35,6 +35,42 @@ export interface TokenInfo {
 }
 
 /**
+ * Result of resolving a token by its contract address.
+ *
+ * Identity (name/symbol/decimals/creator) is resolved from the on-chain
+ * `get_token_info_by_address` view — never fabricated from a guessed default
+ * or the raw address. When the factory cannot confirm the token, callers get
+ * an explicit `unresolved` marker instead of a plausible-looking placeholder,
+ * so the UI can render "unresolved" rather than wrong data (e.g. balances off
+ * by orders of magnitude from a guessed `decimals`).
+ */
+export type TokenInfoResult =
+  | ({ status: 'resolved' } & TokenInfo)
+  | {
+      status: 'unresolved'
+      address: string
+      /** `not-found`: no such token registered with the factory.
+       *  `rpc-error`: the factory could not be reached / returned an error. */
+      reason: 'not-found' | 'rpc-error'
+      message: string
+    }
+
+/**
+ * Per-token event history plus a disclosure that Soroban RPC only retains
+ * events for a bounded window. `retentionLimited` is always true for
+ * event-derived history: the RPC cannot serve events older than
+ * `retentionDays`, so callers must never present the returned list as the
+ * token's complete lifetime.
+ */
+export interface TokenEventsResult {
+  events: ContractEvent[]
+  retentionLimited: boolean
+  /** Approximate RPC event-retention window, in days. */
+  retentionDays: number
+  cursor: string | null
+}
+
+/**
  * FactoryState matches the contract's FactoryState struct.
  * All fields are required and correspond directly to contract storage.
  */
@@ -84,7 +120,15 @@ export interface AppError {
 
 export type SortOrder = 'newest' | 'oldest' | 'alphabetical'
 export type ContractEventType =
-  'init' | 'created' | 'meta' | 'mint' | 'burn' | 'fees' | 'pause' | 'unpause' | 'admin_update'
+  | 'init'
+  | 'created'
+  | 'meta'
+  | 'mint'
+  | 'burn'
+  | 'fees'
+  | 'pause'
+  | 'unpause'
+  | 'admin_update'
 
 export interface ContractEvent {
   id: string


### PR DESCRIPTION
## Summary

Event-derived token lookups only ever saw a bounded slice of the factory event stream, so a token created **beyond the first event page** — or older than the RPC's ~7-day event-retention window — fell out of view. Identity then silently fell back to a fabricated placeholder: the **raw address used as the name** and a **guessed `decimals` of 7**, which renders every balance and amount for that token wrong by orders of magnitude. Per-token history had the same truncation, presenting a partial slice as if it were complete.

This resolves token identity from **on-chain state** (which has no retention window) and discloses the event-retention boundary in the history UI.

Closes #1018

## Contract (`token-factory`)

New view functions, backed by the already-existing `TokenIndex(address)` mapping:

- `get_token_index(address) → u32` — authoritative address → index lookup.
- `get_token_info_by_address(address) → TokenInfo` — the **source of truth** for name/symbol/decimals/creator/created_at in a single call.
- `get_metadata(address) → Option<String>` — current metadata URI from state (no `meta`-event scan).

All return `TokenNotFound` for unregistered addresses (incl. the index-present-but-info-missing case).

## Frontend

- **`resolveTokenInfoByAddress(address)`** reads identity from `get_token_info_by_address` and the URI from `get_metadata`, returning a typed `{ status: 'resolved' } | { status: 'unresolved', reason: 'not-found' | 'rpc-error' }` result. It **never fabricates a placeholder**; `TokenDetail` renders the `unresolved` marker explicitly. Read-only views simulate with a placeholder source account, so anonymous page loads work without a connected wallet.
- **`getTokenEvents(address)`** now paginates the event stream exhaustively via `fetchAllContractEvents` and flags `retentionLimited` + `retentionDays`. `TokenHistory` discloses the boundary ("Events older than about N days are not available from this RPC") instead of implying completeness.
- `getTokenInfoByAddress` is kept as a throwing convenience wrapper so existing callers are unaffected.

## Docs

- `docs/rpc-rate-limits.md` — documents the RPC event-retention constraint and how identity vs. history are sourced.
- `docs/contract-abi.md` — documents the three new views.

## Acceptance criteria

- [x] A token created arbitrarily long ago resolves correct name/symbol/decimals/creator via the contract view — proven by contract + frontend tests.
- [x] Per-token history is cursor-paginated to the retention limit and the UI discloses the limit.
- [x] No code path renders guessed decimals or address-as-name without an explicit "unresolved" marker.

## Testing

- Contract: `cargo test -p token-factory --lib` → **111 passed** (6 new: index/info-by-address/metadata incl. not-found paths). `cargo clippy` clean.
- Frontend: `vitest run` → **560 passed**; `tsc --noEmit` and `eslint` clean. New tests cover contract-view resolution independent of event age, typed unresolved results, and paginated history from beyond the first event page.

> Note: contract `test_snapshots` are intentionally not included — the local toolchain differs only in a trailing-newline convention from CI, which would add unrelated churn.