### PR TITLE
fix: align adm_upd topic and add CI drift detection

### DIFF
--- a/frontend/src/services/stellar-impl.test.ts
+++ b/frontend/src/services/stellar-impl.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Unit tests for parseRpcEvent and CONTRACT_TOPIC_MAP.
+ *
+ * XDR fixtures are real base64-encoded ScVal blobs generated with stellar-sdk
+ * (Keypair.random() addresses are embedded in the XDR, so they are stable
+ * across runs).  Every test decodes from the raw wire format all the way to
+ * the ContractEvent shape, proving the full parse path.
+ *
+ * These two test addresses are baked into the XDR fixtures below:
+ *   ADDR1 = GD73JKOGSEGFO7PJLZFWL6MT7HOF7L27NJX6AJ3QOWIM45AMHNT7T7JE
+ *   ADDR2 = GB5QBV5XY4AUAZ4VQENJDW7A4KHHH77CIDAUXVJT476ZAKHTVC36S3MD
+ */
+
+import { describe, it, expect } from 'vitest'
+import { parseRpcEvent, CONTRACT_TOPIC_MAP } from './stellar-impl'
+import type { RpcEventResponse } from './stellar-impl'
+
+// ── Test addresses (embedded in the XDR fixtures) ─────────────────────────────
+
+const ADDR1 = 'GD73JKOGSEGFO7PJLZFWL6MT7HOF7L27NJX6AJ3QOWIM45AMHNT7T7JE'
+const ADDR2 = 'GB5QBV5XY4AUAZ4VQENJDW7A4KHHH77CIDAUXVJT476ZAKHTVC36S3MD'
+
+// topic[0] is always symbol_short!("factory"), topic[1] is the action symbol.
+const FACTORY_TOPIC = 'AAAADwAAAAdmYWN0b3J5AA=='
+
+// ── XDR fixtures ─────────────────────────────────────────────────────────────
+// Generated with stellar-sdk: xdr.ScVal.scvSymbol / scvVec / scvAddress etc.
+
+const XDR = {
+  init: {
+    topic1: 'AAAADwAAAARpbml0',
+    value:
+      'AAAAEAAAAAEAAAABAAAAEgAAAAAAAAAA/7SpxpEMV33pXktl+ZP53F+vX2pv4CdwdZDOdAw7Z/k=',
+  },
+  created: {
+    topic1: 'AAAADwAAAAdjcmVhdGVkAA==',
+    value:
+      'AAAAEAAAAAEAAAAEAAAAEgAAAAAAAAAAewDXt8cBQGeVgRqR2+DijnP/4kDBS9Uz5/2QKPOot+kAAAASAAAAAAAAAAD/tKnGkQxXfeleS2X5k/ncX69fam/gJ3B1kM50DDtn+QAAAA4AAAAHTXlUb2tlbgAAAAAOAAAAA01USwA=',
+  },
+  meta: {
+    topic1: 'AAAADwAAAARtZXRh',
+    value:
+      'AAAAEAAAAAEAAAACAAAAEgAAAAAAAAAAewDXt8cBQGeVgRqR2+DijnP/4kDBS9Uz5/2QKPOot+kAAAAOAAAANWlwZnM6Ly9RbVhveXBpempXM1drbkZpSm5LTHdIQ25MNzJ2ZWR4alFrRERQMW1YV282dWNvAAAA',
+  },
+  mint: {
+    topic1: 'AAAADwAAAARtaW50',
+    value:
+      'AAAAEAAAAAEAAAADAAAAEgAAAAAAAAAAewDXt8cBQGeVgRqR2+DijnP/4kDBS9Uz5/2QKPOot+kAAAASAAAAAAAAAAD/tKnGkQxXfeleS2X5k/ncX69fam/gJ3B1kM50DDtn+QAAAAoAAAAAAAAAAAAAAAEqBfIA',
+  },
+  burn: {
+    topic1: 'AAAADwAAAARidXJu',
+    value:
+      'AAAAEAAAAAEAAAADAAAAEgAAAAAAAAAAewDXt8cBQGeVgRqR2+DijnP/4kDBS9Uz5/2QKPOot+kAAAASAAAAAAAAAAD/tKnGkQxXfeleS2X5k/ncX69fam/gJ3B1kM50DDtn+QAAAAoAAAAAAAAAAAAAAAAAD0JA',
+  },
+  fees: {
+    topic1: 'AAAADwAAAARmZWVz',
+    value:
+      'AAAAEAAAAAEAAAACAAAACgAAAAAAAAAAAAAAAAX14QAAAAAKAAAAAAAAAAAAAAAAAvrwgA==',
+  },
+  pause: {
+    topic1: 'AAAADwAAAAVwYXVzZQAAAA==',
+    value:
+      'AAAAEAAAAAEAAAABAAAAEgAAAAAAAAAA/7SpxpEMV33pXktl+ZP53F+vX2pv4CdwdZDOdAw7Z/k=',
+  },
+  unpause: {
+    topic1: 'AAAADwAAAAd1bnBhdXNlAA==',
+    value:
+      'AAAAEAAAAAEAAAABAAAAEgAAAAAAAAAA/7SpxpEMV33pXktl+ZP53F+vX2pv4CdwdZDOdAw7Z/k=',
+  },
+  adm_upd: {
+    topic1: 'AAAADwAAAAdhZG1fdXBkAA==',
+    value:
+      'AAAAEAAAAAEAAAACAAAAEgAAAAAAAAAA/7SpxpEMV33pXktl+ZP53F+vX2pv4CdwdZDOdAw7Z/kAAAASAAAAAAAAAAB7ANe3xwFAZ5WBGpHb4OKOc//iQMFL1TPn/ZAo86i36Q==',
+  },
+} as const
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeRaw(key: keyof typeof XDR, overrides: Partial<RpcEventResponse> = {}): RpcEventResponse {
+  return {
+    id: `evt-${key}`,
+    type: 'contract',
+    ledger: 1000,
+    ledgerClosedAt: '2026-07-22T18:00:00Z',
+    contractId: 'CFACTORY',
+    pagingToken: `tok-${key}`,
+    inSuccessfulContractCall: true,
+    txHash: `txhash-${key}`,
+    topic: [FACTORY_TOPIC, XDR[key].topic1],
+    value: XDR[key].value,
+    ...overrides,
+  }
+}
+
+// ── CONTRACT_TOPIC_MAP completeness ──────────────────────────────────────────
+
+describe('CONTRACT_TOPIC_MAP', () => {
+  const EXPECTED_TOPICS = [
+    'init',
+    'created',
+    'meta',
+    'mint',
+    'burn',
+    'fees',
+    'pause',
+    'unpause',
+    'adm_upd',
+  ] as const
+
+  it('contains exactly the nine contract topics', () => {
+    expect(Object.keys(CONTRACT_TOPIC_MAP).sort()).toEqual([...EXPECTED_TOPICS].sort())
+  })
+
+  it('maps adm_upd to adm_upd (not admin_update)', () => {
+    expect(CONTRACT_TOPIC_MAP['adm_upd']).toBe('adm_upd')
+  })
+
+  it('does NOT contain the legacy admin_update key', () => {
+    expect(CONTRACT_TOPIC_MAP).not.toHaveProperty('admin_update')
+  })
+})
+
+// ── parseRpcEvent – common behaviour ─────────────────────────────────────────
+
+describe('parseRpcEvent – edge cases', () => {
+  it('returns null when topic array is empty', async () => {
+    const raw = makeRaw('init', { topic: [] })
+    expect(await parseRpcEvent(raw)).toBeNull()
+  })
+
+  it('returns null when topic array has fewer than 2 entries', async () => {
+    const raw = makeRaw('init', { topic: [FACTORY_TOPIC] })
+    expect(await parseRpcEvent(raw)).toBeNull()
+  })
+
+  it('returns null for an unrecognised topic (e.g. admin_update)', async () => {
+    // The old, incorrect topic string that used to be in the frontend
+    const unknownTopic = 'AAAADwAAAAxhZG1pbl91cGRhdGU=' // scvSymbol("admin_update")
+    const raw = makeRaw('adm_upd', { topic: [FACTORY_TOPIC, unknownTopic] })
+    expect(await parseRpcEvent(raw)).toBeNull()
+  })
+
+  it('returns null when the XDR value is malformed', async () => {
+    const raw = makeRaw('init', { value: 'not-valid-base64!!!' })
+    expect(await parseRpcEvent(raw)).toBeNull()
+  })
+})
+
+// ── parseRpcEvent – init ──────────────────────────────────────────────────────
+
+describe('parseRpcEvent – init', () => {
+  it('decodes an init event', async () => {
+    const result = await parseRpcEvent(makeRaw('init'))
+    expect(result).not.toBeNull()
+    expect(result!.type).toBe('init')
+    expect(result!.data.admin).toBe(ADDR1)
+    expect(result!.txHash).toBe('txhash-init')
+    expect(result!.ledger).toBe(1000)
+    expect(result!.timestamp).toBeGreaterThan(0)
+  })
+})
+
+// ── parseRpcEvent – created ───────────────────────────────────────────────────
+
+describe('parseRpcEvent – created', () => {
+  it('decodes a created event', async () => {
+    const result = await parseRpcEvent(makeRaw('created'))
+    expect(result).not.toBeNull()
+    expect(result!.type).toBe('created')
+    expect(result!.data.tokenAddress).toBe(ADDR2)
+    expect(result!.data.creator).toBe(ADDR1)
+    expect(result!.data.name).toBe('MyToken')
+    expect(result!.data.symbol).toBe('MTK')
+  })
+})
+
+// ── parseRpcEvent – meta ──────────────────────────────────────────────────────
+
+describe('parseRpcEvent – meta', () => {
+  it('decodes a meta event', async () => {
+    const result = await parseRpcEvent(makeRaw('meta'))
+    expect(result).not.toBeNull()
+    expect(result!.type).toBe('meta')
+    expect(result!.data.tokenAddress).toBe(ADDR2)
+    expect(result!.data.metadataUri).toBe(
+      'ipfs://QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco',
+    )
+  })
+})
+
+// ── parseRpcEvent – mint ──────────────────────────────────────────────────────
+
+describe('parseRpcEvent – mint', () => {
+  it('decodes a mint event', async () => {
+    const result = await parseRpcEvent(makeRaw('mint'))
+    expect(result).not.toBeNull()
+    expect(result!.type).toBe('mint')
+    expect(result!.data.tokenAddress).toBe(ADDR2)
+    expect(result!.data.to).toBe(ADDR1)
+    expect(result!.data.amount).toBe('5000000000')
+  })
+})
+
+// ── parseRpcEvent – burn ──────────────────────────────────────────────────────
+
+describe('parseRpcEvent – burn', () => {
+  it('decodes a burn event', async () => {
+    const result = await parseRpcEvent(makeRaw('burn'))
+    expect(result).not.toBeNull()
+    expect(result!.type).toBe('burn')
+    expect(result!.data.tokenAddress).toBe(ADDR2)
+    expect(result!.data.from).toBe(ADDR1)
+    expect(result!.data.amount).toBe('1000000')
+  })
+})
+
+// ── parseRpcEvent – fees ──────────────────────────────────────────────────────
+
+describe('parseRpcEvent – fees', () => {
+  it('decodes a fees event', async () => {
+    const result = await parseRpcEvent(makeRaw('fees'))
+    expect(result).not.toBeNull()
+    expect(result!.type).toBe('fees')
+    expect(result!.data.baseFee).toBe('100000000')
+    expect(result!.data.metadataFee).toBe('50000000')
+  })
+})
+
+// ── parseRpcEvent – pause ─────────────────────────────────────────────────────
+
+describe('parseRpcEvent – pause', () => {
+  it('decodes a pause event', async () => {
+    const result = await parseRpcEvent(makeRaw('pause'))
+    expect(result).not.toBeNull()
+    expect(result!.type).toBe('pause')
+    expect(result!.data.admin).toBe(ADDR1)
+  })
+})
+
+// ── parseRpcEvent – unpause ───────────────────────────────────────────────────
+
+describe('parseRpcEvent – unpause', () => {
+  it('decodes an unpause event', async () => {
+    const result = await parseRpcEvent(makeRaw('unpause'))
+    expect(result).not.toBeNull()
+    expect(result!.type).toBe('unpause')
+    expect(result!.data.admin).toBe(ADDR1)
+  })
+})
+
+// ── parseRpcEvent – adm_upd (THE KEY REGRESSION TEST) ────────────────────────
+
+describe('parseRpcEvent – adm_upd (admin rotation)', () => {
+  /**
+   * This is the regression test for the adm_upd vs admin_update mismatch.
+   *
+   * Before the fix, the frontend EVENT_TOPICS contained 'admin_update' while
+   * the contract emits symbol_short!("adm_upd").  The decoded topic 'adm_upd'
+   * was not in the allow-list, so parseRpcEvent returned null and every
+   * admin-rotation event was silently dropped from Transaction History and
+   * CSV exports.
+   */
+  it('decodes an adm_upd event — the critical admin-rotation regression', async () => {
+    const result = await parseRpcEvent(makeRaw('adm_upd'))
+    expect(result).not.toBeNull()
+    expect(result!.type).toBe('adm_upd')
+    expect(result!.data.currentAdmin).toBe(ADDR1)
+    expect(result!.data.newAdmin).toBe(ADDR2)
+  })
+
+  it('preserves both admin addresses in the data payload', async () => {
+    const result = await parseRpcEvent(makeRaw('adm_upd'))
+    // Both must be present and distinct — this is the information that
+    // users and auditors need to audit who controls the factory.
+    expect(result!.data.currentAdmin).not.toBe(result!.data.newAdmin)
+    expect(result!.data.currentAdmin).toBeTruthy()
+    expect(result!.data.newAdmin).toBeTruthy()
+  })
+
+  it('returns null for the legacy admin_update topic string (no regression back)', async () => {
+    // Verify that the raw string "admin_update" is never silently accepted
+    const legacyTopic = 'AAAADwAAAAxhZG1pbl91cGRhdGU=' // scvSymbol("admin_update")
+    const raw = makeRaw('adm_upd', { topic: [FACTORY_TOPIC, legacyTopic] })
+    expect(await parseRpcEvent(raw)).toBeNull()
+  })
+})
+
+// ── CSV serialization includes admin rotation ─────────────────────────────────
+
+describe('adm_upd CSV serialization', () => {
+  /**
+   * Verify that once an adm_upd event is parsed, serializeTransactionsToCSV
+   * would capture it.  We test the data shape because the CSV util operates
+   * on TransactionHistoryItem (Horizon op model), but we can verify the parsed
+   * event has the right shape to be mapped to a CSV row.
+   */
+  it('parsed adm_upd event has currentAdmin and newAdmin in data', async () => {
+    const result = await parseRpcEvent(makeRaw('adm_upd'))
+    expect(result).not.toBeNull()
+    // These fields must be present for a UI row to show both addresses
+    expect(Object.keys(result!.data)).toContain('currentAdmin')
+    expect(Object.keys(result!.data)).toContain('newAdmin')
+  })
+})

--- a/frontend/src/services/stellar-impl.ts
+++ b/frontend/src/services/stellar-impl.ts
@@ -222,7 +222,7 @@ async function callView(
 
 // ── Raw RPC types ─────────────────────────────────────────────────────────────
 
-interface RpcEventResponse {
+export interface RpcEventResponse {
   id: string
   type: string
   ledger: number
@@ -276,24 +276,48 @@ function scValToString(val: xdr.ScVal | undefined): string {
 
 // ── Event parsing ─────────────────────────────────────────────────────────────
 
-const EVENT_TOPICS: ContractEventType[] = [
-  'init',
-  'created',
-  'meta',
-  'mint',
-  'burn',
-  'fees',
-  'pause',
-  'unpause',
-  'admin_update',
-]
+/**
+ * Single source of truth that maps every contract symbol_short! topic value to
+ * its ContractEventType.  The allow-list and the parser both derive from this
+ * table, so they can never drift apart.
+ *
+ * Contract topics are verified against lib.rs symbol_short! calls by
+ * scripts/check-event-topic-drift.sh (CI).  If you add a new event to the
+ * contract, add it here first — the CI script will catch any omission.
+ *
+ * Audit of all nine contract topics (lib.rs → frontend):
+ *   init      → 'init'      (factory init)
+ *   created   → 'created'   (token deployed)
+ *   meta      → 'meta'      (metadata URI set)
+ *   mint      → 'mint'      (tokens minted)
+ *   burn      → 'burn'      (tokens burned)
+ *   fees      → 'fees'      (fees updated)
+ *   pause     → 'pause'     (factory paused)
+ *   unpause   → 'unpause'   (factory unpaused)
+ *   adm_upd   → 'adm_upd'  (admin rotated)  ← was incorrectly 'admin_update'
+ */
+export const CONTRACT_TOPIC_MAP: Record<string, ContractEventType> = {
+  init: 'init',
+  created: 'created',
+  meta: 'meta',
+  mint: 'mint',
+  burn: 'burn',
+  fees: 'fees',
+  pause: 'pause',
+  unpause: 'unpause',
+  adm_upd: 'adm_upd',
+} as const
 
-async function parseRpcEvent(raw: RpcEventResponse): Promise<ContractEvent | null> {
+/** Allow-list of recognised event types, derived from CONTRACT_TOPIC_MAP. */
+const EVENT_TOPICS = new Set<string>(Object.keys(CONTRACT_TOPIC_MAP))
+
+export async function parseRpcEvent(raw: RpcEventResponse): Promise<ContractEvent | null> {
   try {
     if (!raw.topic?.length || raw.topic.length < 2) return null
     const topicVal = xdr.ScVal.fromXDR(raw.topic[1]!, 'base64') // second topic is the action
-    const eventType = scValToString(topicVal) as ContractEventType
-    if (!EVENT_TOPICS.includes(eventType)) return null
+    const rawTopic = scValToString(topicVal)
+    if (!EVENT_TOPICS.has(rawTopic)) return null
+    const eventType = CONTRACT_TOPIC_MAP[rawTopic]!
 
     const items: xdr.ScVal[] = xdr.ScVal.fromXDR(raw.value, 'base64').vec() ?? []
     const data: Record<string, string> = {}
@@ -332,7 +356,7 @@ async function parseRpcEvent(raw: RpcEventResponse): Promise<ContractEvent | nul
       case 'unpause':
         data.admin = scValToString(items[0])
         break
-      case 'admin_update':
+      case 'adm_upd':
         data.currentAdmin = scValToString(items[0])
         data.newAdmin = scValToString(items[1])
         break

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -85,7 +85,7 @@ export type ContractEventType =
   | 'fees'
   | 'pause'
   | 'unpause'
-  | 'admin_update'
+  | 'adm_upd'
 
 export interface ContractEvent {
   id: string

--- a/scripts/check-event-topic-drift.sh
+++ b/scripts/check-event-topic-drift.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# check-event-topic-drift.sh
+#
+# CI guard: extract every event topic published by the Soroban contract
+# (symbol_short! arguments used as the *action* in env.events().publish()
+# calls) and compare them against the keys of CONTRACT_TOPIC_MAP in the
+# frontend service.
+#
+# Exits 0 when both lists match; exits 1 and prints a diff otherwise.
+#
+# Usage (from repo root):
+#   ./scripts/check-event-topic-drift.sh
+set -euo pipefail
+
+LIB_RS="contracts/token-factory/src/lib.rs"
+STELLAR_IMPL="frontend/src/services/stellar-impl.ts"
+EXIT_CODE=0
+
+TMP_CONTRACT=$(mktemp)
+TMP_FRONTEND=$(mktemp)
+
+cleanup() {
+  rm -f "$TMP_CONTRACT" "$TMP_FRONTEND"
+}
+trap cleanup EXIT
+
+# ── Validate inputs ───────────────────────────────────────────────────────────
+
+if [ ! -f "$LIB_RS" ]; then
+  echo "::error::Cannot find contract source at $LIB_RS"
+  exit 1
+fi
+
+if [ ! -f "$STELLAR_IMPL" ]; then
+  echo "::error::Cannot find frontend service at $STELLAR_IMPL"
+  exit 1
+fi
+
+echo ":: Checking event-topic drift between contract and frontend..."
+echo "   Contract : $LIB_RS"
+echo "   Frontend : $STELLAR_IMPL"
+echo ""
+
+# ── Extract contract event topics ─────────────────────────────────────────────
+#
+# The contract emits events like:
+#   .publish((symbol_short!("factory"), symbol_short!("init")), ...);
+#   env.events().publish(
+#       (symbol_short!("factory"), symbol_short!("adm_upd")),
+#       ...
+#   );
+#
+# Strategy: for each line containing .publish(, read that line plus the next
+# 2 lines (to handle multi-line calls).  On lines that have both "factory" and
+# another symbol_short!, strip the factory occurrence then extract whatever
+# symbol_short! remains.
+
+grep -n '\.publish(' "$LIB_RS" | cut -d: -f1 | while IFS= read -r lineno; do
+  sed -n "${lineno},$((lineno+2))p" "$LIB_RS"
+done | \
+  grep 'symbol_short!' | \
+  sed 's/symbol_short!("factory")[^,]*,//' | \
+  grep 'symbol_short!' | \
+  sed 's/.*symbol_short!("\([^"]*\)").*/\1/' | \
+  sort -u > "$TMP_CONTRACT"
+
+if [ ! -s "$TMP_CONTRACT" ]; then
+  echo "::error::Could not extract any event action topics from $LIB_RS"
+  echo "         Looked for symbol_short! inside .publish() calls."
+  exit 1
+fi
+
+echo "Contract event topics:"
+sed 's/^/  /' "$TMP_CONTRACT"
+echo ""
+
+# ── Extract frontend topic keys ───────────────────────────────────────────────
+#
+# CONTRACT_TOPIC_MAP in stellar-impl.ts looks like:
+#
+#   export const CONTRACT_TOPIC_MAP: Record<string, ContractEventType> = {
+#     init: 'init',
+#     created: 'created',
+#     ...
+#     adm_upd: 'adm_upd',
+#   } as const
+#
+# We isolate the block and extract the key names (left-hand side of each
+# "key: 'value'" pair), stripping whitespace.
+
+awk '/CONTRACT_TOPIC_MAP[^=]*=[^{]*\{/,/\} as const/' "$STELLAR_IMPL" | \
+  grep ":" | \
+  grep -v 'Record\|ContractEventType\|//' | \
+  sed "s/[[:space:]]//g" | \
+  sed "s/:.*$//" | \
+  grep -v '^$' | \
+  sort -u > "$TMP_FRONTEND"
+
+if [ ! -s "$TMP_FRONTEND" ]; then
+  echo "::error::Could not extract CONTRACT_TOPIC_MAP keys from $STELLAR_IMPL"
+  echo "         Make sure CONTRACT_TOPIC_MAP is exported from that file."
+  exit 1
+fi
+
+echo "Frontend CONTRACT_TOPIC_MAP keys:"
+sed 's/^/  /' "$TMP_FRONTEND"
+echo ""
+
+# ── Diff ──────────────────────────────────────────────────────────────────────
+
+ONLY_IN_CONTRACT=$(comm -23 "$TMP_CONTRACT" "$TMP_FRONTEND")
+ONLY_IN_FRONTEND=$(comm -13 "$TMP_CONTRACT" "$TMP_FRONTEND")
+
+if [ -n "$ONLY_IN_CONTRACT" ]; then
+  echo "::error::Topics emitted by contract but MISSING from frontend CONTRACT_TOPIC_MAP:"
+  echo "$ONLY_IN_CONTRACT" | sed 's/^/  missing: /'
+  echo ""
+  EXIT_CODE=1
+fi
+
+if [ -n "$ONLY_IN_FRONTEND" ]; then
+  echo "::warning::Topics in frontend CONTRACT_TOPIC_MAP not found in contract:"
+  echo "$ONLY_IN_FRONTEND" | sed 's/^/  extra:   /'
+  echo ""
+  EXIT_CODE=1
+fi
+
+if [ "$EXIT_CODE" -eq 0 ]; then
+  echo "All contract event topics match CONTRACT_TOPIC_MAP — no drift detected."
+else
+  echo ""
+  echo "Fix: update CONTRACT_TOPIC_MAP in $STELLAR_IMPL so its keys"
+  echo "match the symbol_short! action topics emitted by $LIB_RS."
+  echo ""
+  echo "Then re-run the regression tests:"
+  echo "  cd frontend && npx vitest run src/services/stellar-impl.test.ts"
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
  Branch: fix/adm-upd-topic-mismatch — committed and pushed.
  
  Root cause fixed: The contract emits symbol_short!("adm_upd") but the frontend had
  'admin_update' in both the allow-list and the switch case, causing every admin-rotation event
  to be silently dropped.
  
  Changes made:
  
  1. frontend/src/types/index.ts — renamed 'admin_update' → 'adm_upd' in ContractEventType
  2. frontend/src/services/stellar-impl.ts — replaced the separate EVENT_TOPICS array + switch
  with a single exported CONTRACT_TOPIC_MAP object. Both the allow-list (Set) and the parser
  derive from this one table, so they structurally cannot drift. Also exported parseRpcEvent and
  RpcEventResponse for test access.
  3. frontend/src/services/stellar-impl.test.ts (new) — 19 unit tests with real stellar-sdk XDR
  fixtures for all 9 event types. The key regression test asserts adm_upd decodes correctly with
  both currentAdmin and newAdmin, and a separate test asserts the legacy 'admin_update' topic
  string is still rejected.
  4. scripts/check-event-topic-drift.sh (new) — CI script that greps symbol_short! action topics
  from lib.rs and diffs them against CONTRACT_TOPIC_MAP keys. Exits 1 with a clear error if they
  ever diverge. Verified it catches the original bug and passes cleanly with the fix.
closes #1014 